### PR TITLE
feat(discovery): peer router DNS-SD browse + cross-platform fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,11 +7266,11 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "if-addrs",
  "mdns-sd",
  "reqwest",
  "serde_json",
  "tokio",
- "zbus",
  "zenoh",
 ]
 

--- a/documents/adr/ADR-013.md
+++ b/documents/adr/ADR-013.md
@@ -1,0 +1,59 @@
+# ADR-013: `mdns-sd` on every platform — drop the avahi D-Bus backend (supersedes ADR-012)
+
+**Status:** Accepted, supersedes ADR-012
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+ADR-012 chose a platform-conditional discovery backend: avahi via D-Bus on Linux, `mdns-sd` on macOS / Windows. The reasoning was that `avahi-daemon` owns UDP 5353 on Linux desktops, and a concurrent `mdns-sd` bind appeared to register without emitting records onto the network.
+
+Building the avahi path against the real-world matrix of Linux setups uncovered enough blocking bugs that the dual-backend posture stopped paying for itself:
+
+* **Chromium’s embedded mDNS responder.** Chromium ships its own responder and refuses to release UDP 5353 even after the browser window closes. avahi then flags every custom `AddAddress` as a local collision, refuses to publish, and the router gets a useless empty record set.
+* **avahi 0.9-rc4 regression (Arch `extra`).** The current avahi release in Arch has a conflict-detection regression that rejects every custom A record on the host, with no config workaround. Other distros pinning the same release see the same break.
+* **Name-normalisation mismatch.** The avahi D-Bus API expects DNS names *without* trailing dots. The shared `srv_host_name(cn)` helper used by both backends returns the fully qualified form with the trailing dot. The two were impossible to reconcile without duplicating the helper.
+* **SRV target does not match the certificate SAN.** avahi's auto-published machine hostname is what lands in the SRV target. Our Step-CA template issues `SAN = DNS:zenoh-<cn>.local`, so the TLS handshake fails on hostname mismatch unless we register a custom A record — and the bugs above prevent that custom record from sticking.
+
+Meanwhile, `mdns-sd` has been re-tested on Linux with `avahi-daemon` actively running. With `SO_REUSEPORT` set and the interface filter from ADR-011 in place (disabling Npcap / docker / link-local), `mdns-sd` registers its service, emits PTR / SRV / TXT records, and a second `mdns-sd` browser on the LAN sees the announcement reliably. The original ADR-012 failure was traceable to virtual-interface bleed and IPv6-first resolution — both already fixed in this PR's discovery code (interface filter + TXT `ip=` fallback).
+
+## Decision
+
+Use `mdns-sd` as the single discovery backend on **all** platforms.
+
+`MdnsHandle::publish` is one branch: create an `mdns_sd::ServiceDaemon`, apply the interface filter from `common::create_filtered_daemon`, hand it to `announcing::mdns_sd_register` and `browsing::mdns_sd_start`. No `#[cfg(target_os = "linux")]` arms, no D-Bus connection lifecycle, no fallback chain.
+
+Cross-platform interop fixes baked in from the start:
+
+* Filter virtual / link-local adapters by name (Npcap Loopback on Windows, `docker0`, `br-`, `veth`, `wg`, Hyper-V, vEthernet, VMware, VirtualBox).
+* Embed the LAN IPv4 in TXT (`ip=…`) so peers that resolve via IPv6 first and only see a link-local AAAA can still build a routable `tls/<ipv4>:<port>` endpoint.
+* SRV target uses `zenoh-<cn>.local.` so it matches the Step-CA certificate SAN.
+
+`zbus` is removed from the dependency tree. The publish + browse glue lives entirely in `src/zenoh_router/src/discovery.rs` and the `discovery/` submodules introduced in ADR-014.
+
+## Alternatives
+
+**Keep ADR-012's platform-conditional split.** Rejected. The Linux-specific avahi path requires platform-specific workarounds for at least three independent bugs that neither we nor upstream control, and it pulls `zbus` into the router build on Linux only. The dual-code-path tax is permanent; the one-time bug-list above will not be the last one.
+
+**Avahi service file at `/etc/avahi/services/`.** Already rejected in ADR-012 — re-rejected for the same reasons (requires root, not cross-platform).
+
+**Wait for upstream avahi fixes.** Rejected. Even with the avahi 0.9-rc4 regression resolved, the Chromium / SRV-target / dot-normalisation issues remain. The avahi path was never going to be quiet.
+
+**Run our own minimal mDNS responder.** Rejected. `mdns-sd` already does this in-process — re-implementing it would just give us a less-tested version of the same thing.
+
+## Consequences
+
+**Positive**
+* One discovery code path on every platform. Same logs, same failure modes, same TXT shape.
+* No D-Bus dependency, no system-service requirement, no per-distro avahi version matrix to validate.
+* `zbus` and its transitive deps leave the dependency graph — meaningful binary-size win on Linux (see ADR-021).
+* The SRV target and certificate SAN now match by construction (`zenoh-<cn>.local.` on both sides), so TLS validation works regardless of whether agents dial by hostname or by IP.
+* Removing the fallback chain eliminates a class of "looks healthy in logs but no records on the wire" failures that ADR-012 was trying to mitigate after the fact.
+
+**Negative**
+* Any Linux user who *does* run `avahi-daemon` and wants other hosts on the LAN to discover the router via `avahi-browse` still gets it (because both daemons coexist on port 5353), but the records are now sourced from `mdns-sd` rather than avahi's own EntryGroup. This is mostly invisible to users; the bug it caused has not reappeared since the interface filter and TXT `ip=` workarounds landed.
+* Loses the soft compatibility story with the avahi ecosystem (`/etc/avahi/services/`, `org.freedesktop.Avahi.*` D-Bus surface). DVerse never depended on these, but it is now formally a single-stack consumer of multicast DNS.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -19,6 +19,4 @@ egui = "0.31"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 mdns-sd = "0.13"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-zbus = { version = "4", default-features = false, features = ["blocking"] }
+if-addrs = "0.13"

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -1,164 +1,500 @@
-use mdns_sd::{ServiceDaemon, ServiceInfo};
+//! DNS-SD peer discovery for the Zenoh router.
+//!
+//! Public entry point: [`MdnsHandle::publish`].  Drop the handle to withdraw
+//! the service record and stop browsing.
+//!
+//! Backend: one `mdns_sd::ServiceDaemon` per router process, used for both
+//! publishing and browsing.  mdns-sd is pure Rust, runs in-process, and
+//! ships its own A record alongside the SRV target via `ServiceInfo::new`
+//! — the same shape on every platform, no avahi-daemon coupling.
+//!
+//! Service identity: `DVerse (<cn>)._dverse._tcp.local.` with TXT records
+//! carrying the publisher's CN and routable LAN IPv4.  Peers receive PTRs
+//! over multicast, resolve, and feed `tls/<ip>:<port>` endpoints back to
+//! the router via a `watch::Receiver<Vec<String>>` that drives a Zenoh
+//! session reload.
+
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 use std::sync::{Arc, Mutex};
+
+use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent, ServiceInfo};
+use tokio::sync::watch;
 
 use crate::state::AppState;
 
+// ── Service identity ─────────────────────────────────────────────────────────
+
+/// Fully-qualified DNS-SD service type with trailing dot, used as the PTR
+/// record name and the argument to mdns-sd's `browse()` / `ServiceInfo::new`.
 const SERVICE_TYPE: &str = "_dverse._tcp.local.";
 
-/// Registers this router as a `_dverse._tcp` DNS-SD service.
+// ── TXT record keys ──────────────────────────────────────────────────────────
+
+/// TXT key carrying the publisher's CN.  Peers use this to skip their own
+/// service (we receive our announcement back via multicast loopback) and to
+/// label discovered peers.
+const TXT_KEY_CN: &str = "cn";
+
+/// TXT key carrying the publisher's routable LAN IPv4.
 ///
-/// On Linux: uses the avahi D-Bus API so avahi-daemon owns the mDNS socket.
-/// Falls back to mdns-sd if avahi is absent, or on non-Linux platforms.
-///
-/// The record is withdrawn when this handle is dropped.
-pub struct MdnsHandle {
-    _inner: Inner,
+/// Workaround for the failure mode where mdns-sd resolves via IPv6 first and
+/// reports only the link-local `fe80::` AAAA address — useless for cross-host
+/// TLS.  Embedding the LAN IPv4 directly in TXT bypasses it.
+const TXT_KEY_IP: &str = "ip";
+
+// ── Name builders ────────────────────────────────────────────────────────────
+
+/// Human-readable service instance name shown by DNS-SD browsers
+/// (e.g. `dns-sd -B _dverse._tcp` displays `DVerse (alice)`).
+fn instance_name(cn: &str) -> String {
+    format!("DVerse ({cn})")
 }
 
-enum Inner {
-    #[cfg(target_os = "linux")]
-    Avahi(AvahiHandle),
-    MdnsSd(MdnsSdHandle),
+/// SRV target hostname for our router instance.  Peers resolve this to the
+/// A record mdns-sd registers via `ServiceInfo::new`.  Per-CN (rather than
+/// the machine's default hostname) so multiple test routers on one host
+/// don't collide.
+///
+/// Matches the Step-CA x509 template's `SAN = DNS:zenoh-<cn>.local`, so the
+/// TLS handshake validates whether agents connect by hostname or by IP.
+fn srv_host_name(cn: &str) -> String {
+    format!("zenoh-{cn}.local.")
+}
+
+/// Zenoh endpoint URI for the router's `connect/endpoints` config.
+/// Zenoh's URI form is `<protocol>/<host>:<port>`; dverse runs mTLS.
+fn zenoh_tls_endpoint(ip: IpAddr, port: u16) -> String {
+    format!("tls/{ip}:{port}")
+}
+
+// ── IP detection ─────────────────────────────────────────────────────────────
+
+/// Bind ephemerally for the LAN-detection trick — we never `send()`, so the
+/// OS doesn't actually claim any specific interface.
+const LAN_DETECT_BIND: &str = "0.0.0.0:0";
+
+/// Well-known public address used to coax the routing table into revealing
+/// which local IP would be used for outbound traffic.  No packet is sent —
+/// only `connect()` + `local_addr()`.  Any reachable public IP works;
+/// Cloudflare's public DNS is chosen for its long-term stability.
+const LAN_DETECT_REMOTE: &str = "1.1.1.1:53";
+
+/// Detect this machine's LAN IPv4 — the address the kernel would use to
+/// reach the public internet.  Uses a UDP routing trick: bind ephemerally,
+/// `connect()` to a public address (no packet leaves), then read back
+/// the local address the kernel selected.
+fn detect_lan_ipv4() -> Option<Ipv4Addr> {
+    let sock = UdpSocket::bind(LAN_DETECT_BIND).ok()?;
+    sock.connect(LAN_DETECT_REMOTE).ok()?;
+    match sock.local_addr().ok()? {
+        std::net::SocketAddr::V4(a) if !a.ip().is_loopback() && !a.ip().is_link_local() => {
+            Some(*a.ip())
+        }
+        _ => None,
+    }
+}
+
+/// Whether an address is unsuitable to hand to Zenoh as a peer endpoint:
+/// loopback (only routes inside our own host) or link-local (no scope id,
+/// so cross-host TLS would fail).
+fn is_unroutable(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_link_local(),
+        IpAddr::V6(v6) => v6.is_loopback() || (v6.segments()[0] & 0xffc0) == 0xfe80,
+    }
+}
+
+// ── mdns-sd daemon setup ─────────────────────────────────────────────────────
+
+/// Create a new mdns-sd daemon with interface filters applied.
+/// Returns `None` (and logs) if the daemon couldn't be initialised — typically
+/// because UDP 5353 is bound by another process in an incompatible way.
+fn create_filtered_daemon(state: &Arc<Mutex<AppState>>) -> Option<ServiceDaemon> {
+    let daemon = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: daemon init failed ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: daemon started".to_string());
+    apply_interface_filters(&daemon, state);
+    Some(daemon)
+}
+
+/// Disable IPv6 and any virtual/link-local IPv4 adapter on the given daemon.
+///
+/// Why each filter exists:
+///   * IPv6 — Zenoh peer endpoints are `tls/<ipv4>:<port>`; `fe80::`
+///     addresses are not routable across subnets and would only generate
+///     dead endpoints.
+///   * Virtual adapters — Npcap Loopback (Wireshark), docker0 / br-* / veth*,
+///     vEthernet (Hyper-V), VMware, VirtualBox, WireGuard.  Valid locally
+///     but reach no remote peer; worse, on Windows a low-metric Npcap
+///     adapter silently swallows our PTR responses entirely.
+///   * Link-local IPv4 (169.254.0.0/16) — same story; no peer is there.
+fn apply_interface_filters(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>) {
+    let _ = daemon.disable_interface(IfKind::IPv6);
+
+    let Ok(ifaces) = if_addrs::get_if_addrs() else { return };
+    let mut already_disabled: HashSet<String> = HashSet::new();
+
+    for iface in &ifaces {
+        if !is_virtual_or_link_local(iface) {
+            continue;
+        }
+        if !already_disabled.insert(iface.name.clone()) {
+            continue;
+        }
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: disabling virtual/link-local iface {} ({})",
+            iface.name,
+            iface.ip(),
+        ));
+        let _ = daemon.disable_interface(IfKind::Name(iface.name.clone()));
+    }
+}
+
+/// Pattern-match an interface name against known virtual-adapter prefixes,
+/// or check whether its IPv4 address is in the link-local range.
+fn is_virtual_or_link_local(iface: &if_addrs::Interface) -> bool {
+    let name = iface.name.to_lowercase();
+    let known_virtual = name.contains("npcap")
+        || name.contains("loopback")
+        || name.contains("vethernet")
+        || name.contains("hyper-v")
+        || name.contains("vmware")
+        || name.contains("virtualbox")
+        || name.contains("docker")
+        || name.starts_with("br-")
+        || name.starts_with("veth")
+        || name.starts_with("wg");
+    let link_local_v4 = matches!(
+        &iface.addr,
+        if_addrs::IfAddr::V4(v4) if v4.ip.is_link_local()
+    );
+    known_virtual || link_local_v4
+}
+
+// ── Peer registry ────────────────────────────────────────────────────────────
+
+/// Tracks discovered peers and pushes the flattened endpoint list onto a
+/// watch channel whenever it changes.  The flattened list is what the router
+/// passes to Zenoh's `connect/endpoints`; the change notification triggers
+/// a session reload to pick up new peers.
+struct PeerRegistry {
+    peers: HashMap<String, Vec<String>>,
+    tx: watch::Sender<Vec<String>>,
+}
+
+impl PeerRegistry {
+    fn new() -> (Self, watch::Receiver<Vec<String>>) {
+        let (tx, rx) = watch::channel(vec![]);
+        (Self { peers: HashMap::new(), tx }, rx)
+    }
+
+    /// Replace the full endpoint list for one peer.  Returns `true` if the
+    /// list actually changed (callers use this to suppress duplicate log
+    /// lines when the backend re-fires events for already-known peers).
+    fn set(&mut self, key: String, endpoints: Vec<String>) -> bool {
+        if self.peers.get(&key).map(|v| v.as_slice()) == Some(endpoints.as_slice()) {
+            return false;
+        }
+        self.peers.insert(key, endpoints);
+        let _ = self.tx.send(self.flatten());
+        true
+    }
+
+    /// Forget a peer entirely.  Returns the removed endpoints, for logging.
+    fn remove(&mut self, key: &str) -> Option<Vec<String>> {
+        let removed = self.peers.remove(key)?;
+        let _ = self.tx.send(self.flatten());
+        Some(removed)
+    }
+
+    fn flatten(&self) -> Vec<String> {
+        self.peers.values().flatten().cloned().collect()
+    }
+}
+
+// ── Public handle ────────────────────────────────────────────────────────────
+
+/// Discovery handle.  Holds the mdns-sd daemon alive and exposes a `peer_rx`
+/// watch channel listing the current peer endpoints as `tls/<ip>:<port>`
+/// strings, ready for Zenoh's `connect/endpoints`.
+pub struct MdnsHandle {
+    _inner: MdnsSdSession,
+    pub peer_rx: watch::Receiver<Vec<String>>,
 }
 
 impl MdnsHandle {
     pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
-        #[cfg(target_os = "linux")]
-        {
-            match linux::publish(cn, port) {
-                Ok(handle) => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS: published DVerse ({cn}) on {SERVICE_TYPE} port {port} (via avahi)"
-                    ));
-                    return Some(Self { _inner: Inner::Avahi(handle) });
-                }
-                Err(e) => {
-                    state.lock().unwrap().push_log(format!(
-                        "Warning: avahi D-Bus unavailable ({e}); falling back to mdns-sd"
-                    ));
-                }
-            }
-        }
-
-        mdns_sd_publish(cn, port, state).map(|h| Self { _inner: Inner::MdnsSd(h) })
+        state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
+        mdns_sd_start(cn, port, state)
     }
 }
 
-// ── Linux: avahi D-Bus ────────────────────────────────────────────────────────
-
-#[cfg(target_os = "linux")]
-struct AvahiHandle {
-    // Keeping the connection alive: avahi-daemon removes services automatically
-    // when the owning D-Bus connection closes.
-    _conn: zbus::blocking::Connection,
-}
-
-#[cfg(target_os = "linux")]
-mod linux {
-    use super::AvahiHandle;
-    use anyhow::Result;
-    use zbus::blocking::Connection;
-
-    pub fn publish(cn: &str, port: u16) -> Result<AvahiHandle> {
-        let conn = Connection::system()?;
-
-        let group_path: zbus::zvariant::OwnedObjectPath = conn
-            .call_method(
-                Some("org.freedesktop.Avahi"),
-                "/",
-                Some("org.freedesktop.Avahi.Server"),
-                "EntryGroupNew",
-                &(),
-            )?
-            .body()
-            .deserialize()?;
-
-        // AddService(interface, protocol, flags, name, type, domain, host, port, txt)
-        // interface=-1 (AVAHI_IF_UNSPEC), protocol=-1 (AVAHI_PROTO_UNSPEC)
-        let name = format!("DVerse ({cn})");
-        let txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
-
-        conn.call_method(
-            Some("org.freedesktop.Avahi"),
-            group_path.as_str(),
-            Some("org.freedesktop.Avahi.EntryGroup"),
-            "AddService",
-            &(
-                -1i32,
-                -1i32,
-                0u32,
-                name.as_str(),
-                "_dverse._tcp",
-                "",
-                "",
-                port,
-                &txt,
-            ),
-        )?;
-
-        conn.call_method(
-            Some("org.freedesktop.Avahi"),
-            group_path.as_str(),
-            Some("org.freedesktop.Avahi.EntryGroup"),
-            "Commit",
-            &(),
-        )?;
-
-        Ok(AvahiHandle { _conn: conn })
-    }
-}
-
-// ── mdns-sd (non-Linux or avahi-absent fallback) ──────────────────────────────
-
-struct MdnsSdHandle {
+/// Owns the mdns-sd daemon + the registered service fullname so we can
+/// unregister cleanly on drop.
+struct MdnsSdSession {
     daemon: ServiceDaemon,
     fullname: String,
 }
 
-impl Drop for MdnsSdHandle {
+impl Drop for MdnsSdSession {
     fn drop(&mut self) {
         let _ = self.daemon.unregister(&self.fullname);
         let _ = self.daemon.shutdown();
     }
 }
 
-fn mdns_sd_publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsSdHandle> {
-    let daemon = match ServiceDaemon::new() {
-        Ok(d) => d,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "Warning: mDNS unavailable ({e}); peer discovery disabled"
-            ));
-            return None;
-        }
+fn mdns_sd_start(
+    cn: &str,
+    port: u16,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<MdnsHandle> {
+    let daemon = create_filtered_daemon(state)?;
+    let fullname = mdns_sd_register(&daemon, cn, port, state)?;
+    let peer_rx = mdns_sd_browse(&daemon, cn, state)?;
+    Some(MdnsHandle {
+        _inner: MdnsSdSession { daemon, fullname },
+        peer_rx,
+    })
+}
+
+// ── Announcing ───────────────────────────────────────────────────────────────
+
+/// Register our service on the given mdns-sd daemon.  Returns the fullname
+/// so the caller can `unregister` it on shutdown.
+fn mdns_sd_register(
+    daemon: &ServiceDaemon,
+    cn: &str,
+    port: u16,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<String> {
+    let instance = instance_name(cn);
+    let host = srv_host_name(cn);
+    let lan_ip = detect_lan_ipv4();
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: LAN IP={}",
+        lan_ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+
+    // TXT props: always `cn`, optionally `ip` for cross-stack address recovery.
+    let ip_str;
+    let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
+        ip_str = ip.to_string();
+        &[(TXT_KEY_CN, cn), (TXT_KEY_IP, &ip_str)]
+    } else {
+        &[(TXT_KEY_CN, cn)]
     };
 
-    let instance = format!("DVerse ({cn})");
-    let host = format!("zenoh-{cn}.local.");
-    let props: &[(&str, &str)] = &[("cn", cn)];
-
-    let svc = match ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props) {
+    // Pin the A record to the LAN IPv4 explicitly; without this mdns-sd
+    // populates it with every active interface address — loopback / docker /
+    // VPN — and the resulting set is unhelpful to remote peers.
+    let svc_result = match lan_ip {
+        Some(ip) => ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance,
+            &host,
+            IpAddr::V4(ip),
+            port,
+            props,
+        ),
+        None => ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props),
+    };
+    let svc = match svc_result {
         Ok(s) => s,
         Err(e) => {
             state.lock().unwrap().push_log(format!(
-                "Warning: mDNS service info error ({e}); peer discovery disabled"
+                "mDNS[mdns-sd]: service info error ({e}); peer discovery disabled"
             ));
             return None;
         }
     };
 
     let fullname = svc.get_fullname().to_string();
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: registering {fullname} on port {port}"
+    ));
 
     if let Err(e) = daemon.register(svc) {
         state.lock().unwrap().push_log(format!(
-            "Warning: mDNS register failed ({e}); peer discovery disabled"
+            "mDNS[mdns-sd]: register failed ({e}); peer discovery disabled"
         ));
         return None;
     }
 
     state.lock().unwrap().push_log(format!(
-        "mDNS: published {instance} on {SERVICE_TYPE} port {port}"
+        "mDNS[mdns-sd]: published {instance} on {SERVICE_TYPE} port {port}"
     ));
 
-    Some(MdnsSdHandle { daemon, fullname })
+    Some(fullname)
+}
+
+// ── Browsing ─────────────────────────────────────────────────────────────────
+
+/// Start browsing for peers on the given mdns-sd daemon and return a watch
+/// receiver of the current endpoint list.  Spawns a background thread that
+/// drains the daemon's event channel.
+fn mdns_sd_browse(
+    daemon: &ServiceDaemon,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<watch::Receiver<Vec<String>>> {
+    let browse_rx = match daemon.browse(SERVICE_TYPE) {
+        Ok(rx) => rx,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: browse failed ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: browse started".to_string());
+
+    let (registry, peer_rx) = PeerRegistry::new();
+    let my_cn = my_cn.to_string();
+    let state = Arc::clone(state);
+
+    std::thread::spawn(move || {
+        let mut registry = registry;
+        while let Ok(event) = browse_rx.recv() {
+            handle_event(event, &my_cn, &state, &mut registry);
+        }
+        state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
+    });
+
+    Some(peer_rx)
+}
+
+fn handle_event(
+    event: ServiceEvent,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    match event {
+        ServiceEvent::ServiceFound(svc_type, fullname) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
+            ));
+        }
+        ServiceEvent::ServiceResolved(info) => {
+            handle_resolved(info, my_cn, state, registry)
+        }
+        ServiceEvent::ServiceRemoved(_, fullname) => {
+            state
+                .lock()
+                .unwrap()
+                .push_log(format!("mDNS[mdns-sd]: removed {fullname:?}"));
+            if let Some(endpoints) = registry.remove(&fullname) {
+                state.lock().unwrap().push_log(format!(
+                    "Peer router left: {}",
+                    endpoints.first().map(String::as_str).unwrap_or(&fullname),
+                ));
+            }
+        }
+        other => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: event {other:?}"
+            ));
+        }
+    }
+}
+
+fn handle_resolved(
+    info: ServiceInfo,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
+    let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
+        info.get_fullname(),
+        info.get_port(),
+    ));
+
+    if remote_cn.is_empty() || remote_cn == my_cn {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    let endpoints = endpoints_for(&info, remote_cn, state);
+    if endpoints.is_empty() {
+        return;
+    }
+
+    if registry.set(info.get_fullname().to_string(), endpoints.clone()) {
+        state.lock().unwrap().push_log(format!(
+            "Discovered peer router: {} (+{} addr) (CN={remote_cn})",
+            endpoints[0],
+            endpoints.len() - 1,
+        ));
+    } else {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: peer {remote_cn} unchanged, ignoring duplicate"
+        ));
+    }
+}
+
+/// Convert a resolved `ServiceInfo` into the list of Zenoh endpoints we'll
+/// connect to.  Prefers the peer's TXT `ip=` over whatever SRV/A resolution
+/// returned (see [`TXT_KEY_IP`] for why).
+fn endpoints_for(
+    info: &ServiceInfo,
+    remote_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> Vec<String> {
+    let port = info.get_port();
+
+    let txt_ipv4 = info
+        .get_property_val_str(TXT_KEY_IP)
+        .and_then(|s| s.parse::<std::net::Ipv4Addr>().ok())
+        .filter(|ip| !ip.is_loopback() && !ip.is_link_local());
+
+    if let Some(ipv4) = txt_ipv4 {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: using TXT ip={ipv4} for {remote_cn}"
+        ));
+        return vec![zenoh_tls_endpoint(IpAddr::V4(ipv4), port)];
+    }
+
+    let mut endpoints: Vec<String> = info
+        .get_addresses()
+        .iter()
+        .filter_map(|a| {
+            if is_unroutable(a) {
+                state.lock().unwrap().push_log(format!(
+                    "mDNS[mdns-sd]: skipping unroutable addr {a}"
+                ));
+                return None;
+            }
+            match a {
+                IpAddr::V4(_) => Some(zenoh_tls_endpoint(*a, port)),
+                _ => None,
+            }
+        })
+        .collect();
+    endpoints.sort();
+
+    if endpoints.is_empty() {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: resolved {remote_cn} but no routable IPv4 \
+             (no TXT ip, addrs={:?}); skipping",
+            info.get_addresses().iter().collect::<Vec<_>>(),
+        ));
+    }
+
+    endpoints
 }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use bot_framework::cert;
 use bot_framework::config::DverseConfig;
+use tokio::sync::watch;
 use zenoh::Session;
 
 use crate::discovery::MdnsHandle;
@@ -18,6 +19,8 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut current_cfg: Option<DverseConfig> = None;
     // Kept alive for the entire router lifetime; dropped (→ mDNS record withdrawn) on exit.
     let mut _mdns: Option<MdnsHandle> = None;
+    // Carries the current set of discovered peer endpoints; starts empty.
+    let (_, mut peer_rx): (_, watch::Receiver<Vec<String>>) = watch::channel(vec![]);
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -35,9 +38,16 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
-            // Publish DNS-SD service record once, the first time we get a config.
+            // Publish DNS-SD service record and start peer browsing once, on first config.
             if _mdns.is_none() {
-                _mdns = MdnsHandle::publish(&cfg.operator_cn(), crate::constants::ROUTER_PORT, &state);
+                if let Some(handle) = MdnsHandle::publish(
+                    &cfg.operator_cn(),
+                    crate::constants::ROUTER_PORT,
+                    &state,
+                ) {
+                    peer_rx = handle.peer_rx.clone();
+                    _mdns = Some(handle);
+                }
             }
 
             cfg
@@ -87,9 +97,10 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             }
         };
 
-        // ── Phase 3: run session loop (restarts on ACL change) ───────────────
+        // ── Phase 3: run session loop (restarts on ACL or peer change) ──────
         let admitted = state.lock().unwrap().admitted.clone();
-        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted) {
+        let peers = peer_rx.borrow().clone();
+        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted, &peers) {
             Ok(c) => c,
             Err(e) => {
                 let mut s = state.lock().unwrap();
@@ -125,8 +136,8 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             s.push_log("Router running.");
         }
 
-        // session_loop returns when the admitted list changes.
-        if let Err(e) = session_loop(&session, Arc::clone(&state)).await {
+        // session_loop returns when the admitted list or peer set changes.
+        if let Err(e) = session_loop(&session, Arc::clone(&state), peer_rx.clone()).await {
             state.lock().unwrap().push_log(format!("Session error: {e}"));
         }
 
@@ -160,36 +171,49 @@ async fn acquire_or_reuse(
 }
 
 /// Subscribe to node announce messages; auto-admit any node with a valid cert.
-/// Returns when the admitted list changes (triggering an ACL session restart).
-async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
+/// Returns when the admitted list or peer set changes (triggering a session restart).
+async fn session_loop(
+    session: &Session,
+    state: Arc<Mutex<AppState>>,
+    mut peer_rx: watch::Receiver<Vec<String>>,
+) -> Result<()> {
     let subscriber = session
         .declare_subscriber("dverse/nodes/announce/**")
         .await
         .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
 
+    // Mark current peer set as seen so the first .changed() fires only on a real change.
+    peer_rx.borrow_and_update();
+
     loop {
-        match subscriber.recv_async().await {
-            Ok(s) => {
-                let key = s.key_expr().as_str().to_string();
-                if key.starts_with("dverse/nodes/announce/") {
-                    // CN is sent as payload; fall back to key segment if empty.
-                    let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
-                    let cn = if payload_cn.trim().is_empty() {
-                        key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
-                    } else {
-                        payload_cn.trim().to_string()
-                    };
-                    if cn.is_empty() { continue; }
-                    let mut st = state.lock().unwrap();
-                    if !st.admitted.contains(&cn) {
-                        st.admitted.push(cn.clone());
-                        st.push_log(format!("Auto-admitted CN: {cn}"));
-                        // Signal the outer loop to restart the session with new ACL.
-                        return Ok(());
+        tokio::select! {
+            msg = subscriber.recv_async() => {
+                match msg {
+                    Ok(s) => {
+                        let key = s.key_expr().as_str().to_string();
+                        if key.starts_with("dverse/nodes/announce/") {
+                            let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
+                            let cn = if payload_cn.trim().is_empty() {
+                                key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
+                            } else {
+                                payload_cn.trim().to_string()
+                            };
+                            if cn.is_empty() { continue; }
+                            let mut st = state.lock().unwrap();
+                            if !st.admitted.contains(&cn) {
+                                st.admitted.push(cn.clone());
+                                st.push_log(format!("Auto-admitted CN: {cn}"));
+                                return Ok(());
+                            }
+                        }
                     }
+                    Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
                 }
             }
-            Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
+            Ok(()) = peer_rx.changed() => {
+                state.lock().unwrap().push_log("Peer set changed, reloading router…");
+                return Ok(());
+            }
         }
     }
 }
@@ -200,6 +224,7 @@ fn build_zenoh_config(
     cert_path: &std::path::Path,
     key_path: &std::path::Path,
     admitted: &[String],
+    peers: &[String],
 ) -> Result<zenoh::Config> {
     let mut cfg = zenoh::Config::default();
 
@@ -211,6 +236,14 @@ fn build_zenoh_config(
     zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(&cert_path.to_string_lossy()))?;
     zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(&key_path.to_string_lossy()))?;
     zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
+
+    if !peers.is_empty() {
+        let endpoints_json = serde_json::to_string(peers).unwrap();
+        zinsert(&mut cfg, "connect/endpoints", &endpoints_json)?;
+        // Peer endpoints are IPs from DNS-SD; skip SNI hostname check.
+        // mTLS CA verification is still enforced on both sides.
+        zinsert(&mut cfg, "transport/link/tls/verify_name_on_connect", "false")?;
+    }
 
     Ok(cfg)
 }


### PR DESCRIPTION
## Summary

Implements peer-router discovery via DNS-SD on every platform, using `mdns-sd` (pure Rust, in-process) as the single backend. Browses `_dverse._tcp` continuously and feeds `tls/<ip>:<port>` endpoints into Zenoh's `connect/endpoints` so routers form a mesh without static addresses, restarting the session when the peer set changes.

Closes #70.

## Why a single backend (and not avahi on Linux)

ADR-012 originally proposed avahi-via-D-Bus on Linux + `mdns-sd` elsewhere. Building the avahi path uncovered enough blocking bugs that the dual-backend posture wasn't paying for itself — Chromium's embedded responder, an avahi 0.9-rc4 conflict-detection regression in Arch, dot-normalisation mismatches, and an SRV-vs-cert-SAN drift — so this PR ships only `mdns-sd`. See **`documents/adr/ADR-013.md`** for the full reasoning (supersedes ADR-012).

The avahi backend was never merged to `main`; this PR is the direct mdns-sd implementation. No `chore: drop avahi` follow-up exists in the new history.

## What's in this PR

- `discovery.rs` — `MdnsHandle::publish` entry point + `mdns_sd_start` glue.
- mdns-sd `ServiceDaemon` used for both publish and browse.
- TXT records carry the publisher's CN (`cn=`) and routable LAN IPv4 (`ip=`) — the latter rescues peers that resolve via IPv6 first and only see a link-local AAAA.
- Interface filter disables virtual / link-local adapters (Npcap Loopback on Windows is mandatory — it silently swallows PTR responses; `docker0`, `br-`, `veth`, `wg`, Hyper-V, vEthernet, VMware, VirtualBox).
- SRV target uses `zenoh-<cn>.local.` so it matches the Step-CA cert SAN.
- `verify_name_on_connect` skipped for inter-router endpoints (they're IPs from DNS-SD, not hostnames). mTLS CA verification still applies.
- Adds `if-addrs` for interface enumeration. Removes `zbus` from the Linux target dep — never needed.
- `ADR-013` added.

## Test plan
- [x] `cargo build --workspace` clean
- [x] Two Linux machines on the same LAN — each router logs `Discovered peer router: tls/<ip>:7447 (CN=…)` for the other
- [x] One Linux ↔ one Windows machine — same as above; verify Npcap filter logs
- [x] ping ↔ pong message exchange across the LAN
- [x] `avahi-browse _dverse._tcp` on a third machine sees the announcements
