### PR TITLE
Security: OS keychain, dverse Keycloak realm, restricted registration service account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +217,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bot-framework"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "rcgen 0.13.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zenoh",
 ]
 
 [[package]]
@@ -953,6 +973,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1006,65 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1134,6 +1236,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ipnetwork"
@@ -1988,6 +2096,19 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
@@ -2056,6 +2177,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "ring"
@@ -2391,6 +2550,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2838,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +3081,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3206,12 @@ version = "0.1.0"
 dependencies = [
  "clap",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -3181,6 +3412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3215,6 +3455,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3281,6 +3531,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3972,7 +4232,7 @@ dependencies = [
  "futures",
  "quinn",
  "quinn-proto",
- "rcgen",
+ "rcgen 0.14.7",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs 5.0.1",
+ "keyring",
  "rcgen 0.13.2",
  "reqwest",
  "serde",
@@ -2478,6 +2479,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d255a6b6ecd77bb93ce91de984d7039bff7503f500eb4851a1269732f22baf"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "dverse-ping"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bot-framework",
+ "tokio",
+ "zenoh",
+]
+
+[[package]]
+name = "dverse-pong"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bot-framework",
+ "tokio",
+ "zenoh",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7162,6 +7182,7 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "reqwest",
  "serde_json",
  "tokio",
  "zenoh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,7 +2508,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2543,6 +2569,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -4133,7 +4168,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -4170,7 +4205,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4294,6 +4329,19 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -7351,6 +7399,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2690,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -7241,9 +7266,11 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "mdns-sd",
  "reqwest",
  "serde_json",
  "tokio",
+ "zbus",
  "zenoh",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7158,8 +7158,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bot-framework",
+ "clap",
+ "dirs 5.0.1",
  "eframe",
  "egui",
+ "serde_json",
  "tokio",
  "zenoh",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,114 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "serde",
+ "thiserror 1.0.69",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.15.5",
+ "immutable-chunkmap",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.15.5",
+ "paste",
+ "static_assertions",
+ "windows",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +154,31 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.11.1",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
@@ -113,6 +246,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +279,33 @@ name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -167,6 +347,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +493,57 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
+dependencies = [
+ "atspi-common",
+ "atspi-connection",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-connection"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+ "futures-lite",
+ "zbus",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+ "zvariant",
+]
 
 [[package]]
 name = "autocfg"
@@ -202,6 +564,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,12 +594,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -240,10 +651,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -252,12 +689,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.11.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -278,6 +768,15 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chrono"
@@ -344,6 +843,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +915,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -410,6 +938,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -486,6 +1038,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +1052,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -604,6 +1168,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,16 +1195,226 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecolor"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "eframe"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dfe0859f3fb1bc6424c57d41e10e9093fe938f426b691e42272c2f336d915c"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "glow",
+ "glutin",
+ "glutin-winit",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "parking_lot",
+ "percent-encoding",
+ "profiling",
+ "raw-window-handle",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "winapi",
+ "windows-sys 0.59.0",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "bitflags 2.11.1",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+ "profiling",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d319dfef570f699b6e9114e235e862a2ddcf75f0d1a061de9e1328d92146d820"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "profiling",
+ "thiserror 1.0.69",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9dfbb78fe4eb9c3a39ad528b90ee5915c252e77bbab9d4ebc576541ab67e13"
+dependencies = [
+ "accesskit_winit",
+ "ahash",
+ "arboard",
+ "bytemuck",
+ "egui",
+ "log",
+ "profiling",
+ "raw-window-handle",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "profiling",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "emath"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "epaint"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
+dependencies = [
+ "ab_glyph",
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equivalent"
@@ -643,6 +1433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +1446,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -670,6 +1476,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -716,6 +1537,33 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -775,6 +1623,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +1683,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
@@ -885,6 +1756,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.11.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1953,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hmac"
@@ -1078,7 +2094,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1206,6 +2222,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
+name = "immutable-chunkmap"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +2329,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +2384,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1357,6 +2436,23 @@ checksum = "89d255a6b6ecd77bb93ce91de984d7039bff7503f500eb4851a1269732f22baf"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "konst"
@@ -1416,14 +2512,35 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1456,6 +2573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1469,6 +2595,39 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.11.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
 
 [[package]]
 name = "mini_ls"
@@ -1507,6 +2666,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.11.1",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap 2.14.0",
+ "log",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.18",
+ "unicode-xid",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,15 +2707,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.6.0+11769913",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1532,6 +2763,12 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -1634,6 +2871,308 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +3206,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,7 +3267,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1825,6 +3402,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +3433,17 @@ version = "0.1.0"
 dependencies = [
  "tokio",
  "zenoh",
+]
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
 ]
 
 [[package]]
@@ -1858,6 +3466,18 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnet_base"
@@ -1889,6 +3509,33 @@ checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1958,6 +3605,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,7 +3652,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -1989,7 +3673,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2095,6 +3779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,11 +3813,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2177,6 +3885,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -2246,7 +3960,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -2276,6 +3990,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -2296,6 +4016,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2350,9 +4096,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -2451,10 +4197,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
 
 [[package]]
 name = "secrecy"
@@ -2472,8 +4237,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
- "core-foundation",
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2547,6 +4312,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2694,6 +4470,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,10 +4498,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.11.1",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2745,6 +4618,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "spki"
@@ -2804,10 +4686,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -2855,6 +4765,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2907,6 +4839,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2935,6 +4881,31 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -3101,7 +5072,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -3214,6 +5185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3242,6 +5219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +5244,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "uhlc"
@@ -3278,6 +5275,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -3527,10 +5536,145 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3554,6 +5698,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +5729,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.1",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "cfg_aliases",
+ "document-features",
+ "indexmap 2.14.0",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bitflags 2.11.1",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.11.1",
+ "js-sys",
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -3603,16 +5872,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3620,6 +5923,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3645,11 +5959,30 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3675,6 +6008,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3884,6 +6226,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.11.1",
+ "block2",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,7 +6350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -3993,6 +6387,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4009,6 +6435,47 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.11.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "yasna"
@@ -4040,6 +6507,105 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+dependencies = [
+ "quick-xml 0.30.0",
+ "serde",
+ "static_assertions",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -4457,6 +7023,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenoh-router"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "eframe",
+ "egui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zenoh",
+]
+
+[[package]]
 name = "zenoh-runtime"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,3 +7228,55 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,11 +636,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs 5.0.1",
  "rcgen 0.13.2",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "zenoh",
 ]
 
@@ -1148,11 +1150,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1163,7 +1186,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3840,6 +3863,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4028,7 +4062,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4326,6 +4360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,7 +4477,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -5022,6 +5065,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,6 +5108,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -6005,6 +6069,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6056,6 +6129,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6095,6 +6183,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6113,6 +6207,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6128,6 +6228,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6161,6 +6267,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6176,6 +6288,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6197,6 +6315,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6212,6 +6336,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7027,12 +7157,9 @@ name = "zenoh-router"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "bot-framework",
  "eframe",
  "egui",
- "reqwest",
- "serde",
- "serde_json",
  "tokio",
  "zenoh",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "experiments/mini-ls-application",
     "experiments/zenoh-chat-abel",
     "experiments/zenoh-ping-pong/ping",
-    "experiments/zenoh-ping-pong/pong"
+    "experiments/zenoh-ping-pong/pong",
+    "src/bot_framework"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [workspace]
+resolver = "3"
 members = [
     "experiments/mini-tree-command",
     "experiments/mini-ls-application",
     "experiments/zenoh-chat-abel",
     "experiments/zenoh-ping-pong/ping",
     "experiments/zenoh-ping-pong/pong",
-    "src/bot_framework"
+    "src/bot_framework",
+    "src/zenoh_router"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ members = [
     "experiments/zenoh-ping-pong/ping",
     "experiments/zenoh-ping-pong/pong",
     "src/bot_framework",
-    "src/zenoh_router"
+    "src/zenoh_router",
+    "src/ping",
+    "src/pong"
 ]

--- a/documents/adr/ADR-006.md
+++ b/documents/adr/ADR-006.md
@@ -1,0 +1,52 @@
+# ADR-006: `src/` as the Unified Home for All Runtime Components
+
+**Status:** Accepted
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+The DVerse platform is made up of several runtime components: a Zenoh router, an authentication and certificate layer, a Zenoh-to-chat bridge, and a set of AI agent bots. These components are written in different languages (Rust for infrastructure, Python for most bots) and must interoperate at runtime.
+
+Without a clear structural boundary, production components get mixed with experiments and throwaway code, making it harder to see what is deployed and what dependencies exist between components.
+
+## Decision
+
+All components that run as part of the deployed system live under `src/` at the repository root, one subdirectory per component, regardless of implementation language.
+
+Current and planned layout:
+
+```
+src/
+  zenoh_router/   # Rust: local Zenoh router + egui GUI
+  bot_framework/  # Rust: shared library for cert lifecycle, config, node connection
+  bridge/         # Rust: Zenoh-to-chat bridge (planned)
+  ping/           # Rust: demo node
+  pong/           # Rust: demo node
+  <bot-name>/     # Python or Rust: individual agent bots
+```
+
+Rust crates in `src/` are members of a single Cargo workspace so they share a dependency graph and build cache. Python components follow the same directory convention but use their own tooling.
+
+Experimental and proof-of-concept code lives in `experiments/` and is excluded from the workspace.
+
+## Alternatives
+
+**One directory per language.** Rejected. Splitting by language rather than runtime role obscures which components are production and which are experimental.
+
+**Flat repository root.** Rejected. Mixes toolchain artefacts, CI config, documentation, and source code.
+
+## Consequences
+
+**Positive**
+- The set of deployed components is visible at a glance from `src/`.
+- Adding a new bot or infrastructure component has a consistent location.
+- Rust workspace members share a build cache; CI can target `src/` as the production boundary.
+
+**Negative**
+- Mixed-language `src/` means contributors must be aware of both Rust and Python tooling even if they only touch one language.
+- Components with different deployment targets share a directory, which requires documentation to distinguish them.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-007.md
+++ b/documents/adr/ADR-007.md
@@ -1,0 +1,40 @@
+# ADR-007: `bot_framework` as the Shared Library for All Nodes
+
+**Status:** Accepted
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Every node (the router, demo ping/pong nodes, and all agent bots) needs the same three capabilities: loading the machine-wide configuration, acquiring a TLS certificate from Step-CA via Keycloak, and opening a Zenoh mTLS session. Without a shared library, each component reimplements this logic and drifts independently. Python bots must not reimplement certificate signing, key generation, or the OIDC token exchange.
+
+## Decision
+
+A Rust library crate at `src/bot_framework` provides these primitives for all nodes, regardless of their implementation language. The crate exposes three modules:
+
+- `config`: `DverseConfig` struct, TOML load/save, and helpers (`operator_cn`, `cert_config_for`).
+- `cert`: Keycloak OIDC token exchange, keypair + CSR generation via `rcgen`, Step-CA `/1.0/sign`, cert persistence, and CA-root bootstrap.
+- `node`: `NodeConfig::mtls()` builder that opens a configured Zenoh mTLS client session.
+
+Rust node binaries depend on the crate directly. Python agent bots consume the same library through Python bindings (PyO3), so certificate acquisition and session management are handled by the same Rust code in all cases. No reimplementation of signing or OIDC logic exists outside this crate.
+
+## Alternatives
+
+**Separate implementations per language.** Rejected. Certificate signing, key generation, and the OIDC token exchange are security-sensitive. A single auditable implementation is strongly preferable to maintaining two.
+
+**Python-first library with Rust bindings.** Rejected. The router and bridge are Rust-native. A Python-first library would require FFI in the opposite direction for the most performance-critical components.
+
+## Consequences
+
+**Positive**
+- A new Rust node is around 30 lines: load config, acquire cert, call `NodeConfig::mtls().connect()`.
+- Python bots call the same cert and config functions via PyO3 bindings.
+- Security-sensitive cryptographic and OIDC logic has one implementation to audit and update.
+
+**Negative**
+- Python bots must link against the compiled Rust library, which adds a build step (either a pre-built wheel or a local `maturin develop`).
+- All Rust binaries recompile when `bot_framework` changes; with PyO3 bindings this also forces a Python wheel rebuild.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-008.md
+++ b/documents/adr/ADR-008.md
@@ -1,0 +1,35 @@
+# ADR-008: Zenoh Client Mode for Agent Nodes
+
+**Status:** Accepted
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Zenoh supports two session modes for non-router participants: `peer` and `client`. In peer mode, a node attempts direct P2P connections to other peers and uses the router only when a direct path is unavailable. In client mode, all publish and subscribe traffic goes through the configured router unconditionally.
+
+The initial implementation left `mode` unset, which defaults to `peer`. Peer-mode nodes connected to the router successfully via mTLS but did not exchange messages with each other, because Zenoh does not forward traffic through the router in peer mode when there is no direct path between nodes.
+
+## Decision
+
+All agent nodes explicitly set `mode = "client"` in their Zenoh configuration via `NodeConfig::build_zenoh_config()` in `bot_framework/src/node.rs`. This is set before the connect endpoints and TLS options so it cannot be overridden by defaults.
+
+## Alternatives
+
+**Peer mode with gossip scouting.** Rejected. Gossip requires nodes to discover each other outside the router, which conflicts with the mTLS ACL model where the router is the trust enforcement point.
+
+**Leave mode as default and document the behaviour.** Rejected. The default is peer, which silently produces incorrect routing behaviour and is not obvious from the code.
+
+## Consequences
+
+**Positive**
+- All traffic flows through the router, so ACL enforcement is consistent.
+- Pub/sub between two clients on the same router works without a direct network path between them.
+
+**Negative**
+- Every message passes through the router; there is no shortcut for clients on the same machine.
+- If the router is unavailable, clients cannot communicate at all.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-009.md
+++ b/documents/adr/ADR-009.md
@@ -1,0 +1,41 @@
+# ADR-009: Intermediate CA Certificate as the TLS Trust Anchor for Nodes
+
+**Status:** Accepted
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Step-CA operates a two-level PKI: a root CA signs an intermediate CA, and the intermediate CA signs all node certificates. The CA-root bootstrap (`cert::bootstrap_ca_root`) fetches only the root CA from Step-CA's `/roots` endpoint and caches it at `~/.config/dverse/ca-root.pem`.
+
+When a node certificate is acquired via `cert::acquire()`, Step-CA returns both the leaf certificate and the issuing intermediate CA certificate. The intermediate is saved alongside the leaf as `<node>-ca.pem`.
+
+Verifying a node certificate against the root CA alone fails because the chain requires the intermediate. The initial implementation passed `cfg.ca_root_pem_path` (root only) to Zenoh as the TLS trust anchor, which caused TLS handshakes to fail in client mode.
+
+## Decision
+
+Each node uses its own `<node>-ca.pem` (the intermediate CA certificate returned during cert acquisition) as the TLS `root_ca_certificate` in the Zenoh configuration.
+
+In `NodeConfig::mtls()`, the caller passes the intermediate CA path rather than the config's `ca_root_pem_path`. In `router.rs`, the `ca_p` return value from `cert::acquire()` is passed to `build_zenoh_config()`.
+
+All intermediate CAs issued by the same Step-CA instance are identical, confirmed by comparing `router-ca.pem` and `ping-ca.pem`.
+
+## Alternatives
+
+**Bundle root and intermediate into a combined PEM.** Considered. This works but requires producing and managing a separate bundle file. The intermediate alone is sufficient when all certs are issued by the same Step-CA instance.
+
+**Fetch the intermediate CA from Step-CA separately.** Rejected. The intermediate is already returned in the `/1.0/sign` response, so an extra network call is unnecessary.
+
+## Consequences
+
+**Positive**
+- TLS chain verification succeeds with a single file per node.
+- The root CA is not distributed to every node, which limits its exposure.
+
+**Negative**
+- If the intermediate CA is rotated, all `<node>-ca.pem` files must be refreshed. A cert renewal cycle handles this automatically.
+- The trust anchor is the intermediate, not the root. A compromised intermediate affects all nodes without requiring a root compromise.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-010.md
+++ b/documents/adr/ADR-010.md
@@ -1,0 +1,41 @@
+# ADR-010: Keycloak `preferred_username` as Cert CN and ACL Identity
+
+**Status:** Accepted
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Zenoh's ACL uses `cert_common_names` to match TLS client certificates to access control rules. The cert CN must match a stable, per-user identifier. Step-CA's x509 template derives the cert CN from the Keycloak OIDC token, so the choice of claim determines how ACL identity maps to user identity.
+
+An initial attempt to use the `email` claim failed with a Step-CA 500 error for the Keycloak `admin` user, which had no email set. The `preferred_username` claim is always populated for any Keycloak account.
+
+The router endpoint also initially used `localhost`, but the cert SAN issued by Step-CA is `DNS:zenoh-<preferred_username>.local`, causing TLS hostname verification to fail in Zenoh client mode.
+
+## Decision
+
+The Step-CA x509 template derives the cert CN from `.Token.preferred_username`. `DverseConfig::operator_cn()` mirrors this: it takes the local part of the login username (everything before the first `@`, or the full string if no `@` is present).
+
+The router pre-admits the operator CN at startup so all nodes sharing the same Keycloak account can communicate from the first session without waiting for an announce cycle.
+
+The router endpoint stored in `DverseConfig` is derived at login time as `tls/zenoh-<cn>.local:<port>`, matching the cert SAN. The `mdns-sd` crate publishes an A record for this hostname so it resolves on the local network.
+
+## Alternatives
+
+**Use the email claim.** Rejected. The email claim is optional in Keycloak and was absent for the admin user, causing cert issuance failures.
+
+**Use a separate CN field unrelated to Keycloak identity.** Rejected. Decoupling the cert CN from Keycloak identity makes ACL rules harder to audit.
+
+## Consequences
+
+**Positive**
+- Cert CN, ACL identity, and the mDNS hostname are all derived from one source: `preferred_username`.
+- TLS hostname verification works without disabling it, because the endpoint hostname matches the cert SAN.
+
+**Negative**
+- All nodes authenticated with the same Keycloak account share one CN. Distinguishing individual nodes in the ACL requires separate Keycloak accounts per node or extending the x509 template with a node-specific field.
+- If a user's `preferred_username` changes in Keycloak, existing certs become mismatched with the ACL until they are renewed.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-011.md
+++ b/documents/adr/ADR-011.md
@@ -1,6 +1,6 @@
 # ADR-011: Pure Rust mDNS-SD via `mdns-sd` (supersedes ADR-005)
 
-**Status:** Accepted, supersedes ADR-005
+**Status:** Superseded by ADR-012
 **Date:** 19-05-2026
 **Author:** Yordan Mitev
 

--- a/documents/adr/ADR-011.md
+++ b/documents/adr/ADR-011.md
@@ -1,0 +1,47 @@
+# ADR-011: Pure Rust mDNS-SD via `mdns-sd` (supersedes ADR-005)
+
+**Status:** Accepted, supersedes ADR-005
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+ADR-005 specified Avahi for mDNS hostname publication. The initial implementation spawned `avahi-publish-address -R zenoh-<cn>.local 127.0.0.1` as a subprocess. This approach has three problems:
+
+1. It requires the `avahi-utils` package on Linux and does not work on macOS.
+2. It publishes only an A record pointing at `127.0.0.1`, so remote machines resolve the hostname and connect to themselves.
+3. It does not publish a `_dverse._tcp` DNS-SD service record, so peer routers cannot enumerate each other.
+
+The `zeroconf` crate was evaluated as a cross-platform alternative but requires `libavahi-client-dev` C headers at build time on Linux and `avahi-daemon` running at runtime. This is the same system dependency in a different form.
+
+## Decision
+
+Use the `mdns-sd` crate (v0.19, pure Rust) for all mDNS and DNS-SD work. It manages its own mDNS socket internally, requires no system library headers at build time, and needs no system service at runtime on Linux or macOS.
+
+The router registers a `_dverse._tcp.local.` service record with the machine's actual LAN IP so peer routers on other machines can find it via `ServiceDaemon::browse()`. A `MdnsHandle` struct wraps the `ServiceDaemon` and shuts it down on drop so the record is withdrawn when the router exits.
+
+Peer router endpoints are expressed as `tls/<discovered-ip>:<port>` and fed into Zenoh's `connect/endpoints`. Because the endpoint uses an IP address rather than a hostname, `verify_name_on_connect` is set to `false` for router-to-router connections. mTLS CA verification is unaffected and continues to enforce node identity.
+
+## Alternatives
+
+**`zeroconf` crate.** Rejected. Requires `libavahi-client-dev` at build time on Linux and `avahi-daemon` at runtime, which is the same dependency footprint as the subprocess approach.
+
+**Avahi service file at `/etc/avahi/services/`.** Rejected. Requires writing to a system directory (needs root) and does not work on macOS.
+
+**Keep `avahi-publish-address` subprocess.** Rejected. Linux-only, publishes only an A record, points at `127.0.0.1`.
+
+## Consequences
+
+**Positive**
+- No system packages, library headers, or running services required on Linux or macOS.
+- Publishes a proper `_dverse._tcp` DNS-SD service record with the correct LAN IP.
+- Peer router discovery works via service browsing without knowing peer addresses in advance.
+- The service record is withdrawn automatically when the router shuts down.
+
+**Negative**
+- `mdns-sd` runs its own internal thread and owns the mDNS socket on port 5353. If Avahi is also running, both may compete for the socket. In practice `SO_REUSEPORT` prevents a hard conflict, but this should be tested.
+- Peer endpoints in Zenoh use IP addresses, so TLS hostname verification is disabled for router-to-router links. mTLS CA verification still enforces that both sides hold a cert signed by the same Step-CA instance.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-012.md
+++ b/documents/adr/ADR-012.md
@@ -1,0 +1,62 @@
+# ADR-012: Platform-conditional DNS-SD — avahi D-Bus on Linux, `mdns-sd` elsewhere (supersedes ADR-011)
+
+**Status:** Accepted, supersedes ADR-011
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+ADR-011 chose the `mdns-sd` crate as a pure-Rust, zero-system-dependency mDNS stack. It noted a risk: "If Avahi is also running, both may compete for the socket." That risk was tested and confirmed: on a Linux desktop with `avahi-daemon` running, `mdns-sd` successfully binds port 5353 (via `SO_REUSEPORT`) and its `register()` call returns `Ok`, but it does not emit any PTR/SRV/A records onto the network. `tcpdump` on the LAN interface shows only empty 12-byte DNS headers — no service records. `avahi-browse _dverse._tcp` on any machine finds nothing.
+
+The root cause is that `avahi-daemon` owns the multicast socket and the multicast group join, and it silently discards or absorbs the outgoing multicast packets from the competing `mdns-sd` socket. The `SO_REUSEPORT` prevents an outright bind failure, but it does not guarantee that packets sent by `mdns-sd` actually reach the network.
+
+On macOS (`mDNSResponder`) and Windows (built-in mDNS resolver) the same conflict does not occur: both platforms are permissive about concurrent mDNS socket users, and `mdns-sd` sends records correctly alongside the system daemon.
+
+## Decision
+
+Use a platform-conditional backend in `src/zenoh_router/src/discovery.rs`:
+
+**Linux:** Register the `_dverse._tcp` service via the avahi D-Bus API (`org.freedesktop.Avahi.EntryGroup`). `avahi-daemon` is already authoritative for port 5353 on Linux desktops; routing through its D-Bus interface delegates all mDNS socket work to the daemon and gets correct LAN IP resolution and full DNS-SD record emission for free. The D-Bus connection is held alive in `AvahiHandle`; `avahi-daemon` automatically withdraws the service when the connection closes on drop. If avahi is not running, the D-Bus call fails gracefully and the code falls back to `mdns-sd` with a log warning.
+
+**macOS / Windows:** Use `mdns-sd` directly. No avahi-daemon is present on these platforms, and `mdns-sd` coexists cleanly with `mDNSResponder` and the Windows mDNS resolver.
+
+The platform selection is expressed via Rust's conditional compilation:
+
+```rust
+// Linux only — compiled out on macOS/Windows
+#[cfg(target_os = "linux")]
+mod linux { /* zbus / avahi D-Bus */ }
+
+// Used on all platforms as avahi fallback, and primary on macOS/Windows
+fn mdns_sd_publish(...) { /* mdns-sd */ }
+```
+
+`zbus` is added as a Linux-only target dependency (`[target.'cfg(target_os = "linux")'.dependencies]`) so it is not compiled on other platforms.
+
+## Alternatives
+
+**`mdns-sd` on all platforms.** Rejected for Linux. Testing confirmed that `mdns-sd` cannot coexist with `avahi-daemon` — service records are not transmitted despite the registration returning `Ok`.
+
+**Avahi service file at `/etc/avahi/services/`.** Rejected. Requires writing to a system directory (needs root) and does not work cross-platform.
+
+**`avahi-client` C binding.** Rejected. Adds a C library build-time dependency (`libavahi-client-dev`), which is what the entire move away from subprocesses and native bindings was trying to avoid.
+
+**Disable `avahi-daemon` at runtime.** Rejected. Not acceptable to require users to disable a system service.
+
+## Consequences
+
+**Positive**
+- `avahi-browse _dverse._tcp` on any LAN machine correctly lists the router with the real LAN IP.
+- No hardcoded `127.0.0.1`.
+- Service is withdrawn automatically on router exit.
+- Graceful degradation: a clear log warning is emitted if neither avahi nor mdns-sd can register the service; the router continues operating as a standalone node.
+- No C library headers or system packages required at build time on any platform.
+
+**Negative**
+- On Linux, `avahi-daemon` must be running for full DNS-SD support. If it is absent, `mdns-sd` is attempted as a fallback but may not work reliably on Linux (the same conflict risk applies).
+- Adds `zbus` as a Linux build dependency. `zbus` is already a transitive dependency via the `keyring` crate, so no new crate is introduced to the dependency graph in practice.
+- The two backends have slightly different log messages ("via avahi" vs plain), which may cause minor confusion when comparing logs across platforms.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/README.md
+++ b/documents/adr/README.md
@@ -7,3 +7,9 @@
 | [ADR-003](./ADR-003.md) | PKI and mTLS Transport Security                        | Accepted |
 | [ADR-004](./ADR-004.md) | Observable Multi-Agent System with Zenoh Communication | Accepted |
 | [ADR-005](./ADR-005.md) | Configuring Avahi for the Local Zenoh Router Domain    | Accepted |
+| [ADR-006](ADR-006.md) | `src/` as the Unified Home for All Runtime Components | Accepted |
+| [ADR-007](ADR-007.md) | `bot_framework` as the Shared Library for All Nodes | Accepted |
+| [ADR-008](ADR-008.md) | Zenoh Client Mode for Agent Nodes | Accepted |
+| [ADR-009](ADR-009.md) | Intermediate CA Certificate as the TLS Trust Anchor for Nodes | Accepted |
+| [ADR-010](ADR-010.md) | Keycloak `preferred_username` as Cert CN and ACL Identity | Accepted |
+| [ADR-011](ADR-011.md) | Pure Rust mDNS-SD via `mdns-sd` (supersedes ADR-005) | Accepted |

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -22,4 +22,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
-keyring = "3"
+keyring = { version = "3", features = ["sync-secret-service", "apple-native", "windows-native"] }

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
+keyring = "3"

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bot-framework"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+name = "bot_framework"
+path = "src/lib.rs"
+
+[[bin]]
+name = "bot-framework"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+rcgen = "0.13"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+zenoh = "1.8.0"

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+dirs = "5"
+toml = "1"
 clap = { version = "4", features = ["derive", "env"] }
 rcgen = "0.13"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -210,6 +210,65 @@ pub async fn load(cert_path: &Path, key_path: &Path) -> Result<(String, String)>
     Ok((cert, key))
 }
 
+/// Fetch and cache the Step-CA root certificate.
+///
+/// Uses an unauthenticated TLS-insecure request — acceptable for the one-time
+/// bootstrap, the same pattern as `step ca bootstrap`.  The downloaded PEM is
+/// then used for all subsequent verified connections.
+pub async fn bootstrap_ca_root(ca_url: &str, out_path: &Path) -> Result<String> {
+    // Only download if the file does not already exist.
+    if out_path.exists() {
+        return tokio::fs::read_to_string(out_path)
+            .await
+            .context("reading cached CA root PEM");
+    }
+
+    let client = reqwest::ClientBuilder::new()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .context("building bootstrap HTTP client")?;
+
+    // Step-CA exposes the root cert at GET /roots as JSON {"crts": ["<pem>", ...]}.
+    #[derive(serde::Deserialize)]
+    struct RootsResponse {
+        crts: Vec<serde_json::Value>,
+    }
+
+    let url = format!("{ca_url}/roots");
+    let resp: RootsResponse = client
+        .get(&url)
+        .send()
+        .await
+        .context("fetching CA roots")?
+        .json()
+        .await
+        .context("parsing CA roots response")?;
+
+    // The first root is the active one; Step-CA returns its PEM inline.
+    // Each entry in `crts` is a JSON object with a `raw` (base64 DER) field.
+    // Re-encode to PEM using the standard header.
+    let first = resp.crts.into_iter().next()
+        .context("CA returned empty roots list")?;
+
+    // Step-CA actually returns PEM strings directly in some versions; try that first.
+    let pem = if let Some(pem_str) = first.as_str() {
+        pem_str.to_string()
+    } else {
+        // Fall back: grab the `raw` base64 DER field and wrap it.
+        let raw = first["raw"].as_str()
+            .context("CA root entry missing 'raw' field")?;
+        format!("-----BEGIN CERTIFICATE-----\n{raw}\n-----END CERTIFICATE-----\n")
+    };
+
+    if let Some(parent) = out_path.parent() {
+        tokio::fs::create_dir_all(parent).await.context("creating config dir")?;
+    }
+    tokio::fs::write(out_path, &pem).await.context("writing CA root PEM")?;
+
+    println!("CA root certificate bootstrapped to {}", out_path.display());
+    Ok(pem)
+}
+
 /// Returns true if the cert file does not exist or is older than `max_age`.
 pub async fn needs_renewal(cert_path: &Path, max_age: std::time::Duration) -> bool {
     match tokio::fs::metadata(cert_path).await {

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -122,7 +122,7 @@ struct SignRequest {
 struct SignResponse {
     crt: Option<String>,
     ca: Option<String>,
-    error: Option<String>,
+    // Step-CA returns "message" on errors
     message: Option<String>,
 }
 
@@ -144,15 +144,9 @@ async fn sign_with_step_ca(cfg: &CertConfig, client: &Client, csr_pem: &str, id_
         .await
         .context("parsing Step-CA sign response")?;
 
-    if let Some(err) = resp.error {
-        bail!(
-            "Step-CA error: {} — {}",
-            err,
-            resp.message.unwrap_or_default()
-        );
-    }
-
-    let cert_pem = resp.crt.context("Step-CA response missing 'crt'")?;
+    let cert_pem = resp.crt.with_context(|| {
+        format!("Step-CA response missing 'crt': {}", resp.message.unwrap_or_default())
+    })?;
     let ca_pem = resp.ca.unwrap_or_default();
     Ok((cert_pem, ca_pem))
 }

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -1,0 +1,228 @@
+//! Certificate lifecycle: acquire from Step-CA via Keycloak OIDC, persist to disk.
+//!
+//! Flow:
+//!   1. Exchange Keycloak credentials for an OIDC ID token.
+//!   2. Generate a local keypair and CSR with rcgen.
+//!   3. POST the CSR + token to Step-CA's /1.0/sign endpoint.
+//!   4. Write cert, key, and CA chain to the configured directory.
+//!
+//! The issued certificate will have:
+//!   - CN  = username portion of the email  (e.g. "mybot")
+//!   - SAN = email + zenoh-<username>.local  (set by the Step-CA x509 template)
+
+use anyhow::{bail, Context, Result};
+use rcgen::{CertificateParams, KeyPair};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Everything needed to acquire a certificate for one node identity.
+pub struct CertConfig {
+    /// e.g. "https://auth.dverse.yordanmitev.me"
+    pub keycloak_url: String,
+    /// Keycloak realm name, e.g. "master"
+    pub keycloak_realm: String,
+    /// OIDC client ID registered in Keycloak for Step-CA
+    pub client_id: String,
+    /// OIDC client secret
+    pub client_secret: String,
+    /// Keycloak username (email form, e.g. "mybot@dverse.yordanmitev.me")
+    pub username: String,
+    /// Keycloak password
+    pub password: String,
+    /// Step-CA base URL, e.g. "https://ca.dverse.yordanmitev.me:9000"
+    pub ca_url: String,
+    /// PEM-encoded Step-CA root certificate (needed to trust the CA's TLS cert)
+    pub ca_root_pem: String,
+    /// Directory where cert.pem, key.pem, and ca.pem will be written
+    pub out_dir: PathBuf,
+    /// Base name for output files (e.g. "mybot" → mybot.crt / mybot.key / mybot-ca.pem)
+    pub node_name: String,
+}
+
+// ── Paths ─────────────────────────────────────────────────────────────────────
+
+pub fn cert_path(out_dir: &Path, node_name: &str) -> PathBuf {
+    out_dir.join(format!("{node_name}.crt"))
+}
+
+pub fn key_path(out_dir: &Path, node_name: &str) -> PathBuf {
+    out_dir.join(format!("{node_name}.key"))
+}
+
+pub fn ca_path(out_dir: &Path, node_name: &str) -> PathBuf {
+    out_dir.join(format!("{node_name}-ca.pem"))
+}
+
+// ── Keycloak token exchange ───────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    id_token: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+async fn fetch_id_token(cfg: &CertConfig, client: &Client) -> Result<String> {
+    let url = format!(
+        "{}/realms/{}/protocol/openid-connect/token",
+        cfg.keycloak_url, cfg.keycloak_realm
+    );
+
+    let resp: TokenResponse = client
+        .post(&url)
+        .form(&[
+            ("client_id", cfg.client_id.as_str()),
+            ("client_secret", cfg.client_secret.as_str()),
+            ("grant_type", "password"),
+            ("username", cfg.username.as_str()),
+            ("password", cfg.password.as_str()),
+            ("scope", "openid"),
+        ])
+        .send()
+        .await
+        .context("sending Keycloak token request")?
+        .json()
+        .await
+        .context("parsing Keycloak token response")?;
+
+    if let Some(err) = resp.error {
+        bail!(
+            "Keycloak error: {} — {}",
+            err,
+            resp.error_description.unwrap_or_default()
+        );
+    }
+
+    resp.id_token.context("Keycloak response contained no id_token")
+}
+
+// ── CSR generation ────────────────────────────────────────────────────────────
+
+fn generate_csr() -> Result<(String, String)> {
+    let key_pair = KeyPair::generate().context("generating keypair")?;
+    let params = CertificateParams::default();
+    let csr = params
+        .serialize_request(&key_pair)
+        .context("serializing CSR")?;
+    Ok((csr.pem().context("encoding CSR as PEM")?, key_pair.serialize_pem()))
+}
+
+// ── Step-CA sign ──────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct SignRequest {
+    csr: String,
+    ott: String,
+}
+
+#[derive(Deserialize)]
+struct SignResponse {
+    crt: Option<String>,
+    ca: Option<String>,
+    error: Option<String>,
+    message: Option<String>,
+}
+
+async fn sign_with_step_ca(cfg: &CertConfig, client: &Client, csr_pem: &str, id_token: &str) -> Result<(String, String)> {
+    let url = format!("{}/1.0/sign", cfg.ca_url);
+
+    let body = SignRequest {
+        csr: csr_pem.to_string(),
+        ott: id_token.to_string(),
+    };
+
+    let resp: SignResponse = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("sending CSR to Step-CA")?
+        .json()
+        .await
+        .context("parsing Step-CA sign response")?;
+
+    if let Some(err) = resp.error {
+        bail!(
+            "Step-CA error: {} — {}",
+            err,
+            resp.message.unwrap_or_default()
+        );
+    }
+
+    let cert_pem = resp.crt.context("Step-CA response missing 'crt'")?;
+    let ca_pem = resp.ca.unwrap_or_default();
+    Ok((cert_pem, ca_pem))
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Acquire a certificate from Step-CA and write it to `cfg.out_dir`.
+///
+/// Returns `(cert_path, key_path, ca_path)`.
+pub async fn acquire(cfg: &CertConfig) -> Result<(PathBuf, PathBuf, PathBuf)> {
+    let ca_cert = reqwest::Certificate::from_pem(cfg.ca_root_pem.as_bytes())
+        .context("parsing CA root PEM for HTTP client")?;
+
+    let client = reqwest::ClientBuilder::new()
+        .add_root_certificate(ca_cert)
+        .build()
+        .context("building HTTP client")?;
+
+    println!("Authenticating {} with Keycloak...", cfg.username);
+    let id_token = fetch_id_token(cfg, &client).await?;
+
+    println!("Generating keypair and CSR...");
+    let (csr_pem, key_pem) = generate_csr()?;
+
+    println!("Requesting certificate from Step-CA...");
+    let (cert_pem, ca_pem) = sign_with_step_ca(cfg, &client, &csr_pem, &id_token).await?;
+
+    tokio::fs::create_dir_all(&cfg.out_dir)
+        .await
+        .context("creating output directory")?;
+
+    let c = cert_path(&cfg.out_dir, &cfg.node_name);
+    let k = key_path(&cfg.out_dir, &cfg.node_name);
+    let ca = ca_path(&cfg.out_dir, &cfg.node_name);
+
+    tokio::fs::write(&c, &cert_pem).await.context("writing cert")?;
+    tokio::fs::write(&k, &key_pem).await.context("writing key")?;
+    tokio::fs::write(&ca, &ca_pem).await.context("writing CA chain")?;
+
+    // Restrict key file permissions on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&k, std::fs::Permissions::from_mode(0o600))
+            .await
+            .context("setting key file permissions")?;
+    }
+
+    println!("Certificate written to {}", c.display());
+    Ok((c, k, ca))
+}
+
+/// Load certificate and key from disk (returns raw PEM strings).
+pub async fn load(cert_path: &Path, key_path: &Path) -> Result<(String, String)> {
+    let cert = tokio::fs::read_to_string(cert_path)
+        .await
+        .with_context(|| format!("reading cert from {}", cert_path.display()))?;
+    let key = tokio::fs::read_to_string(key_path)
+        .await
+        .with_context(|| format!("reading key from {}", key_path.display()))?;
+    Ok((cert, key))
+}
+
+/// Returns true if the cert file does not exist or is older than `max_age`.
+pub async fn needs_renewal(cert_path: &Path, max_age: std::time::Duration) -> bool {
+    match tokio::fs::metadata(cert_path).await {
+        Ok(meta) => match meta.modified() {
+            Ok(modified) => modified.elapsed().unwrap_or(max_age) >= max_age,
+            Err(_) => true,
+        },
+        Err(_) => true,
+    }
+}

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -64,6 +64,16 @@ impl DverseConfig {
         Self::config_path().exists()
     }
 
+    /// Returns the cert CN — the `preferred_username` portion of the Keycloak
+    /// login (everything before the first `@`, or the whole string if no `@`).
+    pub fn operator_cn(&self) -> String {
+        self.username
+            .split('@')
+            .next()
+            .unwrap_or(&self.username)
+            .to_string()
+    }
+
     /// Build a `CertConfig` for the given node name using the stored credentials.
     pub fn cert_config_for(&self, node_name: &str) -> Result<crate::cert::CertConfig> {
         let ca_root_pem = std::fs::read_to_string(&self.ca_root_pem_path)

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -4,45 +4,22 @@ use std::path::PathBuf;
 
 /// Machine-wide dverse configuration, stored at `~/.config/dverse/config.toml`.
 /// Only one user session is supported per machine.
+///
+/// The server-side constants (Keycloak URL, CA URL, client credentials) are
+/// set by the application at save time and are not exposed in the UI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DverseConfig {
-    /// Keycloak user email, e.g. "alice@dverse.yordanmitev.me"
     pub username: String,
-    /// Keycloak password (stored locally for non-interactive cert renewal)
     pub password: String,
     pub keycloak_url: String,
     pub keycloak_realm: String,
     pub client_id: String,
     pub client_secret: String,
-    /// Step-CA base URL
     pub ca_url: String,
-    /// Path to the Step-CA root PEM file on disk
+    /// Path to the cached Step-CA root PEM (bootstrapped on first login).
     pub ca_root_pem_path: String,
-    /// Directory where per-node certificates are cached
     pub cert_dir: PathBuf,
-    /// Zenoh listen address for the local router
     pub router_listen: String,
-}
-
-impl Default for DverseConfig {
-    fn default() -> Self {
-        let cert_dir = dirs::data_local_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("dverse")
-            .join("certs");
-        Self {
-            username: String::new(),
-            password: String::new(),
-            keycloak_url: String::from("https://auth.dverse.yordanmitev.me"),
-            keycloak_realm: String::from("master"),
-            client_id: String::from("step-ca"),
-            client_secret: String::new(),
-            ca_url: String::from("https://ca.dverse.yordanmitev.me:9000"),
-            ca_root_pem_path: String::new(),
-            cert_dir,
-            router_listen: String::from("tls/0.0.0.0:7447"),
-        }
-    }
 }
 
 impl DverseConfig {
@@ -51,6 +28,15 @@ impl DverseConfig {
             .unwrap_or_else(|| PathBuf::from("."))
             .join("dverse")
             .join("config.toml")
+    }
+
+    pub fn ca_root_pem_path_default() -> String {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("dverse")
+            .join("ca-root.pem")
+            .to_string_lossy()
+            .into_owned()
     }
 
     pub fn load() -> Result<Self> {

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -19,7 +19,10 @@ pub struct DverseConfig {
     /// Path to the cached Step-CA root PEM (bootstrapped on first login).
     pub ca_root_pem_path: String,
     pub cert_dir: PathBuf,
+    /// Zenoh listen address for the local router (server side).
     pub router_listen: String,
+    /// Zenoh connect endpoint used by local agents (client side).
+    pub router_endpoint: String,
 }
 
 impl DverseConfig {

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -1,0 +1,95 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Machine-wide dverse configuration, stored at `~/.config/dverse/config.toml`.
+/// Only one user session is supported per machine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DverseConfig {
+    /// Keycloak user email, e.g. "alice@dverse.yordanmitev.me"
+    pub username: String,
+    /// Keycloak password (stored locally for non-interactive cert renewal)
+    pub password: String,
+    pub keycloak_url: String,
+    pub keycloak_realm: String,
+    pub client_id: String,
+    pub client_secret: String,
+    /// Step-CA base URL
+    pub ca_url: String,
+    /// Path to the Step-CA root PEM file on disk
+    pub ca_root_pem_path: String,
+    /// Directory where per-node certificates are cached
+    pub cert_dir: PathBuf,
+    /// Zenoh listen address for the local router
+    pub router_listen: String,
+}
+
+impl Default for DverseConfig {
+    fn default() -> Self {
+        let cert_dir = dirs::data_local_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("dverse")
+            .join("certs");
+        Self {
+            username: String::new(),
+            password: String::new(),
+            keycloak_url: String::from("https://auth.dverse.yordanmitev.me"),
+            keycloak_realm: String::from("master"),
+            client_id: String::from("step-ca"),
+            client_secret: String::new(),
+            ca_url: String::from("https://ca.dverse.yordanmitev.me:9000"),
+            ca_root_pem_path: String::new(),
+            cert_dir,
+            router_listen: String::from("tls/0.0.0.0:7447"),
+        }
+    }
+}
+
+impl DverseConfig {
+    pub fn config_path() -> PathBuf {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("dverse")
+            .join("config.toml")
+    }
+
+    pub fn load() -> Result<Self> {
+        let path = Self::config_path();
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        toml::from_str(&text).context("parsing config TOML")
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = Self::config_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context("creating config dir")?;
+        }
+        let text = toml::to_string_pretty(self).context("serializing config")?;
+        std::fs::write(&path, &text)
+            .with_context(|| format!("writing {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn exists() -> bool {
+        Self::config_path().exists()
+    }
+
+    /// Build a `CertConfig` for the given node name using the stored credentials.
+    pub fn cert_config_for(&self, node_name: &str) -> Result<crate::cert::CertConfig> {
+        let ca_root_pem = std::fs::read_to_string(&self.ca_root_pem_path)
+            .with_context(|| format!("reading CA root PEM from {}", self.ca_root_pem_path))?;
+        Ok(crate::cert::CertConfig {
+            keycloak_url: self.keycloak_url.clone(),
+            keycloak_realm: self.keycloak_realm.clone(),
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            username: self.username.clone(),
+            password: self.password.clone(),
+            ca_url: self.ca_url.clone(),
+            ca_root_pem,
+            out_dir: self.cert_dir.clone(),
+            node_name: node_name.to_string(),
+        })
+    }
+}

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DverseConfig {
     pub username: String,
+    #[serde(skip)]
     pub password: String,
     pub keycloak_url: String,
     pub keycloak_realm: String,
@@ -46,10 +47,20 @@ impl DverseConfig {
         let path = Self::config_path();
         let text = std::fs::read_to_string(&path)
             .with_context(|| format!("reading {}", path.display()))?;
-        toml::from_str(&text).context("parsing config TOML")
+        let mut cfg: Self = toml::from_str(&text).context("parsing config TOML")?;
+        let entry = keyring::Entry::new("dverse", &cfg.username)
+            .context("opening keychain entry")?;
+        cfg.password = entry
+            .get_password()
+            .context("reading password from keychain — sign in again to re-enter it")?;
+        Ok(cfg)
     }
 
     pub fn save(&self) -> Result<()> {
+        let entry = keyring::Entry::new("dverse", &self.username)
+            .context("opening keychain entry")?;
+        entry.set_password(&self.password)
+            .context("storing password in keychain")?;
         let path = Self::config_path();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context("creating config dir")?;

--- a/src/bot_framework/src/lib.rs
+++ b/src/bot_framework/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cert;
+pub mod config;
 pub mod node;

--- a/src/bot_framework/src/lib.rs
+++ b/src/bot_framework/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cert;
+pub mod node;

--- a/src/bot_framework/src/main.rs
+++ b/src/bot_framework/src/main.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bot_framework::cert::{self, CertConfig};
+use bot_framework::node::NodeConfig;
+
+#[derive(Parser)]
+#[command(name = "bot-framework", about = "DVerse node certificate and Zenoh management")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Acquire a certificate from Step-CA via Keycloak and write it to disk.
+    GetCert {
+        #[arg(long, env = "NODE_NAME")]
+        node_name: String,
+
+        #[arg(long, env = "KEYCLOAK_URL", default_value = "https://auth.dverse.yordanmitev.me")]
+        keycloak_url: String,
+
+        #[arg(long, env = "KEYCLOAK_REALM", default_value = "master")]
+        keycloak_realm: String,
+
+        #[arg(long, env = "KEYCLOAK_CLIENT_ID", default_value = "step-ca")]
+        client_id: String,
+
+        #[arg(long, env = "KEYCLOAK_CLIENT_SECRET")]
+        client_secret: String,
+
+        #[arg(long, env = "KEYCLOAK_USERNAME")]
+        username: String,
+
+        #[arg(long, env = "KEYCLOAK_PASSWORD")]
+        password: String,
+
+        #[arg(long, env = "STEP_CA_URL", default_value = "https://ca.dverse.yordanmitev.me:9000")]
+        ca_url: String,
+
+        /// Path to Step-CA root certificate PEM
+        #[arg(long, env = "STEP_CA_ROOT")]
+        ca_root: PathBuf,
+
+        /// Directory to write cert, key, and CA chain into
+        #[arg(long, env = "CERT_DIR", default_value = "./certs")]
+        out_dir: PathBuf,
+    },
+
+    /// Check whether the cert on disk needs renewal (exits 1 if it does).
+    CheckCert {
+        #[arg(long, env = "NODE_NAME")]
+        node_name: String,
+
+        #[arg(long, env = "CERT_DIR", default_value = "./certs")]
+        cert_dir: PathBuf,
+
+        /// Treat the cert as stale after this many hours (default: 23)
+        #[arg(long, default_value = "23")]
+        max_age_hours: u64,
+    },
+
+    /// Open a Zenoh session and print the session ID (smoke-test for connectivity).
+    Connect {
+        #[arg(long, env = "ZENOH_ROUTER", default_value = "tcp/localhost:7447")]
+        router: String,
+
+        #[arg(long, env = "ZENOH_TLS_CA")]
+        tls_ca: Option<PathBuf>,
+
+        #[arg(long, env = "ZENOH_TLS_CERT")]
+        tls_cert: Option<PathBuf>,
+
+        #[arg(long, env = "ZENOH_TLS_KEY")]
+        tls_key: Option<PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::GetCert {
+            node_name,
+            keycloak_url,
+            keycloak_realm,
+            client_id,
+            client_secret,
+            username,
+            password,
+            ca_url,
+            ca_root,
+            out_dir,
+        } => {
+            let ca_root_pem = tokio::fs::read_to_string(&ca_root).await?;
+
+            let cfg = CertConfig {
+                keycloak_url,
+                keycloak_realm,
+                client_id,
+                client_secret,
+                username,
+                password,
+                ca_url,
+                ca_root_pem,
+                out_dir,
+                node_name,
+            };
+
+            let (crt, key, ca) = cert::acquire(&cfg).await?;
+            println!("  cert: {}", crt.display());
+            println!("   key: {}", key.display());
+            println!("    ca: {}", ca.display());
+        }
+
+        Command::CheckCert { node_name, cert_dir, max_age_hours } => {
+            let crt = cert::cert_path(&cert_dir, &node_name);
+            let stale = cert::needs_renewal(&crt, Duration::from_secs(max_age_hours * 3600)).await;
+            if stale {
+                eprintln!("Certificate {} needs renewal.", crt.display());
+                std::process::exit(1);
+            } else {
+                println!("Certificate {} is current.", crt.display());
+            }
+        }
+
+        Command::Connect { router, tls_ca, tls_cert, tls_key } => {
+            let node_cfg = match (tls_ca, tls_cert, tls_key) {
+                (Some(ca), Some(cert), Some(key)) => NodeConfig::mtls(router, ca, cert, key),
+                _ => NodeConfig::plain(router),
+            };
+
+            println!("Connecting to Zenoh router...");
+            let session = node_cfg.connect().await?;
+            println!("Connected. Session ZID: {}", session.zid());
+        }
+    }
+
+    Ok(())
+}

--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -75,9 +75,6 @@ impl NodeConfig {
 
         if self.tls_cert.is_some() || self.tls_key.is_some() {
             zinsert(&mut config, "transport/link/tls/enable_mtls", "true")?;
-            // The cert CN/SAN reflects the Keycloak username, not the endpoint hostname.
-            // CA signature verification still runs; hostname check adds nothing here.
-            zinsert(&mut config, "transport/link/tls/verify_name_on_connect", "false")?;
         }
 
         if let Some(cert_path) = &self.tls_cert {

--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -75,6 +75,9 @@ impl NodeConfig {
 
         if self.tls_cert.is_some() || self.tls_key.is_some() {
             zinsert(&mut config, "transport/link/tls/enable_mtls", "true")?;
+            // The cert CN/SAN reflects the Keycloak username, not the endpoint hostname.
+            // CA signature verification still runs; hostname check adds nothing here.
+            zinsert(&mut config, "transport/link/tls/verify_name_on_connect", "false")?;
         }
 
         if let Some(cert_path) = &self.tls_cert {

--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -4,7 +4,7 @@
 //! matching the DNS SAN in the certificate.  The Zenoh router can enforce mTLS
 //! so only nodes with valid CA-signed certificates can join the network.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use zenoh::Session;
 

--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -1,0 +1,102 @@
+//! Zenoh node: opens a session with optional mTLS using Step-CA-issued certs.
+//!
+//! With a cert issued by the CA, the node connects as `zenoh-<name>.local` —
+//! matching the DNS SAN in the certificate.  The Zenoh router can enforce mTLS
+//! so only nodes with valid CA-signed certificates can join the network.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use zenoh::Session;
+
+/// Configuration for a Zenoh node connection.
+pub struct NodeConfig {
+    /// Zenoh router endpoint.
+    /// Plain TCP:  "tcp/localhost:7447"
+    /// TLS / mTLS: "tls/router.local:7447"
+    pub router: String,
+
+    /// Path to the CA root certificate PEM (Step-CA root).
+    /// Required when `router` uses a `tls/` endpoint.
+    pub tls_ca: Option<PathBuf>,
+
+    /// Path to the node's client certificate PEM (issued by Step-CA).
+    /// Required for mTLS.
+    pub tls_cert: Option<PathBuf>,
+
+    /// Path to the node's private key PEM.
+    /// Required for mTLS.
+    pub tls_key: Option<PathBuf>,
+}
+
+impl NodeConfig {
+    /// Create a plain (no TLS) node config.
+    pub fn plain(router: impl Into<String>) -> Self {
+        Self {
+            router: router.into(),
+            tls_ca: None,
+            tls_cert: None,
+            tls_key: None,
+        }
+    }
+
+    /// Create an mTLS node config using a Step-CA-issued certificate.
+    pub fn mtls(
+        router: impl Into<String>,
+        tls_ca: impl Into<PathBuf>,
+        tls_cert: impl Into<PathBuf>,
+        tls_key: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            router: router.into(),
+            tls_ca: Some(tls_ca.into()),
+            tls_cert: Some(tls_cert.into()),
+            tls_key: Some(tls_key.into()),
+        }
+    }
+
+    /// Open a Zenoh session using this configuration.
+    pub async fn connect(self) -> Result<Session> {
+        let config = self.build_zenoh_config().await?;
+        zenoh::open(config)
+            .await
+            .map_err(|e| anyhow::anyhow!("opening Zenoh session: {e}"))
+    }
+
+    async fn build_zenoh_config(&self) -> Result<zenoh::Config> {
+        let mut config = zenoh::Config::default();
+
+        zinsert(&mut config, "connect/endpoints", &format!("[\"{}\"]", self.router))?;
+        zinsert(&mut config, "scouting/multicast/enabled", "false")?;
+
+        if let Some(ca_path) = &self.tls_ca {
+            zinsert(&mut config, "transport/link/tls/root_ca_certificate", &path_to_json_str(ca_path))?;
+        }
+
+        if self.tls_cert.is_some() || self.tls_key.is_some() {
+            zinsert(&mut config, "transport/link/tls/enable_mtls", "true")?;
+        }
+
+        if let Some(cert_path) = &self.tls_cert {
+            zinsert(&mut config, "transport/link/tls/connect_certificate", &path_to_json_str(cert_path))?;
+        }
+
+        if let Some(key_path) = &self.tls_key {
+            zinsert(&mut config, "transport/link/tls/connect_private_key", &path_to_json_str(key_path))?;
+        }
+
+        Ok(config)
+    }
+}
+
+/// Encode a path as a JSON5 string value (quoted, forward slashes).
+fn path_to_json_str(path: &Path) -> String {
+    let s = path.to_string_lossy().replace('\\', "/");
+    format!("\"{s}\"")
+}
+
+/// Thin wrapper: convert zenoh's boxed error into anyhow for `?` ergonomics.
+fn zinsert(config: &mut zenoh::Config, key: &str, value: &str) -> Result<()> {
+    config
+        .insert_json5(key, value)
+        .map_err(|e| anyhow::anyhow!("zenoh config key '{}': {}", key, e))
+}

--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -65,6 +65,7 @@ impl NodeConfig {
     async fn build_zenoh_config(&self) -> Result<zenoh::Config> {
         let mut config = zenoh::Config::default();
 
+        zinsert(&mut config, "mode", "\"client\"")?;
         zinsert(&mut config, "connect/endpoints", &format!("[\"{}\"]", self.router))?;
         zinsert(&mut config, "scouting/multicast/enabled", "false")?;
 

--- a/src/ping/Cargo.toml
+++ b/src/ping/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dverse-ping"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "dverse-ping"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+bot-framework = { path = "../bot_framework" }
+tokio = { version = "1", features = ["full"] }
+zenoh = "1.8.0"

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -1,0 +1,72 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use bot_framework::{cert, config::DverseConfig, node::NodeConfig};
+
+const NODE_NAME: &str = "ping";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cfg = DverseConfig::load()
+        .expect("No dverse config found. Run the router first to log in.");
+
+    let cert_path = cert::cert_path(&cfg.cert_dir, NODE_NAME);
+    let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
+
+    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
+        println!("[{NODE_NAME}] Acquiring certificate…");
+        let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
+        cert::acquire(&cert_cfg).await?;
+    } else {
+        println!("[{NODE_NAME}] Using cached certificate.");
+    }
+
+    println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
+    let session = NodeConfig::mtls(
+        &cfg.router_endpoint,
+        &cfg.ca_root_pem_path,
+        &cert_path,
+        &key_path,
+    )
+    .connect()
+    .await?;
+
+    println!("[{NODE_NAME}] Connected. Announcing…");
+    session
+        .put(format!("dverse/nodes/announce/{NODE_NAME}"), "")
+        .await
+        .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
+
+    let pong_sub = session
+        .declare_subscriber("dverse/pong")
+        .await
+        .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
+
+    let mut seq: u64 = 0;
+    loop {
+        seq += 1;
+        let msg = format!("ping #{seq}");
+        println!("[{NODE_NAME}] → {msg}");
+        session
+            .put("dverse/ping", msg)
+            .await
+            .map_err(|e| anyhow::anyhow!("put: {e}"))?;
+
+        tokio::select! {
+            sample = pong_sub.recv_async() => {
+                match sample {
+                    Ok(s) => {
+                        let payload = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
+                        println!("[{NODE_NAME}] ← {payload}");
+                    }
+                    Err(e) => return Err(anyhow::anyhow!("recv: {e}")),
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_secs(2)) => {
+                println!("[{NODE_NAME}] (no pong yet)");
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -31,9 +31,10 @@ async fn main() -> Result<()> {
     .connect()
     .await?;
 
-    println!("[{NODE_NAME}] Connected. Announcing…");
+    let cn = cfg.operator_cn();
+    println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
     session
-        .put(format!("dverse/nodes/announce/{NODE_NAME}"), "")
+        .put(format!("dverse/nodes/announce/{NODE_NAME}"), cn)
         .await
         .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
 

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<()> {
 
     let cert_path = cert::cert_path(&cfg.cert_dir, NODE_NAME);
     let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
+    let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
     if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
         println!("[{NODE_NAME}] Acquiring certificate…");
@@ -24,7 +25,7 @@ async fn main() -> Result<()> {
     println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
     let session = NodeConfig::mtls(
         &cfg.router_endpoint,
-        &cfg.ca_root_pem_path,
+        &ca_path,
         &cert_path,
         &key_path,
     )

--- a/src/pong/Cargo.toml
+++ b/src/pong/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dverse-pong"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "dverse-pong"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+bot-framework = { path = "../bot_framework" }
+tokio = { version = "1", features = ["full"] }
+zenoh = "1.8.0"

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -31,9 +31,10 @@ async fn main() -> Result<()> {
     .connect()
     .await?;
 
-    println!("[{NODE_NAME}] Connected. Announcing…");
+    let cn = cfg.operator_cn();
+    println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
     session
-        .put(format!("dverse/nodes/announce/{NODE_NAME}"), "")
+        .put(format!("dverse/nodes/announce/{NODE_NAME}"), cn)
         .await
         .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
 

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -1,0 +1,61 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use bot_framework::{cert, config::DverseConfig, node::NodeConfig};
+
+const NODE_NAME: &str = "pong";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cfg = DverseConfig::load()
+        .expect("No dverse config found. Run the router first to log in.");
+
+    let cert_path = cert::cert_path(&cfg.cert_dir, NODE_NAME);
+    let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
+
+    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
+        println!("[{NODE_NAME}] Acquiring certificate…");
+        let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
+        cert::acquire(&cert_cfg).await?;
+    } else {
+        println!("[{NODE_NAME}] Using cached certificate.");
+    }
+
+    println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
+    let session = NodeConfig::mtls(
+        &cfg.router_endpoint,
+        &cfg.ca_root_pem_path,
+        &cert_path,
+        &key_path,
+    )
+    .connect()
+    .await?;
+
+    println!("[{NODE_NAME}] Connected. Announcing…");
+    session
+        .put(format!("dverse/nodes/announce/{NODE_NAME}"), "")
+        .await
+        .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
+
+    let ping_sub = session
+        .declare_subscriber("dverse/ping")
+        .await
+        .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
+
+    println!("[{NODE_NAME}] Listening for pings…");
+    while let Ok(sample) = ping_sub.recv_async().await {
+        let payload = String::from_utf8_lossy(&sample.payload().to_bytes()).into_owned();
+        println!("[{NODE_NAME}] ← {payload}");
+
+        let reply = format!("pong (echoing: {payload})");
+        println!("[{NODE_NAME}] → {reply}");
+        session
+            .put("dverse/pong", reply)
+            .await
+            .map_err(|e| anyhow::anyhow!("put: {e}"))?;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Ok(())
+}

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<()> {
 
     let cert_path = cert::cert_path(&cfg.cert_dir, NODE_NAME);
     let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
+    let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
     if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
         println!("[{NODE_NAME}] Acquiring certificate…");
@@ -24,7 +25,7 @@ async fn main() -> Result<()> {
     println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
     let session = NodeConfig::mtls(
         &cfg.router_endpoint,
-        &cfg.ca_root_pem_path,
+        &ca_path,
         &cert_path,
         &key_path,
     )

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -18,3 +18,7 @@ eframe = "0.31"
 egui = "0.31"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
+mdns-sd = "0.13"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "4", default-features = false, features = ["blocking"] }

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "zenoh-router"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "zenoh-router"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+eframe = "0.31"
+egui = "0.31"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+zenoh = "1.8.0"

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -9,11 +9,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4", features = ["derive", "env"] }
+bot-framework = { path = "../bot_framework" }
 eframe = "0.31"
 egui = "0.31"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1"
 bot-framework = { path = "../bot_framework" }
 clap = { version = "4", features = ["derive"] }
 dirs = "5"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde_json = "1"
 eframe = "0.31"
 egui = "0.31"

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 bot-framework = { path = "../bot_framework" }
+clap = { version = "4", features = ["derive"] }
+dirs = "5"
+serde_json = "1"
 eframe = "0.31"
 egui = "0.31"
 tokio = { version = "1", features = ["full"] }

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -1,0 +1,6 @@
+pub const KEYCLOAK_URL: &str = "https://auth.dverse.yordanmitev.me";
+pub const KEYCLOAK_REALM: &str = "master";
+pub const CLIENT_ID: &str = "step-ca";
+pub const CLIENT_SECRET: &str = "oeWYn8BLhMsAt7j9qG7qEwIWATnBepAr";
+pub const CA_URL: &str = "https://ca.dverse.yordanmitev.me:9000";
+pub const ROUTER_LISTEN: &str = "tls/0.0.0.0:7447";

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -5,5 +5,8 @@ pub const CLIENT_SECRET: &str = "oeWYn8BLhMsAt7j9qG7qEwIWATnBepAr";
 pub const CA_URL: &str = "https://ca.dverse.yordanmitev.me:9000";
 pub const ROUTER_LISTEN: &str = "tls/0.0.0.0:7447";
 pub const ROUTER_PORT: u16 = 7447;
-/// Keycloak admin password — used only for the registration API call.
-pub const KEYCLOAK_ADMIN_PASSWORD: &str = env!("DVERSE_ADMIN_PASSWORD");
+/// Keycloak client used for user self-registration.
+/// The service account for this client must have the manage-users role
+/// scoped to create-only; it cannot read, modify, or delete existing users.
+pub const REGISTRATION_CLIENT_ID: &str = "dverse-registration";
+pub const REGISTRATION_CLIENT_SECRET: &str = env!("DVERSE_REG_SECRET");

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -4,6 +4,6 @@ pub const CLIENT_ID: &str = "step-ca";
 pub const CLIENT_SECRET: &str = "oeWYn8BLhMsAt7j9qG7qEwIWATnBepAr";
 pub const CA_URL: &str = "https://ca.dverse.yordanmitev.me:9000";
 pub const ROUTER_LISTEN: &str = "tls/0.0.0.0:7447";
-pub const ROUTER_ENDPOINT: &str = "tls/localhost:7447";
+pub const ROUTER_PORT: u16 = 7447;
 /// Keycloak admin password — used only for the registration API call.
 pub const KEYCLOAK_ADMIN_PASSWORD: &str = env!("DVERSE_ADMIN_PASSWORD");

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -1,12 +1,11 @@
 pub const KEYCLOAK_URL: &str = "https://auth.dverse.yordanmitev.me";
-pub const KEYCLOAK_REALM: &str = "master";
+pub const KEYCLOAK_REALM: &str = "dverse";
 pub const CLIENT_ID: &str = "step-ca";
 pub const CLIENT_SECRET: &str = "oeWYn8BLhMsAt7j9qG7qEwIWATnBepAr";
 pub const CA_URL: &str = "https://ca.dverse.yordanmitev.me:9000";
 pub const ROUTER_LISTEN: &str = "tls/0.0.0.0:7447";
 pub const ROUTER_PORT: u16 = 7447;
-/// Keycloak client used for user self-registration.
-/// The service account for this client must have the manage-users role
-/// scoped to create-only; it cannot read, modify, or delete existing users.
+/// Service-account client for user self-registration (manage-users scope, dverse realm).
+/// Secret is managed in sops and injected into Keycloak at deploy time.
 pub const REGISTRATION_CLIENT_ID: &str = "dverse-registration";
-pub const REGISTRATION_CLIENT_SECRET: &str = env!("DVERSE_REG_SECRET");
+pub const REGISTRATION_CLIENT_SECRET: &str = "Xv2kR8nQ5mW4jT7eBpL3hC9gF6dA0sYz";

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -4,3 +4,6 @@ pub const CLIENT_ID: &str = "step-ca";
 pub const CLIENT_SECRET: &str = "oeWYn8BLhMsAt7j9qG7qEwIWATnBepAr";
 pub const CA_URL: &str = "https://ca.dverse.yordanmitev.me:9000";
 pub const ROUTER_LISTEN: &str = "tls/0.0.0.0:7447";
+pub const ROUTER_ENDPOINT: &str = "tls/localhost:7447";
+/// Keycloak admin password — used only for the registration API call.
+pub const KEYCLOAK_ADMIN_PASSWORD: &str = env!("DVERSE_ADMIN_PASSWORD");

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -1,0 +1,164 @@
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use std::sync::{Arc, Mutex};
+
+use crate::state::AppState;
+
+const SERVICE_TYPE: &str = "_dverse._tcp.local.";
+
+/// Registers this router as a `_dverse._tcp` DNS-SD service.
+///
+/// On Linux: uses the avahi D-Bus API so avahi-daemon owns the mDNS socket.
+/// Falls back to mdns-sd if avahi is absent, or on non-Linux platforms.
+///
+/// The record is withdrawn when this handle is dropped.
+pub struct MdnsHandle {
+    _inner: Inner,
+}
+
+enum Inner {
+    #[cfg(target_os = "linux")]
+    Avahi(AvahiHandle),
+    MdnsSd(MdnsSdHandle),
+}
+
+impl MdnsHandle {
+    pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            match linux::publish(cn, port) {
+                Ok(handle) => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS: published DVerse ({cn}) on {SERVICE_TYPE} port {port} (via avahi)"
+                    ));
+                    return Some(Self { _inner: Inner::Avahi(handle) });
+                }
+                Err(e) => {
+                    state.lock().unwrap().push_log(format!(
+                        "Warning: avahi D-Bus unavailable ({e}); falling back to mdns-sd"
+                    ));
+                }
+            }
+        }
+
+        mdns_sd_publish(cn, port, state).map(|h| Self { _inner: Inner::MdnsSd(h) })
+    }
+}
+
+// ── Linux: avahi D-Bus ────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+struct AvahiHandle {
+    // Keeping the connection alive: avahi-daemon removes services automatically
+    // when the owning D-Bus connection closes.
+    _conn: zbus::blocking::Connection,
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::AvahiHandle;
+    use anyhow::Result;
+    use zbus::blocking::Connection;
+
+    pub fn publish(cn: &str, port: u16) -> Result<AvahiHandle> {
+        let conn = Connection::system()?;
+
+        let group_path: zbus::zvariant::OwnedObjectPath = conn
+            .call_method(
+                Some("org.freedesktop.Avahi"),
+                "/",
+                Some("org.freedesktop.Avahi.Server"),
+                "EntryGroupNew",
+                &(),
+            )?
+            .body()
+            .deserialize()?;
+
+        // AddService(interface, protocol, flags, name, type, domain, host, port, txt)
+        // interface=-1 (AVAHI_IF_UNSPEC), protocol=-1 (AVAHI_PROTO_UNSPEC)
+        let name = format!("DVerse ({cn})");
+        let txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
+
+        conn.call_method(
+            Some("org.freedesktop.Avahi"),
+            group_path.as_str(),
+            Some("org.freedesktop.Avahi.EntryGroup"),
+            "AddService",
+            &(
+                -1i32,
+                -1i32,
+                0u32,
+                name.as_str(),
+                "_dverse._tcp",
+                "",
+                "",
+                port,
+                &txt,
+            ),
+        )?;
+
+        conn.call_method(
+            Some("org.freedesktop.Avahi"),
+            group_path.as_str(),
+            Some("org.freedesktop.Avahi.EntryGroup"),
+            "Commit",
+            &(),
+        )?;
+
+        Ok(AvahiHandle { _conn: conn })
+    }
+}
+
+// ── mdns-sd (non-Linux or avahi-absent fallback) ──────────────────────────────
+
+struct MdnsSdHandle {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl Drop for MdnsSdHandle {
+    fn drop(&mut self) {
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+fn mdns_sd_publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsSdHandle> {
+    let daemon = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "Warning: mDNS unavailable ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    let instance = format!("DVerse ({cn})");
+    let host = format!("zenoh-{cn}.local.");
+    let props: &[(&str, &str)] = &[("cn", cn)];
+
+    let svc = match ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props) {
+        Ok(s) => s,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "Warning: mDNS service info error ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    let fullname = svc.get_fullname().to_string();
+
+    if let Err(e) = daemon.register(svc) {
+        state.lock().unwrap().push_log(format!(
+            "Warning: mDNS register failed ({e}); peer discovery disabled"
+        ));
+        return None;
+    }
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS: published {instance} on {SERVICE_TYPE} port {port}"
+    ));
+
+    Some(MdnsSdHandle { daemon, fullname })
+}

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -1,109 +1,304 @@
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use eframe::egui;
+use bot_framework::config::DverseConfig;
 
 use crate::state::{Action, AppState, RouterStatus};
 
+// ── Screen state (lives on the GUI thread only) ────────────────────────────────
+
+pub enum Screen {
+    Setup(SetupForm),
+    /// Config submitted; waiting for the background thread to become Running.
+    Loading,
+    Main,
+}
+
+pub struct SetupForm {
+    pub cfg: DverseConfig,
+    pub error: Option<String>,
+}
+
+impl Default for SetupForm {
+    fn default() -> Self {
+        Self {
+            cfg: DverseConfig::default(),
+            error: None,
+        }
+    }
+}
+
+// ── App ────────────────────────────────────────────────────────────────────────
+
 pub struct RouterApp {
     state: Arc<Mutex<AppState>>,
+    screen: Screen,
 }
 
 impl RouterApp {
-    pub fn new(state: Arc<Mutex<AppState>>) -> Self {
-        Self { state }
+    pub fn new(state: Arc<Mutex<AppState>>, screen: Screen) -> Self {
+        Self { state, screen }
     }
 }
 
 impl eframe::App for RouterApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Keep the GUI updating so we see live changes from the background thread.
-        ctx.request_repaint_after(std::time::Duration::from_millis(200));
+        ctx.request_repaint_after(Duration::from_millis(200));
 
-        let mut st = self.state.lock().unwrap();
+        // Watch for background-thread transitions.
+        let status = self.state.lock().unwrap().router_status.clone();
 
-        egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.label("Router:");
-                match &st.router_status {
-                    RouterStatus::Starting => {
-                        ui.colored_label(egui::Color32::YELLOW, "Starting…");
-                    }
-                    RouterStatus::Running => {
-                        ui.colored_label(egui::Color32::GREEN, "Running");
-                    }
-                    RouterStatus::Reloading => {
-                        ui.colored_label(egui::Color32::YELLOW, "Reloading ACL…");
-                    }
-                    RouterStatus::Error(msg) => {
-                        ui.colored_label(egui::Color32::RED, format!("Error: {msg}"));
-                    }
+        match &self.screen {
+            Screen::Setup(_) => {
+                // If the background thread just received staged_config, switch to Loading.
+                // (staged_config is consumed by the background thread, so we detect the
+                //  transition via router_status leaving Idle.)
+                if !matches!(status, RouterStatus::Idle) {
+                    self.screen = Screen::Loading;
                 }
-            });
-        });
+            }
+            Screen::Loading => match &status {
+                RouterStatus::Running => self.screen = Screen::Main,
+                RouterStatus::Error(msg) => {
+                    let error = Some(msg.clone());
+                    self.screen = Screen::Setup(SetupForm { error, ..SetupForm::default() });
+                }
+                _ => {}
+            },
+            Screen::Main => {}
+        }
 
-        egui::TopBottomPanel::bottom("log_panel")
-            .resizable(true)
-            .min_height(120.0)
-            .show(ctx, |ui| {
-                ui.label("Log");
-                egui::ScrollArea::vertical()
-                    .stick_to_bottom(true)
-                    .show(ui, |ui| {
-                        for line in &st.log {
-                            ui.monospace(line);
+        match &mut self.screen {
+            Screen::Setup(form) => show_setup(ctx, &mut self.state, form),
+            Screen::Loading => show_loading(ctx, &self.state),
+            Screen::Main => show_main(ctx, &mut self.state),
+        }
+    }
+}
+
+// ── Setup screen ───────────────────────────────────────────────────────────────
+
+fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut SetupForm) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.heading("dverse — first-time setup");
+        ui.add_space(8.0);
+
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            egui::Grid::new("setup_grid")
+                .num_columns(2)
+                .spacing([12.0, 6.0])
+                .show(ui, |ui| {
+                    section_header(ui, "Account");
+
+                    row(ui, "Username (email)", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.username);
+                    });
+                    row(ui, "Password", |ui| {
+                        ui.add(egui::TextEdit::singleline(&mut form.cfg.password).password(true));
+                    });
+
+                    section_header(ui, "Keycloak");
+
+                    row(ui, "Keycloak URL", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.keycloak_url);
+                    });
+                    row(ui, "Realm", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.keycloak_realm);
+                    });
+                    row(ui, "Client ID", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.client_id);
+                    });
+                    row(ui, "Client Secret", |ui| {
+                        ui.add(egui::TextEdit::singleline(&mut form.cfg.client_secret).password(true));
+                    });
+
+                    section_header(ui, "Step-CA");
+
+                    row(ui, "CA URL", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.ca_url);
+                    });
+                    row(ui, "CA Root PEM path", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.ca_root_pem_path);
+                    });
+
+                    section_header(ui, "Router");
+
+                    row(ui, "Listen address", |ui| {
+                        ui.text_edit_singleline(&mut form.cfg.router_listen);
+                    });
+                    row(ui, "Cert cache dir", |ui| {
+                        let mut s = form.cfg.cert_dir.to_string_lossy().into_owned();
+                        if ui.text_edit_singleline(&mut s).changed() {
+                            form.cfg.cert_dir = s.into();
                         }
                     });
-            });
+                });
 
-        egui::CentralPanel::default().show(ctx, |ui| {
-            ui.columns(2, |cols| {
-                // Left column: pending nodes.
-                cols[0].heading("Pending");
-                let pending_cns: Vec<String> = st.pending.keys().cloned().collect();
-                if pending_cns.is_empty() {
-                    cols[0].label("(none)");
-                } else {
-                    let mut admit_cn: Option<String> = None;
-                    let mut deny_cn: Option<String> = None;
-                    for cn in &pending_cns {
-                        cols[0].horizontal(|ui| {
-                            ui.label(cn);
-                            if ui.button("Admit").clicked() {
-                                admit_cn = Some(cn.clone());
-                            }
-                            if ui.button("Deny").clicked() {
-                                deny_cn = Some(cn.clone());
-                            }
-                        });
-                    }
-                    if let Some(cn) = admit_cn {
-                        st.action_queue.push(Action::Admit(cn));
-                    }
-                    if let Some(cn) = deny_cn {
-                        st.action_queue.push(Action::Deny(cn));
-                    }
-                }
+            ui.add_space(12.0);
 
-                // Right column: admitted and denied nodes.
-                cols[1].heading("Admitted");
-                if st.admitted.is_empty() {
-                    cols[1].label("(none)");
-                } else {
-                    for cn in &st.admitted {
-                        cols[1].label(cn);
-                    }
-                }
+            if let Some(err) = &form.error {
+                ui.colored_label(egui::Color32::RED, err);
+                ui.add_space(6.0);
+            }
 
-                cols[1].add_space(12.0);
-                cols[1].heading("Denied");
-                if st.denied.is_empty() {
-                    cols[1].label("(none)");
-                } else {
-                    for cn in &st.denied {
-                        cols[1].colored_label(egui::Color32::LIGHT_RED, cn);
+            if ui.button("Save & Connect").clicked() {
+                match validate_and_submit(&form.cfg, state) {
+                    Ok(()) => {
+                        // Transition handled by the caller via Screen::Loading.
+                        // We signal the parent by setting a sentinel on form.error.
+                        form.error = None;
                     }
+                    Err(e) => form.error = Some(e),
                 }
-            });
+            }
         });
+    });
+
+    // If submission succeeded, switch the screen from the outside.
+    // We detect success by checking staged_config was just set.
+    if state.lock().unwrap().staged_config.is_some() {
+        // This won't actually run here — the borrow of `self.screen` prevents it.
+        // The caller (RouterApp::update) handles the screen switch after this fn returns.
+        // We leave a marker so the update loop sees it via router_status.
     }
+}
+
+fn validate_and_submit(cfg: &DverseConfig, state: &Arc<Mutex<AppState>>) -> Result<(), String> {
+    if cfg.username.is_empty() {
+        return Err("Username is required.".into());
+    }
+    if cfg.password.is_empty() {
+        return Err("Password is required.".into());
+    }
+    if cfg.client_secret.is_empty() {
+        return Err("Client secret is required.".into());
+    }
+    if cfg.ca_root_pem_path.is_empty() {
+        return Err("CA root PEM path is required.".into());
+    }
+    if !std::path::Path::new(&cfg.ca_root_pem_path).exists() {
+        return Err(format!("CA root PEM not found: {}", cfg.ca_root_pem_path));
+    }
+
+    cfg.save().map_err(|e| e.to_string())?;
+
+    let mut st = state.lock().unwrap();
+    st.push_log(format!("Config saved for {}. Acquiring certificate…", cfg.username));
+    st.staged_config = Some(cfg.clone());
+
+    Ok(())
+}
+
+// ── Loading screen ─────────────────────────────────────────────────────────────
+
+fn show_loading(ctx: &egui::Context, state: &Arc<Mutex<AppState>>) {
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.add_space(ui.available_height() / 3.0);
+        ui.vertical_centered(|ui| {
+            ui.heading("Connecting…");
+            ui.add_space(12.0);
+
+            let st = state.lock().unwrap();
+            if let Some(last) = st.log.last() {
+                ui.label(last);
+            }
+        });
+    });
+}
+
+// ── Main screen ────────────────────────────────────────────────────────────────
+
+fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
+    let mut st = state.lock().unwrap();
+
+    egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
+        ui.horizontal(|ui| {
+            ui.label("Router:");
+            match &st.router_status {
+                RouterStatus::Idle => { ui.label("Idle"); }
+                RouterStatus::Acquiring => { ui.colored_label(egui::Color32::YELLOW, "Acquiring cert…"); }
+                RouterStatus::Starting => { ui.colored_label(egui::Color32::YELLOW, "Starting…"); }
+                RouterStatus::Running => { ui.colored_label(egui::Color32::GREEN, "Running"); }
+                RouterStatus::Reloading => { ui.colored_label(egui::Color32::YELLOW, "Reloading ACL…"); }
+                RouterStatus::Error(msg) => { ui.colored_label(egui::Color32::RED, format!("Error: {msg}")); }
+            }
+        });
+    });
+
+    egui::TopBottomPanel::bottom("log_panel")
+        .resizable(true)
+        .min_height(120.0)
+        .show(ctx, |ui| {
+            ui.label("Log");
+            egui::ScrollArea::vertical()
+                .stick_to_bottom(true)
+                .show(ui, |ui| {
+                    for line in &st.log {
+                        ui.monospace(line);
+                    }
+                });
+        });
+
+    egui::CentralPanel::default().show(ctx, |ui| {
+        ui.columns(2, |cols| {
+            cols[0].heading("Pending");
+            let pending_cns: Vec<String> = st.pending.keys().cloned().collect();
+            if pending_cns.is_empty() {
+                cols[0].label("(none)");
+            } else {
+                let mut admit_cn: Option<String> = None;
+                let mut deny_cn: Option<String> = None;
+                for cn in &pending_cns {
+                    cols[0].horizontal(|ui| {
+                        ui.label(cn);
+                        if ui.button("Admit").clicked() {
+                            admit_cn = Some(cn.clone());
+                        }
+                        if ui.button("Deny").clicked() {
+                            deny_cn = Some(cn.clone());
+                        }
+                    });
+                }
+                if let Some(cn) = admit_cn {
+                    st.action_queue.push(Action::Admit(cn));
+                }
+                if let Some(cn) = deny_cn {
+                    st.action_queue.push(Action::Deny(cn));
+                }
+            }
+
+            cols[1].heading("Admitted");
+            if st.admitted.is_empty() {
+                cols[1].label("(none)");
+            } else {
+                for cn in &st.admitted {
+                    cols[1].label(cn);
+                }
+            }
+
+            cols[1].add_space(12.0);
+            cols[1].heading("Denied");
+            if st.denied.is_empty() {
+                cols[1].label("(none)");
+            } else {
+                for cn in &st.denied {
+                    cols[1].colored_label(egui::Color32::LIGHT_RED, cn);
+                }
+            }
+        });
+    });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn section_header(ui: &mut egui::Ui, label: &str) {
+    ui.strong(label);
+    ui.end_row();
+}
+
+fn row(ui: &mut egui::Ui, label: &str, content: impl FnOnce(&mut egui::Ui)) {
+    ui.label(label);
+    content(ui);
+    ui.end_row();
 }

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use eframe::egui;
 use bot_framework::config::DverseConfig;
 
-use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_ADMIN_PASSWORD, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_LISTEN, ROUTER_PORT};
+use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, REGISTRATION_CLIENT_ID, REGISTRATION_CLIENT_SECRET, ROUTER_LISTEN, ROUTER_PORT};
 use crate::state::{AppState, RouterStatus};
 
 // ── Screen state (GUI thread only) ─────────────────────────────────────────────
@@ -355,15 +355,15 @@ fn register_user(username: &str, password: &str) -> Result<(), String> {
 async fn register_user_async(username: &str, password: &str) -> Result<(), String> {
     let client = reqwest::Client::new();
 
-    // 1. Obtain an admin access token.
+    // 1. Obtain a service-account token using client credentials.
+    //    The dverse-registration client has manage-users scoped to create-only.
     let token_url = format!("{KEYCLOAK_URL}/realms/master/protocol/openid-connect/token");
     let token_resp = client
         .post(&token_url)
         .form(&[
-            ("client_id", "admin-cli"),
-            ("grant_type", "password"),
-            ("username", "admin"),
-            ("password", KEYCLOAK_ADMIN_PASSWORD),
+            ("client_id", REGISTRATION_CLIENT_ID),
+            ("client_secret", REGISTRATION_CLIENT_SECRET),
+            ("grant_type", "client_credentials"),
         ])
         .send()
         .await

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use eframe::egui;
 use bot_framework::config::DverseConfig;
 
+use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_LISTEN};
 use crate::state::{Action, AppState, RouterStatus};
 
 // ── Screen state (lives on the GUI thread only) ────────────────────────────────
@@ -16,14 +17,16 @@ pub enum Screen {
 }
 
 pub struct SetupForm {
-    pub cfg: DverseConfig,
+    pub username: String,
+    pub password: String,
     pub error: Option<String>,
 }
 
 impl Default for SetupForm {
     fn default() -> Self {
         Self {
-            cfg: DverseConfig::default(),
+            username: String::new(),
+            password: String::new(),
             error: None,
         }
     }
@@ -81,111 +84,104 @@ impl eframe::App for RouterApp {
 
 fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut SetupForm) {
     egui::CentralPanel::default().show(ctx, |ui| {
-        ui.heading("dverse — first-time setup");
-        ui.add_space(8.0);
+        // Centre the card vertically.
+        let top_pad = (ui.available_height() - 280.0).max(0.0) / 2.0;
+        ui.add_space(top_pad);
 
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            egui::Grid::new("setup_grid")
+        ui.vertical_centered(|ui| {
+            ui.heading("Sign in to dverse");
+            ui.add_space(4.0);
+            ui.weak(format!("Connecting to {KEYCLOAK_URL}"));
+            ui.add_space(20.0);
+
+            egui::Grid::new("login_grid")
                 .num_columns(2)
-                .spacing([12.0, 6.0])
+                .spacing([12.0, 8.0])
                 .show(ui, |ui| {
-                    section_header(ui, "Account");
+                    ui.label("Username");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.username)
+                            .hint_text("you@dverse.yordanmitev.me")
+                            .min_size(egui::vec2(260.0, 0.0)),
+                    );
+                    ui.end_row();
 
-                    row(ui, "Username (email)", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.username);
-                    });
-                    row(ui, "Password", |ui| {
-                        ui.add(egui::TextEdit::singleline(&mut form.cfg.password).password(true));
-                    });
-
-                    section_header(ui, "Keycloak");
-
-                    row(ui, "Keycloak URL", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.keycloak_url);
-                    });
-                    row(ui, "Realm", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.keycloak_realm);
-                    });
-                    row(ui, "Client ID", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.client_id);
-                    });
-                    row(ui, "Client Secret", |ui| {
-                        ui.add(egui::TextEdit::singleline(&mut form.cfg.client_secret).password(true));
-                    });
-
-                    section_header(ui, "Step-CA");
-
-                    row(ui, "CA URL", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.ca_url);
-                    });
-                    row(ui, "CA Root PEM path", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.ca_root_pem_path);
-                    });
-
-                    section_header(ui, "Router");
-
-                    row(ui, "Listen address", |ui| {
-                        ui.text_edit_singleline(&mut form.cfg.router_listen);
-                    });
-                    row(ui, "Cert cache dir", |ui| {
-                        let mut s = form.cfg.cert_dir.to_string_lossy().into_owned();
-                        if ui.text_edit_singleline(&mut s).changed() {
-                            form.cfg.cert_dir = s.into();
-                        }
-                    });
+                    ui.label("Password");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.password)
+                            .password(true)
+                            .min_size(egui::vec2(260.0, 0.0)),
+                    );
+                    ui.end_row();
                 });
 
-            ui.add_space(12.0);
+            ui.add_space(16.0);
 
             if let Some(err) = &form.error {
                 ui.colored_label(egui::Color32::RED, err);
-                ui.add_space(6.0);
+                ui.add_space(8.0);
             }
 
-            if ui.button("Save & Connect").clicked() {
-                match validate_and_submit(&form.cfg, state) {
-                    Ok(()) => {
-                        // Transition handled by the caller via Screen::Loading.
-                        // We signal the parent by setting a sentinel on form.error.
-                        form.error = None;
-                    }
+            if ui.button("  Connect  ").clicked() {
+                match build_and_submit(form, state) {
+                    Ok(()) => form.error = None,
                     Err(e) => form.error = Some(e),
                 }
             }
+
+            ui.add_space(24.0);
+            ui.separator();
+            ui.add_space(8.0);
+
+            egui::Grid::new("info_grid")
+                .num_columns(2)
+                .spacing([8.0, 4.0])
+                .show(ui, |ui| {
+                    info_row(ui, "Identity provider", KEYCLOAK_URL);
+                    info_row(ui, "Certificate authority", CA_URL);
+                    info_row(ui, "Router listens on", ROUTER_LISTEN);
+                });
         });
     });
-
-    // If submission succeeded, switch the screen from the outside.
-    // We detect success by checking staged_config was just set.
-    if state.lock().unwrap().staged_config.is_some() {
-        // This won't actually run here — the borrow of `self.screen` prevents it.
-        // The caller (RouterApp::update) handles the screen switch after this fn returns.
-        // We leave a marker so the update loop sees it via router_status.
-    }
 }
 
-fn validate_and_submit(cfg: &DverseConfig, state: &Arc<Mutex<AppState>>) -> Result<(), String> {
-    if cfg.username.is_empty() {
+fn info_row(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.weak(label);
+    ui.weak(value);
+    ui.end_row();
+}
+
+fn build_and_submit(form: &SetupForm, state: &Arc<Mutex<AppState>>) -> Result<(), String> {
+    if form.username.is_empty() {
         return Err("Username is required.".into());
     }
-    if cfg.password.is_empty() {
+    if form.password.is_empty() {
         return Err("Password is required.".into());
     }
-    if cfg.client_secret.is_empty() {
-        return Err("Client secret is required.".into());
-    }
-    if cfg.ca_root_pem_path.is_empty() {
-        return Err("CA root PEM path is required.".into());
-    }
-    if !std::path::Path::new(&cfg.ca_root_pem_path).exists() {
-        return Err(format!("CA root PEM not found: {}", cfg.ca_root_pem_path));
-    }
+
+    let cert_dir = dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("dverse")
+        .join("certs");
+
+    let cfg = DverseConfig {
+        username: form.username.clone(),
+        password: form.password.clone(),
+        keycloak_url: KEYCLOAK_URL.into(),
+        keycloak_realm: KEYCLOAK_REALM.into(),
+        client_id: CLIENT_ID.into(),
+        client_secret: CLIENT_SECRET.into(),
+        ca_url: CA_URL.into(),
+        ca_root_pem_path: DverseConfig::ca_root_pem_path_default(),
+        cert_dir,
+        router_listen: ROUTER_LISTEN.into(),
+    };
 
     cfg.save().map_err(|e| e.to_string())?;
 
     let mut st = state.lock().unwrap();
-    st.push_log(format!("Config saved for {}. Acquiring certificate…", cfg.username));
-    st.staged_config = Some(cfg.clone());
+    st.push_log(format!("Signed in as {}. Bootstrapping…", cfg.username));
+    st.staged_config = Some(cfg);
 
     Ok(())
 }
@@ -292,13 +288,3 @@ fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-fn section_header(ui: &mut egui::Ui, label: &str) {
-    ui.strong(label);
-    ui.end_row();
-}
-
-fn row(ui: &mut egui::Ui, label: &str, content: impl FnOnce(&mut egui::Ui)) {
-    ui.label(label);
-    content(ui);
-    ui.end_row();
-}

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -4,30 +4,48 @@ use std::time::Duration;
 use eframe::egui;
 use bot_framework::config::DverseConfig;
 
-use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_LISTEN};
-use crate::state::{Action, AppState, RouterStatus};
+use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_ADMIN_PASSWORD, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_ENDPOINT, ROUTER_LISTEN};
+use crate::state::{AppState, RouterStatus};
 
-// ── Screen state (lives on the GUI thread only) ────────────────────────────────
+// ── Screen state (GUI thread only) ─────────────────────────────────────────────
 
 pub enum Screen {
-    Setup(SetupForm),
-    /// Config submitted; waiting for the background thread to become Running.
+    Login(LoginForm),
+    Register(RegisterForm),
     Loading,
     Main,
 }
 
-pub struct SetupForm {
+pub struct LoginForm {
     pub username: String,
     pub password: String,
     pub error: Option<String>,
 }
 
-impl Default for SetupForm {
+impl Default for LoginForm {
+    fn default() -> Self {
+        Self { username: String::new(), password: String::new(), error: None }
+    }
+}
+
+pub struct RegisterForm {
+    pub username: String,   // chosen username (becomes Keycloak username + email prefix)
+    pub password: String,
+    pub confirm: String,
+    pub error: Option<String>,
+    pub working: bool,
+    pub success: Option<String>,
+}
+
+impl Default for RegisterForm {
     fn default() -> Self {
         Self {
             username: String::new(),
             password: String::new(),
+            confirm: String::new(),
             error: None,
+            working: false,
+            success: None,
         }
     }
 }
@@ -49,14 +67,11 @@ impl eframe::App for RouterApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         ctx.request_repaint_after(Duration::from_millis(200));
 
-        // Watch for background-thread transitions.
         let status = self.state.lock().unwrap().router_status.clone();
 
+        // Screen transitions driven by background thread status.
         match &self.screen {
-            Screen::Setup(_) => {
-                // If the background thread just received staged_config, switch to Loading.
-                // (staged_config is consumed by the background thread, so we detect the
-                //  transition via router_status leaving Idle.)
+            Screen::Login(_) | Screen::Register(_) => {
                 if !matches!(status, RouterStatus::Idle) {
                     self.screen = Screen::Loading;
                 }
@@ -64,8 +79,9 @@ impl eframe::App for RouterApp {
             Screen::Loading => match &status {
                 RouterStatus::Running => self.screen = Screen::Main,
                 RouterStatus::Error(msg) => {
-                    let error = Some(msg.clone());
-                    self.screen = Screen::Setup(SetupForm { error, ..SetupForm::default() });
+                    let mut form = LoginForm::default();
+                    form.error = Some(msg.clone());
+                    self.screen = Screen::Login(form);
                 }
                 _ => {}
             },
@@ -73,19 +89,30 @@ impl eframe::App for RouterApp {
         }
 
         match &mut self.screen {
-            Screen::Setup(form) => show_setup(ctx, &mut self.state, form),
+            Screen::Login(form) => {
+                if let Some(next) = show_login(ctx, &mut self.state, form) {
+                    self.screen = next;
+                }
+            }
+            Screen::Register(form) => {
+                if let Some(next) = show_register(ctx, form) {
+                    self.screen = next;
+                }
+            }
             Screen::Loading => show_loading(ctx, &self.state),
             Screen::Main => show_main(ctx, &mut self.state),
         }
     }
 }
 
-// ── Setup screen ───────────────────────────────────────────────────────────────
+// ── Login screen ───────────────────────────────────────────────────────────────
 
-fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut SetupForm) {
+/// Returns `Some(Screen)` to transition to, or `None` to stay.
+fn show_login(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut LoginForm) -> Option<Screen> {
+    let mut next: Option<Screen> = None;
+
     egui::CentralPanel::default().show(ctx, |ui| {
-        // Centre the card vertically.
-        let top_pad = (ui.available_height() - 280.0).max(0.0) / 2.0;
+        let top_pad = (ui.available_height() - 320.0).max(0.0) / 2.0;
         ui.add_space(top_pad);
 
         ui.vertical_centered(|ui| {
@@ -99,7 +126,7 @@ fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                 .spacing([12.0, 8.0])
                 .show(ui, |ui| {
                     ui.label("Username");
-                    ui.add(
+                    let r = ui.add(
                         egui::TextEdit::singleline(&mut form.username)
                             .hint_text("you@dverse.yordanmitev.me")
                             .min_size(egui::vec2(260.0, 0.0)),
@@ -107,12 +134,17 @@ fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                     ui.end_row();
 
                     ui.label("Password");
-                    ui.add(
+                    let p = ui.add(
                         egui::TextEdit::singleline(&mut form.password)
                             .password(true)
                             .min_size(egui::vec2(260.0, 0.0)),
                     );
                     ui.end_row();
+
+                    // Submit on Enter in any field.
+                    if (r.lost_focus() || p.lost_focus()) && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                        try_login(form, state);
+                    }
                 });
 
             ui.add_space(16.0);
@@ -122,12 +154,15 @@ fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                 ui.add_space(8.0);
             }
 
-            if ui.button("  Connect  ").clicked() {
-                match build_and_submit(form, state) {
-                    Ok(()) => form.error = None,
-                    Err(e) => form.error = Some(e),
+            ui.horizontal(|ui| {
+                if ui.button("  Sign in  ").clicked() {
+                    try_login(form, state);
                 }
-            }
+                ui.add_space(12.0);
+                if ui.button("Register").clicked() {
+                    next = Some(Screen::Register(RegisterForm::default()));
+                }
+            });
 
             ui.add_space(24.0);
             ui.separator();
@@ -143,20 +178,18 @@ fn show_setup(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                 });
         });
     });
+
+    next
 }
 
-fn info_row(ui: &mut egui::Ui, label: &str, value: &str) {
-    ui.weak(label);
-    ui.weak(value);
-    ui.end_row();
-}
-
-fn build_and_submit(form: &SetupForm, state: &Arc<Mutex<AppState>>) -> Result<(), String> {
+fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
     if form.username.is_empty() {
-        return Err("Username is required.".into());
+        form.error = Some("Username is required.".into());
+        return;
     }
     if form.password.is_empty() {
-        return Err("Password is required.".into());
+        form.error = Some("Password is required.".into());
+        return;
     }
 
     let cert_dir = dirs::data_local_dir()
@@ -175,15 +208,212 @@ fn build_and_submit(form: &SetupForm, state: &Arc<Mutex<AppState>>) -> Result<()
         ca_root_pem_path: DverseConfig::ca_root_pem_path_default(),
         cert_dir,
         router_listen: ROUTER_LISTEN.into(),
+        router_endpoint: ROUTER_ENDPOINT.into(),
     };
 
-    cfg.save().map_err(|e| e.to_string())?;
+    if let Err(e) = cfg.save() {
+        form.error = Some(e.to_string());
+        return;
+    }
 
     let mut st = state.lock().unwrap();
     st.push_log(format!("Signed in as {}. Bootstrapping…", cfg.username));
     st.staged_config = Some(cfg);
+    form.error = None;
+}
 
+// ── Register screen ────────────────────────────────────────────────────────────
+
+fn show_register(ctx: &egui::Context, form: &mut RegisterForm) -> Option<Screen> {
+    let mut next: Option<Screen> = None;
+
+    egui::CentralPanel::default().show(ctx, |ui| {
+        let top_pad = (ui.available_height() - 360.0).max(0.0) / 2.0;
+        ui.add_space(top_pad);
+
+        ui.vertical_centered(|ui| {
+            ui.heading("Create a dverse account");
+            ui.add_space(4.0);
+            ui.weak(format!("Your account will be created on {KEYCLOAK_URL}"));
+            ui.add_space(20.0);
+
+            egui::Grid::new("register_grid")
+                .num_columns(2)
+                .spacing([12.0, 8.0])
+                .show(ui, |ui| {
+                    ui.label("Username");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.username)
+                            .hint_text("alice")
+                            .min_size(egui::vec2(260.0, 0.0)),
+                    );
+                    ui.end_row();
+
+                    ui.label("Password");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.password)
+                            .password(true)
+                            .min_size(egui::vec2(260.0, 0.0)),
+                    );
+                    ui.end_row();
+
+                    ui.label("Confirm");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.confirm)
+                            .password(true)
+                            .min_size(egui::vec2(260.0, 0.0)),
+                    );
+                    ui.end_row();
+                });
+
+            ui.add_space(16.0);
+
+            if let Some(err) = &form.error {
+                ui.colored_label(egui::Color32::RED, err);
+                ui.add_space(8.0);
+            }
+            if let Some(ok) = &form.success {
+                ui.colored_label(egui::Color32::GREEN, ok);
+                ui.add_space(8.0);
+            }
+
+            ui.horizontal(|ui| {
+                let btn = ui.add_enabled(!form.working, egui::Button::new("  Create account  "));
+                if btn.clicked() {
+                    form.error = None;
+                    form.success = None;
+                    match validate_registration(form) {
+                        Ok(()) => {
+                            form.working = true;
+                            // Synchronous call — runs on GUI thread, acceptable for a local tool.
+                            match register_user(&form.username, &form.password) {
+                                Ok(()) => {
+                                    form.success = Some(format!(
+                                        "Account '{}' created. You can now sign in.",
+                                        form.username
+                                    ));
+                                    form.working = false;
+                                }
+                                Err(e) => {
+                                    form.error = Some(e);
+                                    form.working = false;
+                                }
+                            }
+                        }
+                        Err(e) => form.error = Some(e),
+                    }
+                }
+
+                ui.add_space(12.0);
+                if ui.button("Back to sign in").clicked() {
+                    next = Some(Screen::Login(LoginForm {
+                        username: form.username.clone(),
+                        ..Default::default()
+                    }));
+                }
+            });
+        });
+    });
+
+    next
+}
+
+fn validate_registration(form: &RegisterForm) -> Result<(), String> {
+    if form.username.is_empty() {
+        return Err("Username is required.".into());
+    }
+    if form.username.contains('@') || form.username.contains(' ') {
+        return Err("Username must not contain '@' or spaces.".into());
+    }
+    if form.password.len() < 8 {
+        return Err("Password must be at least 8 characters.".into());
+    }
+    if form.password != form.confirm {
+        return Err("Passwords do not match.".into());
+    }
     Ok(())
+}
+
+/// Create a Keycloak user via the Admin REST API using the hardcoded admin credentials.
+fn register_user(username: &str, password: &str) -> Result<(), String> {
+    // Keycloak Admin REST API is synchronous-friendly via blocking reqwest.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    rt.block_on(async move {
+        register_user_async(username, password).await
+    })
+}
+
+async fn register_user_async(username: &str, password: &str) -> Result<(), String> {
+    let client = reqwest::Client::new();
+
+    // 1. Obtain an admin access token.
+    let token_url = format!("{KEYCLOAK_URL}/realms/master/protocol/openid-connect/token");
+    let token_resp = client
+        .post(&token_url)
+        .form(&[
+            ("client_id", "admin-cli"),
+            ("grant_type", "password"),
+            ("username", "admin"),
+            ("password", KEYCLOAK_ADMIN_PASSWORD),
+        ])
+        .send()
+        .await
+        .map_err(|e| format!("Token request failed: {e}"))?;
+
+    let status = token_resp.status();
+    let body = token_resp.text().await.unwrap_or_default();
+
+    if !status.is_success() {
+        return Err(format!("Admin login failed ({status}): {body}"));
+    }
+
+    let token: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| format!("Token parse error: {e}"))?;
+    let access_token = token["access_token"]
+        .as_str()
+        .ok_or("No access_token in response")?
+        .to_string();
+
+    // 2. Create the user.
+    let email = format!("{username}@dverse.yordanmitev.me");
+    let users_url = format!("{KEYCLOAK_URL}/admin/realms/{KEYCLOAK_REALM}/users");
+
+    let user_payload = serde_json::json!({
+        "username": username,
+        "email": email,
+        "emailVerified": true,
+        "enabled": true,
+        "credentials": [{
+            "type": "password",
+            "value": password,
+            "temporary": false
+        }]
+    });
+
+    let create_resp = client
+        .post(&users_url)
+        .bearer_auth(&access_token)
+        .json(&user_payload)
+        .send()
+        .await
+        .map_err(|e| format!("User creation request failed: {e}"))?;
+
+    let status = create_resp.status();
+    if status.is_success() || status.as_u16() == 201 {
+        Ok(())
+    } else {
+        let body = create_resp.text().await.unwrap_or_default();
+        // Keycloak returns {"errorMessage": "..."} on conflict etc.
+        let msg = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v["errorMessage"].as_str().map(str::to_string))
+            .unwrap_or_else(|| format!("HTTP {status}: {body}"));
+        Err(msg)
+    }
 }
 
 // ── Loading screen ─────────────────────────────────────────────────────────────
@@ -194,7 +424,6 @@ fn show_loading(ctx: &egui::Context, state: &Arc<Mutex<AppState>>) {
         ui.vertical_centered(|ui| {
             ui.heading("Connecting…");
             ui.add_space(12.0);
-
             let st = state.lock().unwrap();
             if let Some(last) = st.log.last() {
                 ui.label(last);
@@ -206,18 +435,18 @@ fn show_loading(ctx: &egui::Context, state: &Arc<Mutex<AppState>>) {
 // ── Main screen ────────────────────────────────────────────────────────────────
 
 fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
-    let mut st = state.lock().unwrap();
+    let st = state.lock().unwrap();
 
     egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
         ui.horizontal(|ui| {
             ui.label("Router:");
             match &st.router_status {
-                RouterStatus::Idle => { ui.label("Idle"); }
+                RouterStatus::Idle     => { ui.label("Idle"); }
                 RouterStatus::Acquiring => { ui.colored_label(egui::Color32::YELLOW, "Acquiring cert…"); }
-                RouterStatus::Starting => { ui.colored_label(egui::Color32::YELLOW, "Starting…"); }
-                RouterStatus::Running => { ui.colored_label(egui::Color32::GREEN, "Running"); }
+                RouterStatus::Starting  => { ui.colored_label(egui::Color32::YELLOW, "Starting…"); }
+                RouterStatus::Running   => { ui.colored_label(egui::Color32::GREEN,  "Running"); }
                 RouterStatus::Reloading => { ui.colored_label(egui::Color32::YELLOW, "Reloading ACL…"); }
-                RouterStatus::Error(msg) => { ui.colored_label(egui::Color32::RED, format!("Error: {msg}")); }
+                RouterStatus::Error(m)  => { ui.colored_label(egui::Color32::RED,    format!("Error: {m}")); }
             }
         });
     });
@@ -237,54 +466,26 @@ fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
         });
 
     egui::CentralPanel::default().show(ctx, |ui| {
-        ui.columns(2, |cols| {
-            cols[0].heading("Pending");
-            let pending_cns: Vec<String> = st.pending.keys().cloned().collect();
-            if pending_cns.is_empty() {
-                cols[0].label("(none)");
-            } else {
-                let mut admit_cn: Option<String> = None;
-                let mut deny_cn: Option<String> = None;
-                for cn in &pending_cns {
-                    cols[0].horizontal(|ui| {
-                        ui.label(cn);
-                        if ui.button("Admit").clicked() {
-                            admit_cn = Some(cn.clone());
-                        }
-                        if ui.button("Deny").clicked() {
-                            deny_cn = Some(cn.clone());
-                        }
-                    });
-                }
-                if let Some(cn) = admit_cn {
-                    st.action_queue.push(Action::Admit(cn));
-                }
-                if let Some(cn) = deny_cn {
-                    st.action_queue.push(Action::Deny(cn));
-                }
+        ui.heading("Connected nodes");
+        ui.add_space(6.0);
+        if st.admitted.is_empty() {
+            ui.weak("Waiting for nodes to connect…");
+        } else {
+            for cn in &st.admitted {
+                ui.horizontal(|ui| {
+                    ui.colored_label(egui::Color32::GREEN, "●");
+                    ui.label(cn);
+                });
             }
-
-            cols[1].heading("Admitted");
-            if st.admitted.is_empty() {
-                cols[1].label("(none)");
-            } else {
-                for cn in &st.admitted {
-                    cols[1].label(cn);
-                }
-            }
-
-            cols[1].add_space(12.0);
-            cols[1].heading("Denied");
-            if st.denied.is_empty() {
-                cols[1].label("(none)");
-            } else {
-                for cn in &st.denied {
-                    cols[1].colored_label(egui::Color32::LIGHT_RED, cn);
-                }
-            }
-        });
+        }
     });
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+fn info_row(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.weak(label);
+    ui.weak(value);
+    ui.end_row();
+}
 

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -357,7 +357,7 @@ async fn register_user_async(username: &str, password: &str) -> Result<(), Strin
 
     // 1. Obtain a service-account token using client credentials.
     //    The dverse-registration client has manage-users scoped to create-only.
-    let token_url = format!("{KEYCLOAK_URL}/realms/master/protocol/openid-connect/token");
+    let token_url = format!("{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token");
     let token_resp = client
         .post(&token_url)
         .form(&[
@@ -390,8 +390,11 @@ async fn register_user_async(username: &str, password: &str) -> Result<(), Strin
     let user_payload = serde_json::json!({
         "username": username,
         "email": email,
+        "firstName": username,
+        "lastName": "",
         "emailVerified": true,
         "enabled": true,
+        "requiredActions": [],
         "credentials": [{
             "type": "password",
             "value": password,

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -1,0 +1,109 @@
+use std::sync::{Arc, Mutex};
+
+use eframe::egui;
+
+use crate::state::{Action, AppState, RouterStatus};
+
+pub struct RouterApp {
+    state: Arc<Mutex<AppState>>,
+}
+
+impl RouterApp {
+    pub fn new(state: Arc<Mutex<AppState>>) -> Self {
+        Self { state }
+    }
+}
+
+impl eframe::App for RouterApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Keep the GUI updating so we see live changes from the background thread.
+        ctx.request_repaint_after(std::time::Duration::from_millis(200));
+
+        let mut st = self.state.lock().unwrap();
+
+        egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Router:");
+                match &st.router_status {
+                    RouterStatus::Starting => {
+                        ui.colored_label(egui::Color32::YELLOW, "Starting…");
+                    }
+                    RouterStatus::Running => {
+                        ui.colored_label(egui::Color32::GREEN, "Running");
+                    }
+                    RouterStatus::Reloading => {
+                        ui.colored_label(egui::Color32::YELLOW, "Reloading ACL…");
+                    }
+                    RouterStatus::Error(msg) => {
+                        ui.colored_label(egui::Color32::RED, format!("Error: {msg}"));
+                    }
+                }
+            });
+        });
+
+        egui::TopBottomPanel::bottom("log_panel")
+            .resizable(true)
+            .min_height(120.0)
+            .show(ctx, |ui| {
+                ui.label("Log");
+                egui::ScrollArea::vertical()
+                    .stick_to_bottom(true)
+                    .show(ui, |ui| {
+                        for line in &st.log {
+                            ui.monospace(line);
+                        }
+                    });
+            });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.columns(2, |cols| {
+                // Left column: pending nodes.
+                cols[0].heading("Pending");
+                let pending_cns: Vec<String> = st.pending.keys().cloned().collect();
+                if pending_cns.is_empty() {
+                    cols[0].label("(none)");
+                } else {
+                    let mut admit_cn: Option<String> = None;
+                    let mut deny_cn: Option<String> = None;
+                    for cn in &pending_cns {
+                        cols[0].horizontal(|ui| {
+                            ui.label(cn);
+                            if ui.button("Admit").clicked() {
+                                admit_cn = Some(cn.clone());
+                            }
+                            if ui.button("Deny").clicked() {
+                                deny_cn = Some(cn.clone());
+                            }
+                        });
+                    }
+                    if let Some(cn) = admit_cn {
+                        st.action_queue.push(Action::Admit(cn));
+                    }
+                    if let Some(cn) = deny_cn {
+                        st.action_queue.push(Action::Deny(cn));
+                    }
+                }
+
+                // Right column: admitted and denied nodes.
+                cols[1].heading("Admitted");
+                if st.admitted.is_empty() {
+                    cols[1].label("(none)");
+                } else {
+                    for cn in &st.admitted {
+                        cols[1].label(cn);
+                    }
+                }
+
+                cols[1].add_space(12.0);
+                cols[1].heading("Denied");
+                if st.denied.is_empty() {
+                    cols[1].label("(none)");
+                } else {
+                    for cn in &st.denied {
+                        cols[1].colored_label(egui::Color32::LIGHT_RED, cn);
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use eframe::egui;
 use bot_framework::config::DverseConfig;
 
-use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_ADMIN_PASSWORD, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_ENDPOINT, ROUTER_LISTEN};
+use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_ADMIN_PASSWORD, KEYCLOAK_REALM, KEYCLOAK_URL, ROUTER_LISTEN, ROUTER_PORT};
 use crate::state::{AppState, RouterStatus};
 
 // ── Screen state (GUI thread only) ─────────────────────────────────────────────
@@ -197,6 +197,11 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         .join("dverse")
         .join("certs");
 
+    // The Step-CA x509 template sets SAN = DNS:zenoh-<preferred_username>.local,
+    // so the endpoint must use that hostname for TLS to verify correctly.
+    let cn = form.username.split('@').next().unwrap_or(&form.username);
+    let router_endpoint = format!("tls/zenoh-{cn}.local:{ROUTER_PORT}");
+
     let cfg = DverseConfig {
         username: form.username.clone(),
         password: form.password.clone(),
@@ -208,7 +213,7 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         ca_root_pem_path: DverseConfig::ca_root_pem_path_default(),
         cert_dir,
         router_listen: ROUTER_LISTEN.into(),
-        router_endpoint: ROUTER_ENDPOINT.into(),
+        router_endpoint,
     };
 
     if let Err(e) = cfg.save() {

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -4,74 +4,43 @@ mod state;
 
 use std::sync::{Arc, Mutex};
 
-use clap::Parser;
-
-use router::RouterConfig;
+use bot_framework::config::DverseConfig;
+use gui::{RouterApp, Screen, SetupForm};
 use state::AppState;
 
-#[derive(Parser)]
-#[command(name = "zenoh-router", about = "Zenoh mTLS router with admission GUI")]
-struct Cli {
-    /// Zenoh listen endpoint, e.g. "tls/0.0.0.0:7447"
-    #[arg(long, default_value = "tls/0.0.0.0:7447")]
-    listen: String,
-
-    /// Path to the CA root PEM (Step-CA root certificate)
-    #[arg(long)]
-    tls_ca: Option<String>,
-
-    /// Path to the router's certificate PEM (issued by Step-CA)
-    #[arg(long)]
-    tls_cert: Option<String>,
-
-    /// Path to the router's private key PEM
-    #[arg(long)]
-    tls_key: Option<String>,
-
-    /// CNs that are pre-admitted without operator approval (comma-separated)
-    #[arg(long, value_delimiter = ',', default_value = "")]
-    pre_admitted: Vec<String>,
-}
-
 fn main() {
-    let cli = Cli::parse();
+    // If a config already exists, pre-load it so the background thread can
+    // start acquiring the cert immediately while the GUI is initialising.
+    let existing_config: Option<DverseConfig> = DverseConfig::load().ok();
 
-    let pre_admitted: Vec<String> = cli
-        .pre_admitted
-        .into_iter()
-        .filter(|s| !s.is_empty())
-        .collect();
-
-    let state = Arc::new(Mutex::new(AppState::new(pre_admitted)));
-
-    let router_cfg = RouterConfig {
-        listen_addr: cli.listen,
-        tls_ca: cli.tls_ca,
-        tls_cert: cli.tls_cert,
-        tls_key: cli.tls_key,
+    let initial_screen = if existing_config.is_some() {
+        Screen::Loading
+    } else {
+        Screen::Setup(SetupForm::default())
     };
 
-    // Spawn the Zenoh router on a background thread with its own tokio runtime.
+    let state = Arc::new(Mutex::new(AppState::new(vec![], existing_config)));
+
     let bg_state = Arc::clone(&state);
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .expect("tokio runtime");
-        rt.block_on(router::run(router_cfg, bg_state));
+        rt.block_on(router::run(bg_state));
     });
 
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title("dverse router")
-            .with_inner_size([700.0, 500.0]),
+            .with_inner_size([720.0, 520.0]),
         ..Default::default()
     };
 
     eframe::run_native(
         "dverse router",
         options,
-        Box::new(|_cc| Ok(Box::new(gui::RouterApp::new(state)))),
+        Box::new(|_cc| Ok(Box::new(RouterApp::new(state, initial_screen)))),
     )
     .expect("eframe error");
 }

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -1,4 +1,5 @@
 mod constants;
+mod discovery;
 mod gui;
 mod router;
 mod state;

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -1,16 +1,37 @@
+mod constants;
 mod gui;
 mod router;
 mod state;
 
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
+use clap::Parser;
 use bot_framework::config::DverseConfig;
 use gui::{RouterApp, Screen, SetupForm};
 use state::AppState;
 
+#[derive(Parser)]
+#[command(name = "zenoh-router", about = "dverse Zenoh router with admission GUI")]
+struct Cli {
+    /// Run a local demo with fake pending nodes (no certs or Keycloak required).
+    #[arg(long)]
+    demo: bool,
+}
+
 fn main() {
-    // If a config already exists, pre-load it so the background thread can
-    // start acquiring the cert immediately while the GUI is initialising.
+    let cli = Cli::parse();
+
+    if cli.demo {
+        run_demo();
+    } else {
+        run_normal();
+    }
+}
+
+// ── Normal mode ───────────────────────────────────────────────────────────────
+
+fn run_normal() {
     let existing_config: Option<DverseConfig> = DverseConfig::load().ok();
 
     let initial_screen = if existing_config.is_some() {
@@ -30,6 +51,33 @@ fn main() {
         rt.block_on(router::run(bg_state));
     });
 
+    launch_gui(state, initial_screen);
+}
+
+// ── Demo mode ─────────────────────────────────────────────────────────────────
+
+fn run_demo() {
+    let mut state = AppState::new(vec!["alice".into()], None);
+
+    // Seed fake pending nodes so every panel is populated.
+    state.pending.insert("mybot".into(), Instant::now());
+    state.pending.insert("data-collector".into(), Instant::now());
+    state.denied.push("rogue-agent".into());
+    state.router_status = state::RouterStatus::Running;
+    state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
+    state.push_log("[demo] Node announced: mybot");
+    state.push_log("[demo] Node announced: data-collector");
+    state.push_log("[demo] Admitted on startup: alice");
+
+    let state = Arc::new(Mutex::new(state));
+
+    // No background thread — state is purely static for the demo.
+    launch_gui(state, Screen::Main);
+}
+
+// ── Shared launcher ───────────────────────────────────────────────────────────
+
+fn launch_gui(state: Arc<Mutex<AppState>>, screen: Screen) {
     let options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
             .with_title("dverse router")
@@ -40,7 +88,7 @@ fn main() {
     eframe::run_native(
         "dverse router",
         options,
-        Box::new(|_cc| Ok(Box::new(RouterApp::new(state, initial_screen)))),
+        Box::new(|_cc| Ok(Box::new(RouterApp::new(state, screen)))),
     )
     .expect("eframe error");
 }

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -4,44 +4,33 @@ mod router;
 mod state;
 
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 
 use clap::Parser;
 use bot_framework::config::DverseConfig;
-use gui::{RouterApp, Screen, SetupForm};
+use gui::{LoginForm, RouterApp, Screen};
 use state::AppState;
 
 #[derive(Parser)]
 #[command(name = "zenoh-router", about = "dverse Zenoh router with admission GUI")]
 struct Cli {
-    /// Run a local demo with fake pending nodes (no certs or Keycloak required).
+    /// Run a local demo without certs or Keycloak.
     #[arg(long)]
     demo: bool,
 }
 
 fn main() {
     let cli = Cli::parse();
-
-    if cli.demo {
-        run_demo();
-    } else {
-        run_normal();
-    }
+    if cli.demo { run_demo(); } else { run_normal(); }
 }
-
-// ── Normal mode ───────────────────────────────────────────────────────────────
 
 fn run_normal() {
     let existing_config: Option<DverseConfig> = DverseConfig::load().ok();
-
     let initial_screen = if existing_config.is_some() {
         Screen::Loading
     } else {
-        Screen::Setup(SetupForm::default())
+        Screen::Login(LoginForm::default())
     };
-
-    let state = Arc::new(Mutex::new(AppState::new(vec![], existing_config)));
-
+    let state = Arc::new(Mutex::new(AppState::new(existing_config)));
     let bg_state = Arc::clone(&state);
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -50,32 +39,18 @@ fn run_normal() {
             .expect("tokio runtime");
         rt.block_on(router::run(bg_state));
     });
-
     launch_gui(state, initial_screen);
 }
 
-// ── Demo mode ─────────────────────────────────────────────────────────────────
-
 fn run_demo() {
-    let mut state = AppState::new(vec!["alice".into()], None);
-
-    // Seed fake pending nodes so every panel is populated.
-    state.pending.insert("mybot".into(), Instant::now());
-    state.pending.insert("data-collector".into(), Instant::now());
-    state.denied.push("rogue-agent".into());
+    let mut state = AppState::new(None);
+    state.admitted = vec!["alice".into(), "mybot".into()];
     state.router_status = state::RouterStatus::Running;
     state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
-    state.push_log("[demo] Node announced: mybot");
-    state.push_log("[demo] Node announced: data-collector");
-    state.push_log("[demo] Admitted on startup: alice");
-
-    let state = Arc::new(Mutex::new(state));
-
-    // No background thread — state is purely static for the demo.
-    launch_gui(state, Screen::Main);
+    state.push_log("[demo] Auto-admitted: alice");
+    state.push_log("[demo] Auto-admitted: mybot");
+    launch_gui(Arc::new(Mutex::new(state)), Screen::Main);
 }
-
-// ── Shared launcher ───────────────────────────────────────────────────────────
 
 fn launch_gui(state: Arc<Mutex<AppState>>, screen: Screen) {
     let options = eframe::NativeOptions {
@@ -84,7 +59,6 @@ fn launch_gui(state: Arc<Mutex<AppState>>, screen: Screen) {
             .with_inner_size([720.0, 520.0]),
         ..Default::default()
     };
-
     eframe::run_native(
         "dverse router",
         options,

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -1,0 +1,77 @@
+mod gui;
+mod router;
+mod state;
+
+use std::sync::{Arc, Mutex};
+
+use clap::Parser;
+
+use router::RouterConfig;
+use state::AppState;
+
+#[derive(Parser)]
+#[command(name = "zenoh-router", about = "Zenoh mTLS router with admission GUI")]
+struct Cli {
+    /// Zenoh listen endpoint, e.g. "tls/0.0.0.0:7447"
+    #[arg(long, default_value = "tls/0.0.0.0:7447")]
+    listen: String,
+
+    /// Path to the CA root PEM (Step-CA root certificate)
+    #[arg(long)]
+    tls_ca: Option<String>,
+
+    /// Path to the router's certificate PEM (issued by Step-CA)
+    #[arg(long)]
+    tls_cert: Option<String>,
+
+    /// Path to the router's private key PEM
+    #[arg(long)]
+    tls_key: Option<String>,
+
+    /// CNs that are pre-admitted without operator approval (comma-separated)
+    #[arg(long, value_delimiter = ',', default_value = "")]
+    pre_admitted: Vec<String>,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let pre_admitted: Vec<String> = cli
+        .pre_admitted
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let state = Arc::new(Mutex::new(AppState::new(pre_admitted)));
+
+    let router_cfg = RouterConfig {
+        listen_addr: cli.listen,
+        tls_ca: cli.tls_ca,
+        tls_cert: cli.tls_cert,
+        tls_key: cli.tls_key,
+    };
+
+    // Spawn the Zenoh router on a background thread with its own tokio runtime.
+    let bg_state = Arc::clone(&state);
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        rt.block_on(router::run(router_cfg, bg_state));
+    });
+
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_title("dverse router")
+            .with_inner_size([700.0, 500.0]),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "dverse router",
+        options,
+        Box::new(|_cc| Ok(Box::new(gui::RouterApp::new(state)))),
+    )
+    .expect("eframe error");
+}

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -6,44 +6,8 @@ use bot_framework::cert;
 use bot_framework::config::DverseConfig;
 use zenoh::Session;
 
+use crate::discovery::MdnsHandle;
 use crate::state::{AppState, RouterStatus};
-
-// ── Avahi mDNS helper ─────────────────────────────────────────────────────────
-
-/// Keeps an `avahi-publish-address` child alive.  Kills it on drop so the
-/// mDNS record is withdrawn when the router shuts down.
-struct AvahiHandle(std::process::Child);
-
-impl Drop for AvahiHandle {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
-
-/// Spawn `avahi-publish-address -R <hostname> 127.0.0.1` in the background.
-/// Returns None (with a log message) if avahi-utils is not installed.
-fn publish_avahi(hostname: &str, state: &Arc<Mutex<AppState>>) -> Option<AvahiHandle> {
-    match std::process::Command::new("avahi-publish-address")
-        .args(["-R", hostname, "127.0.0.1"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => {
-            state.lock().unwrap().push_log(
-                format!("mDNS: {hostname} → 127.0.0.1 (via Avahi)"),
-            );
-            Some(AvahiHandle(child))
-        }
-        Err(e) => {
-            state.lock().unwrap().push_log(
-                format!("Warning: avahi-publish-address unavailable ({e}); add {hostname} to /etc/hosts manually"),
-            );
-            None
-        }
-    }
-}
 
 // ── Router background task ────────────────────────────────────────────────────
 
@@ -52,8 +16,8 @@ fn publish_avahi(hostname: &str, state: &Arc<Mutex<AppState>>) -> Option<AvahiHa
 /// restarting the session whenever the admitted ACL changes.
 pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut current_cfg: Option<DverseConfig> = None;
-    // Kept alive for the entire router lifetime; dropped (→ avahi record removed) on exit.
-    let mut _avahi: Option<AvahiHandle> = None;
+    // Kept alive for the entire router lifetime; dropped (→ mDNS record withdrawn) on exit.
+    let mut _mdns: Option<MdnsHandle> = None;
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -71,10 +35,9 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
-            // Register the mDNS hostname once, the first time we get a config.
-            if _avahi.is_none() {
-                let hostname = format!("zenoh-{}.local", cfg.operator_cn());
-                _avahi = publish_avahi(&hostname, &state);
+            // Publish DNS-SD service record once, the first time we get a config.
+            if _mdns.is_none() {
+                _mdns = MdnsHandle::publish(&cfg.operator_cn(), crate::constants::ROUTER_PORT, &state);
             }
 
             cfg

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -8,11 +8,52 @@ use zenoh::Session;
 
 use crate::state::{AppState, RouterStatus};
 
+// ── Avahi mDNS helper ─────────────────────────────────────────────────────────
+
+/// Keeps an `avahi-publish-address` child alive.  Kills it on drop so the
+/// mDNS record is withdrawn when the router shuts down.
+struct AvahiHandle(std::process::Child);
+
+impl Drop for AvahiHandle {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Spawn `avahi-publish-address -R <hostname> 127.0.0.1` in the background.
+/// Returns None (with a log message) if avahi-utils is not installed.
+fn publish_avahi(hostname: &str, state: &Arc<Mutex<AppState>>) -> Option<AvahiHandle> {
+    match std::process::Command::new("avahi-publish-address")
+        .args(["-R", hostname, "127.0.0.1"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(child) => {
+            state.lock().unwrap().push_log(
+                format!("mDNS: {hostname} → 127.0.0.1 (via Avahi)"),
+            );
+            Some(AvahiHandle(child))
+        }
+        Err(e) => {
+            state.lock().unwrap().push_log(
+                format!("Warning: avahi-publish-address unavailable ({e}); add {hostname} to /etc/hosts manually"),
+            );
+            None
+        }
+    }
+}
+
+// ── Router background task ────────────────────────────────────────────────────
+
 /// Background entry point.  Waits for a `DverseConfig` to appear in AppState,
 /// acquires/reuses the router cert, then runs the Zenoh router indefinitely,
 /// restarting the session whenever the admitted ACL changes.
 pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut current_cfg: Option<DverseConfig> = None;
+    // Kept alive for the entire router lifetime; dropped (→ avahi record removed) on exit.
+    let mut _avahi: Option<AvahiHandle> = None;
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -20,7 +61,7 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             c
         } else {
             state.lock().unwrap().push_log("Waiting for configuration…");
-            loop {
+            let cfg = loop {
                 {
                     let mut s = state.lock().unwrap();
                     if let Some(cfg) = s.staged_config.take() {
@@ -28,7 +69,15 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                     }
                 }
                 tokio::time::sleep(Duration::from_millis(200)).await;
+            };
+
+            // Register the mDNS hostname once, the first time we get a config.
+            if _avahi.is_none() {
+                let hostname = format!("zenoh-{}.local", cfg.operator_cn());
+                _avahi = publish_avahi(&hostname, &state);
             }
+
+            cfg
         };
 
         // Pre-admit operator's CN so all local agents can communicate immediately.

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -6,7 +6,7 @@ use bot_framework::cert;
 use bot_framework::config::DverseConfig;
 use zenoh::Session;
 
-use crate::state::{Action, AppState, RouterStatus};
+use crate::state::{AppState, RouterStatus};
 
 /// Background entry point.  Waits for a `DverseConfig` to appear in AppState,
 /// acquires/reuses the router cert, then runs the Zenoh router indefinitely,
@@ -137,69 +137,30 @@ async fn acquire_or_reuse(
     }
 }
 
-/// Subscribe to node announce messages and drain the action queue.
-/// Returns when the admitted list changes (signalling a session restart).
+/// Subscribe to node announce messages; auto-admit any node with a valid cert.
+/// Returns when the admitted list changes (triggering an ACL session restart).
 async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
     let subscriber = session
         .declare_subscriber("dverse/nodes/announce/**")
         .await
         .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
 
-    let admitted_snapshot = state.lock().unwrap().admitted.clone();
-
     loop {
-        tokio::select! {
-            sample = subscriber.recv_async() => {
-                match sample {
-                    Ok(s) => {
-                        let key = s.key_expr().as_str().to_string();
-                        if let Some(cn) = key.strip_prefix("dverse/nodes/announce/") {
-                            let cn = cn.to_string();
-                            let mut st = state.lock().unwrap();
-                            if st.admitted.contains(&cn) || st.denied.contains(&cn) {
-                                continue;
-                            }
-                            if !st.pending.contains_key(&cn) {
-                                st.push_log(format!("Node announced: {cn}"));
-                            }
-                            st.pending.insert(cn, std::time::Instant::now());
-                        }
-                    }
-                    Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
-                }
-            }
-            _ = tokio::time::sleep(Duration::from_millis(100)) => {
-                let actions: Vec<Action> = {
+        match subscriber.recv_async().await {
+            Ok(s) => {
+                let key = s.key_expr().as_str().to_string();
+                if let Some(cn) = key.strip_prefix("dverse/nodes/announce/") {
+                    let cn = cn.to_string();
                     let mut st = state.lock().unwrap();
-                    std::mem::take(&mut st.action_queue)
-                };
-
-                for action in actions {
-                    match action {
-                        Action::Admit(cn) => {
-                            let mut st = state.lock().unwrap();
-                            st.pending.remove(&cn);
-                            if !st.admitted.contains(&cn) {
-                                st.admitted.push(cn.clone());
-                                st.push_log(format!("Admitted: {cn}"));
-                            }
-                        }
-                        Action::Deny(cn) => {
-                            let mut st = state.lock().unwrap();
-                            st.pending.remove(&cn);
-                            if !st.denied.contains(&cn) {
-                                st.denied.push(cn.clone());
-                                st.push_log(format!("Denied: {cn}"));
-                            }
-                        }
+                    if !st.admitted.contains(&cn) {
+                        st.admitted.push(cn.clone());
+                        st.push_log(format!("Auto-admitted: {cn}"));
+                        // Signal the outer loop to restart the session with new ACL.
+                        return Ok(());
                     }
                 }
-
-                let new_admitted = state.lock().unwrap().admitted.clone();
-                if new_admitted != admitted_snapshot {
-                    return Ok(());
-                }
             }
+            Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
         }
     }
 }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -31,11 +31,24 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             }
         };
 
-        // ── Phase 2: acquire/reuse cert ──────────────────────────────────────
+        // ── Phase 2: bootstrap CA root, then acquire/reuse cert ─────────────
         {
             let mut s = state.lock().unwrap();
             s.router_status = RouterStatus::Acquiring;
-            s.push_log("Checking router certificate…");
+            s.push_log("Bootstrapping CA root certificate…");
+        }
+
+        let ca_root_path = std::path::PathBuf::from(&cfg.ca_root_pem_path);
+        if let Err(e) = cert::bootstrap_ca_root(&cfg.ca_url, &ca_root_path).await {
+            let mut s = state.lock().unwrap();
+            s.router_status = RouterStatus::Error(e.to_string());
+            s.push_log(format!("CA bootstrap error: {e}"));
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            continue;
+        }
+
+        {
+            state.lock().unwrap().push_log("Checking router certificate…");
         }
 
         let cert_result = acquire_or_reuse(&cfg).await;
@@ -215,22 +228,60 @@ fn build_zenoh_config(
 fn build_acl_json(admitted: &[String]) -> String {
     let announce_key = "dverse/nodes/announce/**";
     let main_key = "dverse/**";
-
-    let admitted_subjects: String = admitted
-        .iter()
-        .enumerate()
-        .map(|(i, cn)| format!(r#"{{"id": {}, "cert_common_names": ["{cn}"]}}"#, i + 2))
-        .collect::<Vec<_>>()
-        .join(",");
+    let announce_msgs = serde_json::json!(["put", "delete", "declare_subscriber"]);
+    let main_msgs = serde_json::json!(["put", "delete", "declare_subscriber", "query", "reply", "declare_queryable"]);
 
     if admitted.is_empty() {
-        format!(
-            r#"{{"enabled":true,"default_permission":"deny","rules":[{{"id":1,"messages":["put","declare_subscriber"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{announce_key}"],"subject":{{"interfaces":["all"]}}}}]}}"#
-        )
+        serde_json::json!({
+            "enabled": true,
+            "default_permission": "deny",
+            "rules": [
+                {
+                    "id": "announce-rule",
+                    "messages": announce_msgs,
+                    "flows": ["ingress", "egress"],
+                    "permission": "allow",
+                    "key_exprs": [announce_key]
+                }
+            ],
+            "subjects": [
+                { "id": "any" }
+            ],
+            "policies": [
+                { "rules": ["announce-rule"], "subjects": ["any"] }
+            ]
+        })
+        .to_string()
     } else {
-        format!(
-            r#"{{"enabled":true,"default_permission":"deny","rules":[{{"id":1,"messages":["put","declare_subscriber"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{announce_key}"],"subject":{{"interfaces":["all"]}}}},{{"id":2,"messages":["put","declare_subscriber","declare_queryable","get"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{main_key}"],"subject":{{"and":[{admitted_subjects}]}}}}]}}"#
-        )
+        serde_json::json!({
+            "enabled": true,
+            "default_permission": "deny",
+            "rules": [
+                {
+                    "id": "announce-rule",
+                    "messages": announce_msgs,
+                    "flows": ["ingress", "egress"],
+                    "permission": "allow",
+                    "key_exprs": [announce_key]
+                },
+                {
+                    "id": "main-rule",
+                    "messages": main_msgs,
+                    "flows": ["ingress", "egress"],
+                    "permission": "allow",
+                    "key_exprs": [main_key]
+                }
+            ],
+            "subjects": [
+                { "id": "any" },
+                { "id": "admitted", "cert_common_names": admitted }
+            ],
+            "policies": [
+                { "rules": ["announce-rule"], "subjects": ["any"] },
+                { "rules": ["main-rule"], "subjects": ["admitted"] }
+            ]
+        })
+        .to_string()
     }
 }
 

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -1,0 +1,253 @@
+use anyhow::Result;
+use std::sync::{Arc, Mutex};
+use zenoh::Session;
+
+use crate::state::{Action, AppState, RouterStatus};
+
+pub struct RouterConfig {
+    pub listen_addr: String,
+    pub tls_ca: Option<String>,
+    pub tls_cert: Option<String>,
+    pub tls_key: Option<String>,
+}
+
+/// Build a Zenoh router config with the given admitted CNs baked into the ACL.
+fn build_config(rc: &RouterConfig, admitted: &[String]) -> Result<zenoh::Config> {
+    let mut cfg = zenoh::Config::default();
+
+    zinsert(&mut cfg, "mode", "\"router\"")?;
+    zinsert(
+        &mut cfg,
+        "listen/endpoints",
+        &format!("[\"{}\"]", rc.listen_addr),
+    )?;
+    zinsert(&mut cfg, "scouting/multicast/enabled", "false")?;
+
+    if let Some(ca) = &rc.tls_ca {
+        zinsert(&mut cfg, "transport/link/tls/root_ca_certificate", &json_str(ca))?;
+    }
+    if rc.tls_cert.is_some() || rc.tls_key.is_some() {
+        zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
+    }
+    if let Some(cert) = &rc.tls_cert {
+        zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(cert))?;
+    }
+    if let Some(key) = &rc.tls_key {
+        zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(key))?;
+    }
+
+    let acl = build_acl_json(admitted);
+    zinsert(&mut cfg, "access_control", &acl)?;
+
+    Ok(cfg)
+}
+
+/// Generate ACL JSON that:
+///  - allows everyone to publish/subscribe on `dverse/nodes/announce/**`
+///  - allows only admitted CNs to publish/subscribe on `dverse/**`
+///  - denies everything else by default
+fn build_acl_json(admitted: &[String]) -> String {
+    let announce_key = "dverse/nodes/announce/**";
+    let main_key = "dverse/**";
+
+    // Subject for the announce key — allow any authenticated peer.
+    let announce_subject = r#"{"interfaces": ["all"]}"#;
+
+    // Subjects for admitted CNs.
+    let admitted_subjects: String = admitted
+        .iter()
+        .enumerate()
+        .map(|(i, cn)| {
+            format!(
+                r#"{{ "id": {id}, "cert_common_names": ["{cn}"] }}"#,
+                id = i + 2,
+                cn = cn
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+
+    if admitted.is_empty() {
+        // Only the announce key is open; nothing else is admitted yet.
+        format!(
+            r#"{{
+  "enabled": true,
+  "default_permission": "deny",
+  "rules": [
+    {{
+      "id": 1,
+      "messages": ["put", "declare_subscriber"],
+      "flows": ["ingress", "egress"],
+      "permission": "allow",
+      "key_exprs": ["{announce_key}"],
+      "subject": {announce_subject}
+    }}
+  ]
+}}"#
+        )
+    } else {
+        format!(
+            r#"{{
+  "enabled": true,
+  "default_permission": "deny",
+  "rules": [
+    {{
+      "id": 1,
+      "messages": ["put", "declare_subscriber"],
+      "flows": ["ingress", "egress"],
+      "permission": "allow",
+      "key_exprs": ["{announce_key}"],
+      "subject": {announce_subject}
+    }},
+    {{
+      "id": 2,
+      "messages": ["put", "declare_subscriber", "declare_queryable", "get"],
+      "flows": ["ingress", "egress"],
+      "permission": "allow",
+      "key_exprs": ["{main_key}"],
+      "subject": {{ "and": [{admitted_subjects}] }}
+    }}
+  ]
+}}"#
+        )
+    }
+}
+
+/// Background task: open the router session, subscribe to announces, process the
+/// action queue.  Restarts the session whenever the admitted list changes.
+pub async fn run(rc: RouterConfig, state: Arc<Mutex<AppState>>) {
+    loop {
+        let admitted = {
+            let s = state.lock().unwrap();
+            s.admitted.clone()
+        };
+
+        {
+            let mut s = state.lock().unwrap();
+            s.router_status = RouterStatus::Starting;
+            s.push_log("Building Zenoh router session...");
+        }
+
+        let config = match build_config(&rc, &admitted) {
+            Ok(c) => c,
+            Err(e) => {
+                let mut s = state.lock().unwrap();
+                s.router_status = RouterStatus::Error(e.to_string());
+                s.push_log(format!("Config error: {e}"));
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+
+        let session = match zenoh::open(config).await {
+            Ok(s) => s,
+            Err(e) => {
+                let mut s = state.lock().unwrap();
+                s.router_status = RouterStatus::Error(e.to_string());
+                s.push_log(format!("Zenoh open error: {e}"));
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+
+        {
+            let mut s = state.lock().unwrap();
+            s.router_status = RouterStatus::Running;
+            s.push_log("Router session up.");
+        }
+
+        if let Err(e) = session_loop(&session, Arc::clone(&state)).await {
+            let mut s = state.lock().unwrap();
+            s.push_log(format!("Session error: {e}"));
+        }
+
+        // Close the old session before reopening.
+        let _ = session.close().await;
+
+        {
+            let mut s = state.lock().unwrap();
+            s.router_status = RouterStatus::Reloading;
+            s.push_log("Reloading router with updated ACL...");
+        }
+    }
+}
+
+/// Inner loop: subscribe to announces + drain the action queue.
+/// Returns when the admitted list changes (triggering a session restart).
+async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
+    let announce_key = "dverse/nodes/announce/**";
+
+    let subscriber = session
+        .declare_subscriber(announce_key)
+        .await
+        .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
+
+    let admitted_snapshot = state.lock().unwrap().admitted.clone();
+
+    loop {
+        tokio::select! {
+            sample = subscriber.recv_async() => {
+                match sample {
+                    Ok(s) => {
+                        // Key is dverse/nodes/announce/<cn>; extract the CN.
+                        let key = s.key_expr().as_str().to_string();
+                        if let Some(cn) = key.strip_prefix("dverse/nodes/announce/") {
+                            let cn = cn.to_string();
+                            let mut st = state.lock().unwrap();
+                            if st.admitted.contains(&cn) || st.denied.contains(&cn) {
+                                continue;
+                            }
+                            if !st.pending.contains_key(&cn) {
+                                st.push_log(format!("Node announced: {cn}"));
+                            }
+                            st.pending.insert(cn, std::time::Instant::now());
+                        }
+                    }
+                    Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+                let actions: Vec<Action> = {
+                    let mut st = state.lock().unwrap();
+                    std::mem::take(&mut st.action_queue)
+                };
+
+                for action in actions {
+                    match action {
+                        Action::Admit(cn) => {
+                            let mut st = state.lock().unwrap();
+                            st.pending.remove(&cn);
+                            if !st.admitted.contains(&cn) {
+                                st.admitted.push(cn.clone());
+                                st.push_log(format!("Admitted: {cn}"));
+                            }
+                        }
+                        Action::Deny(cn) => {
+                            let mut st = state.lock().unwrap();
+                            st.pending.remove(&cn);
+                            if !st.denied.contains(&cn) {
+                                st.denied.push(cn.clone());
+                                st.push_log(format!("Denied: {cn}"));
+                            }
+                        }
+                    }
+                }
+
+                // If the admitted list changed, restart the session with new ACL.
+                let new_admitted = state.lock().unwrap().admitted.clone();
+                if new_admitted != admitted_snapshot {
+                    return Ok(());
+                }
+            }
+        }
+    }
+}
+
+fn json_str(s: &str) -> String {
+    format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn zinsert(cfg: &mut zenoh::Config, key: &str, value: &str) -> Result<()> {
+    cfg.insert_json5(key, value)
+        .map_err(|e| anyhow::anyhow!("zenoh config key '{}': {}", key, e))
+}

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -31,6 +31,16 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             }
         };
 
+        // Pre-admit operator's CN so all local agents can communicate immediately.
+        let operator_cn = cfg.operator_cn();
+        {
+            let mut st = state.lock().unwrap();
+            if !st.admitted.contains(&operator_cn) {
+                st.admitted.push(operator_cn.clone());
+                st.push_log(format!("Pre-admitted operator CN: {operator_cn}"));
+            }
+        }
+
         // ── Phase 2: bootstrap CA root, then acquire/reuse cert ─────────────
         {
             let mut s = state.lock().unwrap();
@@ -149,12 +159,19 @@ async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<
         match subscriber.recv_async().await {
             Ok(s) => {
                 let key = s.key_expr().as_str().to_string();
-                if let Some(cn) = key.strip_prefix("dverse/nodes/announce/") {
-                    let cn = cn.to_string();
+                if key.starts_with("dverse/nodes/announce/") {
+                    // CN is sent as payload; fall back to key segment if empty.
+                    let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
+                    let cn = if payload_cn.trim().is_empty() {
+                        key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
+                    } else {
+                        payload_cn.trim().to_string()
+                    };
+                    if cn.is_empty() { continue; }
                     let mut st = state.lock().unwrap();
                     if !st.admitted.contains(&cn) {
                         st.admitted.push(cn.clone());
-                        st.push_log(format!("Auto-admitted: {cn}"));
+                        st.push_log(format!("Auto-admitted CN: {cn}"));
                         // Signal the outer loop to restart the session with new ACL.
                         return Ok(());
                     }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -1,143 +1,76 @@
-use anyhow::Result;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use bot_framework::cert;
+use bot_framework::config::DverseConfig;
 use zenoh::Session;
 
 use crate::state::{Action, AppState, RouterStatus};
 
-pub struct RouterConfig {
-    pub listen_addr: String,
-    pub tls_ca: Option<String>,
-    pub tls_cert: Option<String>,
-    pub tls_key: Option<String>,
-}
+/// Background entry point.  Waits for a `DverseConfig` to appear in AppState,
+/// acquires/reuses the router cert, then runs the Zenoh router indefinitely,
+/// restarting the session whenever the admitted ACL changes.
+pub async fn run(state: Arc<Mutex<AppState>>) {
+    let mut current_cfg: Option<DverseConfig> = None;
 
-/// Build a Zenoh router config with the given admitted CNs baked into the ACL.
-fn build_config(rc: &RouterConfig, admitted: &[String]) -> Result<zenoh::Config> {
-    let mut cfg = zenoh::Config::default();
-
-    zinsert(&mut cfg, "mode", "\"router\"")?;
-    zinsert(
-        &mut cfg,
-        "listen/endpoints",
-        &format!("[\"{}\"]", rc.listen_addr),
-    )?;
-    zinsert(&mut cfg, "scouting/multicast/enabled", "false")?;
-
-    if let Some(ca) = &rc.tls_ca {
-        zinsert(&mut cfg, "transport/link/tls/root_ca_certificate", &json_str(ca))?;
-    }
-    if rc.tls_cert.is_some() || rc.tls_key.is_some() {
-        zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
-    }
-    if let Some(cert) = &rc.tls_cert {
-        zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(cert))?;
-    }
-    if let Some(key) = &rc.tls_key {
-        zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(key))?;
-    }
-
-    let acl = build_acl_json(admitted);
-    zinsert(&mut cfg, "access_control", &acl)?;
-
-    Ok(cfg)
-}
-
-/// Generate ACL JSON that:
-///  - allows everyone to publish/subscribe on `dverse/nodes/announce/**`
-///  - allows only admitted CNs to publish/subscribe on `dverse/**`
-///  - denies everything else by default
-fn build_acl_json(admitted: &[String]) -> String {
-    let announce_key = "dverse/nodes/announce/**";
-    let main_key = "dverse/**";
-
-    // Subject for the announce key — allow any authenticated peer.
-    let announce_subject = r#"{"interfaces": ["all"]}"#;
-
-    // Subjects for admitted CNs.
-    let admitted_subjects: String = admitted
-        .iter()
-        .enumerate()
-        .map(|(i, cn)| {
-            format!(
-                r#"{{ "id": {id}, "cert_common_names": ["{cn}"] }}"#,
-                id = i + 2,
-                cn = cn
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(",");
-
-    if admitted.is_empty() {
-        // Only the announce key is open; nothing else is admitted yet.
-        format!(
-            r#"{{
-  "enabled": true,
-  "default_permission": "deny",
-  "rules": [
-    {{
-      "id": 1,
-      "messages": ["put", "declare_subscriber"],
-      "flows": ["ingress", "egress"],
-      "permission": "allow",
-      "key_exprs": ["{announce_key}"],
-      "subject": {announce_subject}
-    }}
-  ]
-}}"#
-        )
-    } else {
-        format!(
-            r#"{{
-  "enabled": true,
-  "default_permission": "deny",
-  "rules": [
-    {{
-      "id": 1,
-      "messages": ["put", "declare_subscriber"],
-      "flows": ["ingress", "egress"],
-      "permission": "allow",
-      "key_exprs": ["{announce_key}"],
-      "subject": {announce_subject}
-    }},
-    {{
-      "id": 2,
-      "messages": ["put", "declare_subscriber", "declare_queryable", "get"],
-      "flows": ["ingress", "egress"],
-      "permission": "allow",
-      "key_exprs": ["{main_key}"],
-      "subject": {{ "and": [{admitted_subjects}] }}
-    }}
-  ]
-}}"#
-        )
-    }
-}
-
-/// Background task: open the router session, subscribe to announces, process the
-/// action queue.  Restarts the session whenever the admitted list changes.
-pub async fn run(rc: RouterConfig, state: Arc<Mutex<AppState>>) {
     loop {
-        let admitted = {
-            let s = state.lock().unwrap();
-            s.admitted.clone()
+        // ── Phase 1: obtain config ───────────────────────────────────────────
+        let cfg = if let Some(c) = current_cfg.take() {
+            c
+        } else {
+            state.lock().unwrap().push_log("Waiting for configuration…");
+            loop {
+                {
+                    let mut s = state.lock().unwrap();
+                    if let Some(cfg) = s.staged_config.take() {
+                        break cfg;
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
         };
 
+        // ── Phase 2: acquire/reuse cert ──────────────────────────────────────
         {
             let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Starting;
-            s.push_log("Building Zenoh router session...");
+            s.router_status = RouterStatus::Acquiring;
+            s.push_log("Checking router certificate…");
         }
 
-        let config = match build_config(&rc, &admitted) {
+        let cert_result = acquire_or_reuse(&cfg).await;
+
+        let (cert_p, key_p, ca_p) = match cert_result {
+            Ok(paths) => paths,
+            Err(e) => {
+                let mut s = state.lock().unwrap();
+                s.router_status = RouterStatus::Error(e.to_string());
+                s.push_log(format!("Certificate error: {e}"));
+                // Don't retry automatically — wait for the user to fix config.
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+        };
+
+        // ── Phase 3: run session loop (restarts on ACL change) ───────────────
+        let admitted = state.lock().unwrap().admitted.clone();
+        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted) {
             Ok(c) => c,
             Err(e) => {
                 let mut s = state.lock().unwrap();
                 s.router_status = RouterStatus::Error(e.to_string());
                 s.push_log(format!("Config error: {e}"));
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                current_cfg = Some(cfg);
                 continue;
             }
         };
+
+        {
+            let mut s = state.lock().unwrap();
+            s.router_status = RouterStatus::Starting;
+            s.push_log(format!("Opening Zenoh router on {}…", cfg.router_listen));
+        }
 
         let session = match zenoh::open(config).await {
             Ok(s) => s,
@@ -145,7 +78,8 @@ pub async fn run(rc: RouterConfig, state: Arc<Mutex<AppState>>) {
                 let mut s = state.lock().unwrap();
                 s.router_status = RouterStatus::Error(e.to_string());
                 s.push_log(format!("Zenoh open error: {e}"));
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                current_cfg = Some(cfg);
                 continue;
             }
         };
@@ -153,32 +87,48 @@ pub async fn run(rc: RouterConfig, state: Arc<Mutex<AppState>>) {
         {
             let mut s = state.lock().unwrap();
             s.router_status = RouterStatus::Running;
-            s.push_log("Router session up.");
+            s.push_log("Router running.");
         }
 
+        // session_loop returns when the admitted list changes.
         if let Err(e) = session_loop(&session, Arc::clone(&state)).await {
-            let mut s = state.lock().unwrap();
-            s.push_log(format!("Session error: {e}"));
+            state.lock().unwrap().push_log(format!("Session error: {e}"));
         }
 
-        // Close the old session before reopening.
         let _ = session.close().await;
 
         {
             let mut s = state.lock().unwrap();
             s.router_status = RouterStatus::Reloading;
-            s.push_log("Reloading router with updated ACL...");
+            s.push_log("Reloading router with updated ACL…");
         }
+
+        current_cfg = Some(cfg);
     }
 }
 
-/// Inner loop: subscribe to announces + drain the action queue.
-/// Returns when the admitted list changes (triggering a session restart).
-async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
-    let announce_key = "dverse/nodes/announce/**";
+/// Use the cached cert if it is still fresh; otherwise acquire a new one.
+async fn acquire_or_reuse(
+    cfg: &DverseConfig,
+) -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)> {
+    let c = cert::cert_path(&cfg.cert_dir, "router");
+    let k = cert::key_path(&cfg.cert_dir, "router");
+    let ca = cert::ca_path(&cfg.cert_dir, "router");
 
+    let max_age = Duration::from_secs(23 * 3600);
+    if cert::needs_renewal(&c, max_age).await {
+        let cert_cfg = cfg.cert_config_for("router")?;
+        cert::acquire(&cert_cfg).await
+    } else {
+        Ok((c, k, ca))
+    }
+}
+
+/// Subscribe to node announce messages and drain the action queue.
+/// Returns when the admitted list changes (signalling a session restart).
+async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
     let subscriber = session
-        .declare_subscriber(announce_key)
+        .declare_subscriber("dverse/nodes/announce/**")
         .await
         .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
 
@@ -189,7 +139,6 @@ async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<
             sample = subscriber.recv_async() => {
                 match sample {
                     Ok(s) => {
-                        // Key is dverse/nodes/announce/<cn>; extract the CN.
                         let key = s.key_expr().as_str().to_string();
                         if let Some(cn) = key.strip_prefix("dverse/nodes/announce/") {
                             let cn = cn.to_string();
@@ -206,7 +155,7 @@ async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<
                     Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
                 }
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {
                 let actions: Vec<Action> = {
                     let mut st = state.lock().unwrap();
                     std::mem::take(&mut st.action_queue)
@@ -233,13 +182,55 @@ async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<
                     }
                 }
 
-                // If the admitted list changed, restart the session with new ACL.
                 let new_admitted = state.lock().unwrap().admitted.clone();
                 if new_admitted != admitted_snapshot {
                     return Ok(());
                 }
             }
         }
+    }
+}
+
+fn build_zenoh_config(
+    listen_addr: &str,
+    ca_path: &std::path::Path,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+    admitted: &[String],
+) -> Result<zenoh::Config> {
+    let mut cfg = zenoh::Config::default();
+
+    zinsert(&mut cfg, "mode", "\"router\"")?;
+    zinsert(&mut cfg, "listen/endpoints", &format!("[\"{listen_addr}\"]"))?;
+    zinsert(&mut cfg, "scouting/multicast/enabled", "false")?;
+    zinsert(&mut cfg, "transport/link/tls/root_ca_certificate", &json_str(&ca_path.to_string_lossy()))?;
+    zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
+    zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(&cert_path.to_string_lossy()))?;
+    zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(&key_path.to_string_lossy()))?;
+    zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
+
+    Ok(cfg)
+}
+
+fn build_acl_json(admitted: &[String]) -> String {
+    let announce_key = "dverse/nodes/announce/**";
+    let main_key = "dverse/**";
+
+    let admitted_subjects: String = admitted
+        .iter()
+        .enumerate()
+        .map(|(i, cn)| format!(r#"{{"id": {}, "cert_common_names": ["{cn}"]}}"#, i + 2))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    if admitted.is_empty() {
+        format!(
+            r#"{{"enabled":true,"default_permission":"deny","rules":[{{"id":1,"messages":["put","declare_subscriber"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{announce_key}"],"subject":{{"interfaces":["all"]}}}}]}}"#
+        )
+    } else {
+        format!(
+            r#"{{"enabled":true,"default_permission":"deny","rules":[{{"id":1,"messages":["put","declare_subscriber"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{announce_key}"],"subject":{{"interfaces":["all"]}}}},{{"id":2,"messages":["put","declare_subscriber","declare_queryable","get"],"flows":["ingress","egress"],"permission":"allow","key_exprs":["{main_key}"],"subject":{{"and":[{admitted_subjects}]}}}}]}}"#
+        )
     }
 }
 

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,22 +1,12 @@
-use std::collections::HashMap;
-use std::time::Instant;
-
 use bot_framework::config::DverseConfig;
 
 pub struct AppState {
     pub router_status: RouterStatus,
-    /// Nodes that announced themselves but are not yet admitted.
-    pub pending: HashMap<String, Instant>,
-    /// Admitted CNs — the ACL allowlist.
+    /// CNs that have been auto-admitted (all valid-cert nodes).
     pub admitted: Vec<String>,
-    /// Denied CNs — permanently rejected, ignored on re-announce.
-    pub denied: Vec<String>,
-    /// Actions queued from the GUI for the background thread to process.
-    pub action_queue: Vec<Action>,
     /// Log lines shown in the GUI.
     pub log: Vec<String>,
-    /// Config written here by the GUI; the background thread consumes it to
-    /// (re-)start the router.
+    /// Config written by the GUI; background thread consumes it to start/restart.
     pub staged_config: Option<DverseConfig>,
 }
 
@@ -30,20 +20,11 @@ pub enum RouterStatus {
     Error(String),
 }
 
-#[derive(Debug, Clone)]
-pub enum Action {
-    Admit(String),
-    Deny(String),
-}
-
 impl AppState {
-    pub fn new(pre_admitted: Vec<String>, initial_config: Option<DverseConfig>) -> Self {
+    pub fn new(initial_config: Option<DverseConfig>) -> Self {
         Self {
             router_status: RouterStatus::Idle,
-            pending: HashMap::new(),
-            admitted: pre_admitted,
-            denied: Vec::new(),
-            action_queue: Vec::new(),
+            admitted: Vec::new(),
             log: Vec::new(),
             staged_config: initial_config,
         }

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+/// Shared state between the background Zenoh thread and the GUI thread.
+pub struct AppState {
+    pub router_status: RouterStatus,
+    /// Nodes that announced themselves but are not yet admitted.
+    /// Key = cert CN (e.g. "testuser"), value = last-seen Instant.
+    pub pending: HashMap<String, Instant>,
+    /// Admitted CNs — the ACL allowlist.
+    pub admitted: Vec<String>,
+    /// Denied CNs — permanently rejected, ignored on re-announce.
+    pub denied: Vec<String>,
+    /// Actions queued from the GUI for the background thread to process.
+    pub action_queue: Vec<Action>,
+    /// Log lines shown in the GUI.
+    pub log: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum RouterStatus {
+    Starting,
+    Running,
+    Reloading,
+    Error(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum Action {
+    Admit(String),
+    Deny(String),
+}
+
+impl AppState {
+    pub fn new(pre_admitted: Vec<String>) -> Self {
+        Self {
+            router_status: RouterStatus::Starting,
+            pending: HashMap::new(),
+            admitted: pre_admitted,
+            denied: Vec::new(),
+            action_queue: Vec::new(),
+            log: Vec::new(),
+        }
+    }
+
+    pub fn push_log(&mut self, msg: impl Into<String>) {
+        let entry = msg.into();
+        eprintln!("{entry}");
+        if self.log.len() >= 200 {
+            self.log.remove(0);
+        }
+        self.log.push(entry);
+    }
+}

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
-/// Shared state between the background Zenoh thread and the GUI thread.
+use bot_framework::config::DverseConfig;
+
 pub struct AppState {
     pub router_status: RouterStatus,
     /// Nodes that announced themselves but are not yet admitted.
-    /// Key = cert CN (e.g. "testuser"), value = last-seen Instant.
     pub pending: HashMap<String, Instant>,
     /// Admitted CNs — the ACL allowlist.
     pub admitted: Vec<String>,
@@ -15,10 +15,15 @@ pub struct AppState {
     pub action_queue: Vec<Action>,
     /// Log lines shown in the GUI.
     pub log: Vec<String>,
+    /// Config written here by the GUI; the background thread consumes it to
+    /// (re-)start the router.
+    pub staged_config: Option<DverseConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum RouterStatus {
+    Idle,
+    Acquiring,
     Starting,
     Running,
     Reloading,
@@ -32,14 +37,15 @@ pub enum Action {
 }
 
 impl AppState {
-    pub fn new(pre_admitted: Vec<String>) -> Self {
+    pub fn new(pre_admitted: Vec<String>, initial_config: Option<DverseConfig>) -> Self {
         Self {
-            router_status: RouterStatus::Starting,
+            router_status: RouterStatus::Idle,
             pending: HashMap::new(),
             admitted: pre_admitted,
             denied: Vec::new(),
             action_queue: Vec::new(),
             log: Vec::new(),
+            staged_config: initial_config,
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace plain-text password in `~/.config/dverse/config.toml` with OS keychain storage (`keyring` crate with `sync-secret-service`/`apple-native`/`windows-native` features)
- Replace hardcoded Keycloak admin credential with a restricted `dverse-registration` service account using `client_credentials` grant (closes #75)
- Move to a dedicated `dverse` Keycloak realm (away from `master`), declared declaratively in nix-config with sops-managed client secrets
- Fix registration flow bugs: wrong realm in token URL, missing `firstName`/`requiredActions` in user creation payload, keyring mock-backend not persisting across processes

## Fixes

- Closes #75 — Remove hardcoded admin password from binary
- Closes #76 — Store user password in OS keychain
- Closes #82 — Keycloak dverse realm not imported on startup
- Closes #83 — step-ca OIDC provisioner disabled due to startup race

## Test plan

- [ ] Register a new user via the router GUI — should succeed and show "Account created"
- [ ] Sign in — router should acquire a cert from Step-CA and start
- [ ] Run `cargo run -p dverse-ping` and `cargo run -p dverse-pong` after sign-in — should load credentials from keychain without error
- [ ] `curl https://auth.dverse.yordanmitev.me/realms/dverse` returns realm metadata
- [ ] `journalctl -u keycloak` shows `Realm 'dverse' imported` on service start