### PR TITLE
feat: publish _dverse._tcp DNS-SD service record (closes #69)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2287,6 +2287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2690,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.13.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328f4e1041f7cfeb3affccb814ddbe2f004856a2ce769c8bf22080d74c5204c6"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +2774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -7241,9 +7266,11 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "mdns-sd",
  "reqwest",
  "serde_json",
  "tokio",
+ "zbus",
  "zenoh",
 ]
 

--- a/documents/adr/ADR-011.md
+++ b/documents/adr/ADR-011.md
@@ -1,6 +1,6 @@
 # ADR-011: Pure Rust mDNS-SD via `mdns-sd` (supersedes ADR-005)
 
-**Status:** Accepted, supersedes ADR-005
+**Status:** Superseded by ADR-012
 **Date:** 19-05-2026
 **Author:** Yordan Mitev
 

--- a/documents/adr/ADR-012.md
+++ b/documents/adr/ADR-012.md
@@ -1,0 +1,62 @@
+# ADR-012: Platform-conditional DNS-SD — avahi D-Bus on Linux, `mdns-sd` elsewhere (supersedes ADR-011)
+
+**Status:** Accepted, supersedes ADR-011
+**Date:** 19-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+ADR-011 chose the `mdns-sd` crate as a pure-Rust, zero-system-dependency mDNS stack. It noted a risk: "If Avahi is also running, both may compete for the socket." That risk was tested and confirmed: on a Linux desktop with `avahi-daemon` running, `mdns-sd` successfully binds port 5353 (via `SO_REUSEPORT`) and its `register()` call returns `Ok`, but it does not emit any PTR/SRV/A records onto the network. `tcpdump` on the LAN interface shows only empty 12-byte DNS headers — no service records. `avahi-browse _dverse._tcp` on any machine finds nothing.
+
+The root cause is that `avahi-daemon` owns the multicast socket and the multicast group join, and it silently discards or absorbs the outgoing multicast packets from the competing `mdns-sd` socket. The `SO_REUSEPORT` prevents an outright bind failure, but it does not guarantee that packets sent by `mdns-sd` actually reach the network.
+
+On macOS (`mDNSResponder`) and Windows (built-in mDNS resolver) the same conflict does not occur: both platforms are permissive about concurrent mDNS socket users, and `mdns-sd` sends records correctly alongside the system daemon.
+
+## Decision
+
+Use a platform-conditional backend in `src/zenoh_router/src/discovery.rs`:
+
+**Linux:** Register the `_dverse._tcp` service via the avahi D-Bus API (`org.freedesktop.Avahi.EntryGroup`). `avahi-daemon` is already authoritative for port 5353 on Linux desktops; routing through its D-Bus interface delegates all mDNS socket work to the daemon and gets correct LAN IP resolution and full DNS-SD record emission for free. The D-Bus connection is held alive in `AvahiHandle`; `avahi-daemon` automatically withdraws the service when the connection closes on drop. If avahi is not running, the D-Bus call fails gracefully and the code falls back to `mdns-sd` with a log warning.
+
+**macOS / Windows:** Use `mdns-sd` directly. No avahi-daemon is present on these platforms, and `mdns-sd` coexists cleanly with `mDNSResponder` and the Windows mDNS resolver.
+
+The platform selection is expressed via Rust's conditional compilation:
+
+```rust
+// Linux only — compiled out on macOS/Windows
+#[cfg(target_os = "linux")]
+mod linux { /* zbus / avahi D-Bus */ }
+
+// Used on all platforms as avahi fallback, and primary on macOS/Windows
+fn mdns_sd_publish(...) { /* mdns-sd */ }
+```
+
+`zbus` is added as a Linux-only target dependency (`[target.'cfg(target_os = "linux")'.dependencies]`) so it is not compiled on other platforms.
+
+## Alternatives
+
+**`mdns-sd` on all platforms.** Rejected for Linux. Testing confirmed that `mdns-sd` cannot coexist with `avahi-daemon` — service records are not transmitted despite the registration returning `Ok`.
+
+**Avahi service file at `/etc/avahi/services/`.** Rejected. Requires writing to a system directory (needs root) and does not work cross-platform.
+
+**`avahi-client` C binding.** Rejected. Adds a C library build-time dependency (`libavahi-client-dev`), which is what the entire move away from subprocesses and native bindings was trying to avoid.
+
+**Disable `avahi-daemon` at runtime.** Rejected. Not acceptable to require users to disable a system service.
+
+## Consequences
+
+**Positive**
+- `avahi-browse _dverse._tcp` on any LAN machine correctly lists the router with the real LAN IP.
+- No hardcoded `127.0.0.1`.
+- Service is withdrawn automatically on router exit.
+- Graceful degradation: a clear log warning is emitted if neither avahi nor mdns-sd can register the service; the router continues operating as a standalone node.
+- No C library headers or system packages required at build time on any platform.
+
+**Negative**
+- On Linux, `avahi-daemon` must be running for full DNS-SD support. If it is absent, `mdns-sd` is attempted as a fallback but may not work reliably on Linux (the same conflict risk applies).
+- Adds `zbus` as a Linux build dependency. `zbus` is already a transitive dependency via the `keyring` crate, so no new crate is introduced to the dependency graph in practice.
+- The two backends have slightly different log messages ("via avahi" vs plain), which may cause minor confusion when comparing logs across platforms.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -18,3 +18,7 @@ eframe = "0.31"
 egui = "0.31"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
+mdns-sd = "0.13"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "4", default-features = false, features = ["blocking"] }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -1,0 +1,164 @@
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use std::sync::{Arc, Mutex};
+
+use crate::state::AppState;
+
+const SERVICE_TYPE: &str = "_dverse._tcp.local.";
+
+/// Registers this router as a `_dverse._tcp` DNS-SD service.
+///
+/// On Linux: uses the avahi D-Bus API so avahi-daemon owns the mDNS socket.
+/// Falls back to mdns-sd if avahi is absent, or on non-Linux platforms.
+///
+/// The record is withdrawn when this handle is dropped.
+pub struct MdnsHandle {
+    _inner: Inner,
+}
+
+enum Inner {
+    #[cfg(target_os = "linux")]
+    Avahi(AvahiHandle),
+    MdnsSd(MdnsSdHandle),
+}
+
+impl MdnsHandle {
+    pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            match linux::publish(cn, port) {
+                Ok(handle) => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS: published DVerse ({cn}) on {SERVICE_TYPE} port {port} (via avahi)"
+                    ));
+                    return Some(Self { _inner: Inner::Avahi(handle) });
+                }
+                Err(e) => {
+                    state.lock().unwrap().push_log(format!(
+                        "Warning: avahi D-Bus unavailable ({e}); falling back to mdns-sd"
+                    ));
+                }
+            }
+        }
+
+        mdns_sd_publish(cn, port, state).map(|h| Self { _inner: Inner::MdnsSd(h) })
+    }
+}
+
+// ── Linux: avahi D-Bus ────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+struct AvahiHandle {
+    // Keeping the connection alive: avahi-daemon removes services automatically
+    // when the owning D-Bus connection closes.
+    _conn: zbus::blocking::Connection,
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::AvahiHandle;
+    use anyhow::Result;
+    use zbus::blocking::Connection;
+
+    pub fn publish(cn: &str, port: u16) -> Result<AvahiHandle> {
+        let conn = Connection::system()?;
+
+        let group_path: zbus::zvariant::OwnedObjectPath = conn
+            .call_method(
+                Some("org.freedesktop.Avahi"),
+                "/",
+                Some("org.freedesktop.Avahi.Server"),
+                "EntryGroupNew",
+                &(),
+            )?
+            .body()
+            .deserialize()?;
+
+        // AddService(interface, protocol, flags, name, type, domain, host, port, txt)
+        // interface=-1 (AVAHI_IF_UNSPEC), protocol=-1 (AVAHI_PROTO_UNSPEC)
+        let name = format!("DVerse ({cn})");
+        let txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
+
+        conn.call_method(
+            Some("org.freedesktop.Avahi"),
+            group_path.as_str(),
+            Some("org.freedesktop.Avahi.EntryGroup"),
+            "AddService",
+            &(
+                -1i32,
+                -1i32,
+                0u32,
+                name.as_str(),
+                "_dverse._tcp",
+                "",
+                "",
+                port,
+                &txt,
+            ),
+        )?;
+
+        conn.call_method(
+            Some("org.freedesktop.Avahi"),
+            group_path.as_str(),
+            Some("org.freedesktop.Avahi.EntryGroup"),
+            "Commit",
+            &(),
+        )?;
+
+        Ok(AvahiHandle { _conn: conn })
+    }
+}
+
+// ── mdns-sd (non-Linux or avahi-absent fallback) ──────────────────────────────
+
+struct MdnsSdHandle {
+    daemon: ServiceDaemon,
+    fullname: String,
+}
+
+impl Drop for MdnsSdHandle {
+    fn drop(&mut self) {
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+fn mdns_sd_publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsSdHandle> {
+    let daemon = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "Warning: mDNS unavailable ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    let instance = format!("DVerse ({cn})");
+    let host = format!("zenoh-{cn}.local.");
+    let props: &[(&str, &str)] = &[("cn", cn)];
+
+    let svc = match ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props) {
+        Ok(s) => s,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "Warning: mDNS service info error ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    let fullname = svc.get_fullname().to_string();
+
+    if let Err(e) = daemon.register(svc) {
+        state.lock().unwrap().push_log(format!(
+            "Warning: mDNS register failed ({e}); peer discovery disabled"
+        ));
+        return None;
+    }
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS: published {instance} on {SERVICE_TYPE} port {port}"
+    ));
+
+    Some(MdnsSdHandle { daemon, fullname })
+}

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -1,4 +1,5 @@
 mod constants;
+mod discovery;
 mod gui;
 mod router;
 mod state;

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -6,44 +6,8 @@ use bot_framework::cert;
 use bot_framework::config::DverseConfig;
 use zenoh::Session;
 
+use crate::discovery::MdnsHandle;
 use crate::state::{AppState, RouterStatus};
-
-// ── Avahi mDNS helper ─────────────────────────────────────────────────────────
-
-/// Keeps an `avahi-publish-address` child alive.  Kills it on drop so the
-/// mDNS record is withdrawn when the router shuts down.
-struct AvahiHandle(std::process::Child);
-
-impl Drop for AvahiHandle {
-    fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
-    }
-}
-
-/// Spawn `avahi-publish-address -R <hostname> 127.0.0.1` in the background.
-/// Returns None (with a log message) if avahi-utils is not installed.
-fn publish_avahi(hostname: &str, state: &Arc<Mutex<AppState>>) -> Option<AvahiHandle> {
-    match std::process::Command::new("avahi-publish-address")
-        .args(["-R", hostname, "127.0.0.1"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(child) => {
-            state.lock().unwrap().push_log(
-                format!("mDNS: {hostname} → 127.0.0.1 (via Avahi)"),
-            );
-            Some(AvahiHandle(child))
-        }
-        Err(e) => {
-            state.lock().unwrap().push_log(
-                format!("Warning: avahi-publish-address unavailable ({e}); add {hostname} to /etc/hosts manually"),
-            );
-            None
-        }
-    }
-}
 
 // ── Router background task ────────────────────────────────────────────────────
 
@@ -52,8 +16,8 @@ fn publish_avahi(hostname: &str, state: &Arc<Mutex<AppState>>) -> Option<AvahiHa
 /// restarting the session whenever the admitted ACL changes.
 pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut current_cfg: Option<DverseConfig> = None;
-    // Kept alive for the entire router lifetime; dropped (→ avahi record removed) on exit.
-    let mut _avahi: Option<AvahiHandle> = None;
+    // Kept alive for the entire router lifetime; dropped (→ mDNS record withdrawn) on exit.
+    let mut _mdns: Option<MdnsHandle> = None;
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -71,10 +35,9 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
-            // Register the mDNS hostname once, the first time we get a config.
-            if _avahi.is_none() {
-                let hostname = format!("zenoh-{}.local", cfg.operator_cn());
-                _avahi = publish_avahi(&hostname, &state);
+            // Publish DNS-SD service record once, the first time we get a config.
+            if _mdns.is_none() {
+                _mdns = MdnsHandle::publish(&cfg.operator_cn(), crate::constants::ROUTER_PORT, &state);
             }
 
             cfg


### PR DESCRIPTION
## Summary

- Replaces `avahi-publish-address` subprocess with in-process DNS-SD publication
- **Linux:** registers via avahi D-Bus API (`zbus`) — necessary because `avahi-daemon` owns port 5353 and `mdns-sd` cannot coexist with it (confirmed by tcpdump: no records transmitted despite `register()` returning `Ok`)
- **macOS / Windows:** uses `mdns-sd` directly — permissive multicast socket sharing means no conflict with system daemons
- LAN IP resolved automatically; no hardcoded `127.0.0.1`
- Service withdrawn on router exit via `Drop` on `MdnsHandle`
- Graceful fallback with log warning if avahi/mDNS unavailable
- CN published as TXT property (`cn=<username>`) for future peer discovery (#70)
- ADR-012 added documenting the platform-conditional approach; ADR-011 marked superseded

## Closes

- Closes #69 — Publish `_dverse._tcp` DNS-SD service record

## Test plan

- [ ] Start the router, check log shows `mDNS: published DVerse (<cn>) on _dverse._tcp.local. port 7447 (via avahi)`
- [ ] On another LAN machine: `avahi-browse _dverse._tcp` lists the router with its LAN IP (not `127.0.0.1`)
- [ ] Stop the router — service disappears from `avahi-browse` within a few seconds
- [ ] On macOS: `dns-sd -B _dverse._tcp local` lists the router