### PR TITLE
feat(session): SessionRole + DNS-SD session filter

### DIFF
--- a/documents/adr/ADR-015.md
+++ b/documents/adr/ADR-015.md
@@ -1,0 +1,88 @@
+# ADR-015: `SessionRole` and DNS-SD session filter
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Before this change the router had no concept of a session. Two routers on the same LAN would discover each other via `_dverse._tcp`, mutually feed each other into Zenoh's `connect/endpoints`, and form a mesh — regardless of whether the two users intended to collaborate.
+
+The user mental model is:
+
+* On launch, a user either **creates** a new session (becoming its admin — they will later host the bridge to a chat platform out of scope here) or **joins** an existing session by specifying the admin's CN.
+* Two routers running different sessions on the same LAN must not auto-mesh, even if the underlying mTLS would allow it.
+* The session identity needs to travel on the same channel as discovery itself, so the filter applies before any TLS handshake or admission decision is reached.
+
+This needs to land before per-node agent inventory (PR #92) because the inventory ACL key (`dverse/nodes/announce/<cn>/agents/<agent_name>`) is naturally scoped to a session: without session filtering the GUI would render agents from unrelated sessions side-by-side.
+
+Persistence is out of scope (#73). Explicit admit / deny is out of scope (#72). ACL JSON must remain byte-identical (#74).
+
+## Decision
+
+Introduce a `SessionRole` primitive at the config layer, derive a `session_id` string from it, embed `session_id` in DNS-SD TXT records alongside the existing `cn=` / `ip=` entries, and filter peers in the browse path by matching `session_id`.
+
+`bot_framework::config::SessionRole`:
+
+```rust
+pub enum SessionRole {
+    Admin,
+    Client { admin_cn: String },
+}
+```
+
+`DverseConfig::session_id() -> String` returns the admin's CN in both cases:
+
+* `Admin` → the user's own `operator_cn`.
+* `Client { admin_cn }` → the supplied `admin_cn`.
+
+The serde representation uses `#[serde(default)] session_role: SessionRole = Admin`, so existing `~/.config/dverse/config.toml` files without the field load as solo-admin and need no migration. Single-machine setups keep working unchanged.
+
+DNS-SD wire format gains a third TXT key:
+
+```
+session=<session_id>
+```
+
+published in `announcing::mdns_sd_register` alongside `cn=…` and `ip=…`. The shape stays compatible with the existing parser — a peer that doesn't understand `session=` simply doesn't see it, and (per ADR-013) every peer on the LAN is built from this same workspace, so this scenario is theoretical.
+
+The filter runs in `browsing::handle_resolved` immediately after the existing self-CN skip:
+
+```
+if remote_session != my_session {
+    // log and return
+}
+```
+
+`MdnsHandle::publish` plumbs `session_id` through alongside `cn`; the router writes `session_role` + `session_id` into `AppState` before the first announcement so the GUI badge ("Session admin: alice" / "Joined session: alice") and the discovery threads agree.
+
+`Client` clients **pre-admit** their admin's CN at Phase 1 — before any heartbeat arrives — so the admin's router is reachable as soon as DNS-SD resolves it.
+
+ACL JSON construction (`build_acl_json`) is **not** touched. The session filter is a peer-set restriction enforced at the discovery layer, below ACL.
+
+## Alternatives
+
+**Filter on CN admit list at the ACL layer.** Rejected. Means the routers would still form a TLS handshake, exchange identities, and only then refuse the session — wasteful and racy. Filtering at DNS-SD prevents the connect from being attempted at all.
+
+**Carry the session in the mTLS client cert (e.g. as an OU).** Rejected. Requires re-issuing certificates whenever a user joins a different session, and step-CA's template would need a per-session intermediate. The cost is orders of magnitude higher than the benefit.
+
+**A separate service type per session (`_dverse-<session>._tcp`).** Rejected. Service types are baked into the cert SAN and the global helper functions; varying them per session means every other discovery decision has to become session-aware. Filtering inside one stable service type is the surgical move.
+
+**UUIDs for session identity instead of the admin CN.** Rejected. The admin CN is what users actually type ("join alice's session"); reintroducing a UUID would force a name lookup in the GUI and serve no security purpose — the mTLS identity is still per-CN.
+
+## Consequences
+
+**Positive**
+* Two sessions on the same LAN coexist without auto-meshing. Verified with three-machine LAN test: admin `alice`, client `bob` joining alice, admin `carol` — alice + bob mesh, carol stands alone.
+* The `session_id` field is a single, cheap string that travels on a path that already exists (DNS-SD TXT), so the cost at runtime is one comparison per resolved peer.
+* Old configs (no `session_role`) continue to work as solo-admin sessions — single-machine dev loops never see a regression.
+* Sets up the agent-inventory PR (#92) cleanly: the inventory tree is naturally scoped to the session because the session filter has already excluded peers from other sessions before any heartbeat reaches `connected_nodes`.
+
+**Negative**
+* Adds a new login-form decision that did not exist before. The GUI now has a radio for "Create session" / "Join session" and a text field for the admin's CN; users have to type the admin's CN exactly, with no discovery UX yet. A future "discover sessions on the LAN" picker could read the `session=` TXT directly but is out of scope.
+* Joining a session that doesn't exist on the LAN currently times out silently — there's no "session not found" feedback. Acceptable for the first iteration; the log line `mDNS: skipping peer X (session="X", ours="Y")` from any reachable peer makes the situation diagnosable.
+* The session-id format is "the admin's CN as a plain string." It carries no opaque randomness, so it is by definition guessable. This is intentional — the security boundary is still mTLS and the per-CN admission list — but it does mean session identity is a usability feature, not a security one.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -2,6 +2,25 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Whether this dverse install hosts its own session (Admin) or joins
+/// another user's session (Client of some admin CN).
+///
+/// Persisted in `DverseConfig`. Old config files without this field load as
+/// `Admin` via the `Default` impl + `#[serde(default)]` — so single-machine
+/// setups keep working unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "admin_cn", rename_all = "snake_case")]
+pub enum SessionRole {
+    Admin,
+    Client { admin_cn: String },
+}
+
+impl Default for SessionRole {
+    fn default() -> Self {
+        Self::Admin
+    }
+}
+
 /// Machine-wide dverse configuration, stored at `~/.config/dverse/config.toml`.
 /// Only one user session is supported per machine.
 ///
@@ -24,6 +43,10 @@ pub struct DverseConfig {
     pub router_listen: String,
     /// Zenoh connect endpoint used by local agents (client side).
     pub router_endpoint: String,
+    /// Whether this user creates a new session or joins someone else's.
+    /// Missing from old configs → `Admin` by default.
+    #[serde(default)]
+    pub session_role: SessionRole,
 }
 
 impl DverseConfig {
@@ -83,6 +106,17 @@ impl DverseConfig {
             .next()
             .unwrap_or(&self.username)
             .to_string()
+    }
+
+    /// Identifier shared by every router participating in the same session.
+    /// Equals our own CN when we host (Admin), the admin's CN when we joined
+    /// (Client). Used as the `session=` TXT entry in DNS-SD and to filter
+    /// peers — two routers with different session_ids never auto-mesh.
+    pub fn session_id(&self) -> String {
+        match &self.session_role {
+            SessionRole::Admin => self.operator_cn(),
+            SessionRole::Client { admin_cn } => admin_cn.clone(),
+        }
     }
 
     /// Build a `CertConfig` for the given node name using the stored credentials.

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -31,9 +31,14 @@ pub struct MdnsHandle {
 }
 
 impl MdnsHandle {
-    pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
+    pub fn publish(
+        cn: &str,
+        session_id: &str,
+        port: u16,
+        state: &Arc<Mutex<AppState>>,
+    ) -> Option<Self> {
         state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
-        mdns_sd_start(cn, port, state)
+        mdns_sd_start(cn, session_id, port, state)
     }
 }
 
@@ -53,12 +58,13 @@ impl Drop for MdnsSdSession {
 
 fn mdns_sd_start(
     cn: &str,
+    session_id: &str,
     port: u16,
     state: &Arc<Mutex<AppState>>,
 ) -> Option<MdnsHandle> {
     let daemon = create_filtered_daemon(state)?;
-    let fullname = announcing::mdns_sd_register(&daemon, cn, port, state)?;
-    let peer_rx = browsing::mdns_sd_start(&daemon, cn, state)?;
+    let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port, state)?;
+    let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id, state)?;
     Some(MdnsHandle {
         _inner: MdnsSdSession { daemon, fullname },
         peer_rx,

--- a/src/zenoh_router/src/discovery/announcing.rs
+++ b/src/zenoh_router/src/discovery/announcing.rs
@@ -13,6 +13,7 @@ use crate::state::AppState;
 
 use super::common::{
     detect_lan_ipv4, instance_name, srv_host_name, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    TXT_KEY_SESSION,
 };
 
 /// Register our service on the given mdns-sd daemon.  Returns the fullname
@@ -20,6 +21,7 @@ use super::common::{
 pub(super) fn mdns_sd_register(
     daemon: &ServiceDaemon,
     cn: &str,
+    session_id: &str,
     port: u16,
     state: &Arc<Mutex<AppState>>,
 ) -> Option<String> {
@@ -34,13 +36,18 @@ pub(super) fn mdns_sd_register(
             .unwrap_or_else(|| "unknown".to_string())
     ));
 
-    // TXT props: always `cn`, optionally `ip` for cross-stack address recovery.
+    // TXT props: always `cn` + `session`, optionally `ip` for cross-stack
+    // address recovery.
     let ip_str;
     let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
         ip_str = ip.to_string();
-        &[(TXT_KEY_CN, cn), (TXT_KEY_IP, &ip_str)]
+        &[
+            (TXT_KEY_CN, cn),
+            (TXT_KEY_SESSION, session_id),
+            (TXT_KEY_IP, &ip_str),
+        ]
     } else {
-        &[(TXT_KEY_CN, cn)]
+        &[(TXT_KEY_CN, cn), (TXT_KEY_SESSION, session_id)]
     };
 
     // Pin the A record to the LAN IPv4 explicitly; without this mdns-sd

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -10,6 +10,7 @@ use crate::state::AppState;
 
 use super::common::{
     is_unroutable, zenoh_tls_endpoint, PeerRegistry, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    TXT_KEY_SESSION,
 };
 
 /// Start browsing for peers on the given mdns-sd daemon and return a watch
@@ -18,6 +19,7 @@ use super::common::{
 pub(super) fn mdns_sd_start(
     daemon: &ServiceDaemon,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
 ) -> Option<watch::Receiver<Vec<String>>> {
     let browse_rx = match daemon.browse(SERVICE_TYPE) {
@@ -33,12 +35,13 @@ pub(super) fn mdns_sd_start(
 
     let (registry, peer_rx) = PeerRegistry::new();
     let my_cn = my_cn.to_string();
+    let my_session = my_session.to_string();
     let state = Arc::clone(state);
 
     std::thread::spawn(move || {
         let mut registry = registry;
         while let Ok(event) = browse_rx.recv() {
-            handle_event(event, &my_cn, &state, &mut registry);
+            handle_event(event, &my_cn, &my_session, &state, &mut registry);
         }
         state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
     });
@@ -49,6 +52,7 @@ pub(super) fn mdns_sd_start(
 fn handle_event(
     event: ServiceEvent,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
@@ -59,7 +63,7 @@ fn handle_event(
             ));
         }
         ServiceEvent::ServiceResolved(info) => {
-            handle_resolved(info, my_cn, state, registry)
+            handle_resolved(info, my_cn, my_session, state, registry)
         }
         ServiceEvent::ServiceRemoved(_, fullname) => {
             state
@@ -84,13 +88,15 @@ fn handle_event(
 fn handle_resolved(
     info: ServiceInfo,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
     let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
+    let remote_session = info.get_property_val_str(TXT_KEY_SESSION).unwrap_or_default();
     let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
     state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
+        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} session={remote_session:?} addrs={addrs:?} port={}",
         info.get_fullname(),
         info.get_port(),
     ));
@@ -98,6 +104,15 @@ fn handle_resolved(
     if remote_cn.is_empty() || remote_cn == my_cn {
         state.lock().unwrap().push_log(format!(
             "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    // Session filter: skip peers that belong to a different session.  Without
+    // this, two unrelated users on the same LAN would auto-mesh their routers.
+    if remote_session != my_session {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
         ));
         return;
     }

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -110,6 +110,17 @@ fn handle_resolved(
 
     // Session filter: skip peers that belong to a different session.  Without
     // this, two unrelated users on the same LAN would auto-mesh their routers.
+    //
+    // Separate log line for "no session= TXT" because `unwrap_or_default()`
+    // collapses a missing TXT key and a literal empty string to the same ""
+    // value, and the failure mode (older binary, manual `dns-sd` test) is
+    // diagnostically different from "different session running on the LAN".
+    if remote_session.is_empty() {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: skipping peer {remote_cn} — no session= TXT key (likely older or non-DVerse announcement)"
+        ));
+        return;
+    }
     if remote_session != my_session {
         state.lock().unwrap().push_log(format!(
             "mDNS[mdns-sd]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -34,6 +34,12 @@ pub(super) const TXT_KEY_CN: &str = "cn";
 /// TLS.  Embedding the LAN IPv4 directly in TXT bypasses it.
 pub(super) const TXT_KEY_IP: &str = "ip";
 
+/// TXT key carrying the session identifier — the admin's CN for everyone
+/// participating in the session.  Browsers skip peers whose session value
+/// doesn't match their own, so two unrelated users on the same LAN don't
+/// auto-mesh their routers.
+pub(super) const TXT_KEY_SESSION: &str = "session";
+
 // ── Name builders ────────────────────────────────────────────────────────────
 
 /// Human-readable service instance name shown by DNS-SD browsers

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use eframe::egui;
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 
 use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, REGISTRATION_CLIENT_ID, REGISTRATION_CLIENT_SECRET, ROUTER_LISTEN, ROUTER_PORT};
 use crate::state::{AppState, RouterStatus};
@@ -20,11 +20,22 @@ pub struct LoginForm {
     pub username: String,
     pub password: String,
     pub error: Option<String>,
+    /// Radio: true = create a new session (this user becomes admin),
+    /// false = join an existing session whose admin's CN is `join_admin_cn`.
+    pub create_session: bool,
+    /// Admin CN to join when `create_session == false`.
+    pub join_admin_cn: String,
 }
 
 impl Default for LoginForm {
     fn default() -> Self {
-        Self { username: String::new(), password: String::new(), error: None }
+        Self {
+            username: String::new(),
+            password: String::new(),
+            error: None,
+            create_session: true,
+            join_admin_cn: String::new(),
+        }
     }
 }
 
@@ -147,6 +158,29 @@ fn show_login(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                     }
                 });
 
+            ui.add_space(12.0);
+            ui.separator();
+            ui.add_space(8.0);
+
+            // Session role selector: create your own session, or join an
+            // existing one whose admin's CN you know.
+            ui.horizontal(|ui| {
+                ui.radio_value(&mut form.create_session, true, "Create new session");
+                ui.add_space(12.0);
+                ui.radio_value(&mut form.create_session, false, "Join session");
+            });
+            if !form.create_session {
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    ui.label("Admin username");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.join_admin_cn)
+                            .hint_text("e.g. alice")
+                            .min_size(egui::vec2(220.0, 0.0)),
+                    );
+                });
+            }
+
             ui.add_space(16.0);
 
             if let Some(err) = &form.error {
@@ -192,6 +226,19 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         return;
     }
 
+    // Build session role from the radio + admin CN field.  When joining,
+    // the admin CN is required and must be non-empty.
+    let session_role = if form.create_session {
+        SessionRole::Admin
+    } else {
+        let admin_cn = form.join_admin_cn.trim().to_string();
+        if admin_cn.is_empty() {
+            form.error = Some("Admin username is required to join a session.".into());
+            return;
+        }
+        SessionRole::Client { admin_cn }
+    };
+
     let cert_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("dverse")
@@ -214,6 +261,7 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         cert_dir,
         router_listen: ROUTER_LISTEN.into(),
         router_endpoint,
+        session_role,
     };
 
     if let Err(e) = cfg.save() {
@@ -444,6 +492,28 @@ fn show_loading(ctx: &egui::Context, state: &Arc<Mutex<AppState>>) {
 
 fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
     let st = state.lock().unwrap();
+
+    // Session badge — declared first so it renders above status_bar.  egui's
+    // top panels stack in declaration order.
+    egui::TopBottomPanel::top("session_bar").show(ctx, |ui| {
+        ui.horizontal(|ui| {
+            ui.label("Session:");
+            match &st.session_role {
+                SessionRole::Admin => {
+                    ui.colored_label(
+                        egui::Color32::LIGHT_BLUE,
+                        format!("Admin · {}", st.session_id),
+                    );
+                }
+                SessionRole::Client { admin_cn } => {
+                    ui.colored_label(
+                        egui::Color32::LIGHT_GREEN,
+                        format!("Joined · admin: {admin_cn}"),
+                    );
+                }
+            }
+        });
+    });
 
     egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
         ui.horizontal(|ui| {

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -495,25 +495,31 @@ fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
 
     // Session badge — declared first so it renders above status_bar.  egui's
     // top panels stack in declaration order.
-    egui::TopBottomPanel::top("session_bar").show(ctx, |ui| {
-        ui.horizontal(|ui| {
-            ui.label("Session:");
-            match &st.session_role {
-                SessionRole::Admin => {
-                    ui.colored_label(
-                        egui::Color32::LIGHT_BLUE,
-                        format!("Admin · {}", st.session_id),
-                    );
+    //
+    // Hidden entirely until a config has been accepted (signalled by a
+    // non-empty `session_id`).  Otherwise the Admin variant would render
+    // `Admin · ` with an empty CN during the Idle / Acquiring states.
+    if !st.session_id.is_empty() {
+        egui::TopBottomPanel::top("session_bar").show(ctx, |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Session:");
+                match &st.session_role {
+                    SessionRole::Admin => {
+                        ui.colored_label(
+                            egui::Color32::LIGHT_BLUE,
+                            format!("Admin · {}", st.session_id),
+                        );
+                    }
+                    SessionRole::Client { admin_cn } => {
+                        ui.colored_label(
+                            egui::Color32::LIGHT_GREEN,
+                            format!("Joined · admin: {admin_cn}"),
+                        );
+                    }
                 }
-                SessionRole::Client { admin_cn } => {
-                    ui.colored_label(
-                        egui::Color32::LIGHT_GREEN,
-                        format!("Joined · admin: {admin_cn}"),
-                    );
-                }
-            }
+            });
         });
-    });
+    }
 
     egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
         ui.horizontal(|ui| {

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -47,7 +47,9 @@ fn run_demo() {
     let mut state = AppState::new(None);
     state.admitted = vec!["alice".into(), "mybot".into()];
     state.router_status = state::RouterStatus::Running;
+    state.session_id = "alice".into();
     state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
+    state.push_log("[demo] Session admin: alice");
     state.push_log("[demo] Auto-admitted: alice");
     state.push_log("[demo] Auto-admitted: mybot");
     launch_gui(Arc::new(Mutex::new(state)), Screen::Main);

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bot_framework::cert;
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 use tokio::sync::watch;
 use zenoh::Session;
 
@@ -38,10 +38,21 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
+            // Copy session role + id into AppState before MdnsHandle::publish so
+            // the GUI shows the badge immediately and DNS-SD includes session=
+            // in its first announcement.
+            let session_id = cfg.session_id();
+            {
+                let mut s = state.lock().unwrap();
+                s.session_role = cfg.session_role.clone();
+                s.session_id = session_id.clone();
+            }
+
             // Publish DNS-SD service record and start peer browsing once, on first config.
             if _mdns.is_none() {
                 if let Some(handle) = MdnsHandle::publish(
                     &cfg.operator_cn(),
+                    &session_id,
                     crate::constants::ROUTER_PORT,
                     &state,
                 ) {
@@ -60,6 +71,16 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             if !st.admitted.contains(&operator_cn) {
                 st.admitted.push(operator_cn.clone());
                 st.push_log(format!("Pre-admitted operator CN: {operator_cn}"));
+            }
+            // When joining someone else's session, pre-admit the admin's CN too,
+            // so the admin's router (which carries that cert) can connect and
+            // form the mesh before we've heard a heartbeat from any of their
+            // agents.
+            if let SessionRole::Client { admin_cn } = &cfg.session_role {
+                if !admin_cn.is_empty() && !st.admitted.contains(admin_cn) {
+                    st.admitted.push(admin_cn.clone());
+                    st.push_log(format!("Pre-admitted session admin CN: {admin_cn}"));
+                }
             }
         }
 

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,4 +1,4 @@
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 
 pub struct AppState {
     pub router_status: RouterStatus,
@@ -8,6 +8,13 @@ pub struct AppState {
     pub log: Vec<String>,
     /// Config written by the GUI; background thread consumes it to start/restart.
     pub staged_config: Option<DverseConfig>,
+    /// Whether this router hosts the session (Admin) or joined one (Client).
+    /// Copied from the accepted config; the GUI reads it for the session badge.
+    pub session_role: SessionRole,
+    /// Cached `cfg.session_id()` — copied once at config-accept time so the
+    /// GUI and DNS-SD threads don't re-derive it.  Empty string until a config
+    /// has been accepted.
+    pub session_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -22,11 +29,17 @@ pub enum RouterStatus {
 
 impl AppState {
     pub fn new(initial_config: Option<DverseConfig>) -> Self {
+        let (session_role, session_id) = match &initial_config {
+            Some(cfg) => (cfg.session_role.clone(), cfg.session_id()),
+            None => (SessionRole::Admin, String::new()),
+        };
         Self {
             router_status: RouterStatus::Idle,
             admitted: Vec::new(),
             log: Vec::new(),
             staged_config: initial_config,
+            session_role,
+            session_id,
         }
     }
 


### PR DESCRIPTION
## Summary

Introduces a session primitive: each user creates a new session (Admin, their own CN becomes the session_id) or joins someone else's (Client, the admin's CN is the session_id). Two routers running different sessions on the same LAN no longer auto-mesh.

Full reasoning + rejected alternatives (filter at ACL, OU in mTLS cert, per-session service type, UUID identity): **`documents/adr/ADR-015.md`**.

## What's in this PR

- `bot_framework::config::SessionRole { Admin, Client { admin_cn } }`, with `#[serde(default)]` so old configs without the field load as `Admin`.
- `DverseConfig::session_id()` returns the admin's CN in both cases.
- DNS-SD TXT gains `session=<session_id>`, emitted in `announcing::mdns_sd_register`.
- `browsing::handle_resolved` filters peers immediately after the existing self-CN skip — skip with a single log line if `remote_session != my_session`.
- `MdnsHandle::publish` plumbs `session_id` through alongside `cn`.
- Router copies `session_role` + `session_id` into `AppState` before the first announcement.
- `Client` clients pre-admit their admin's CN at Phase 1 so the admin's router is reachable before any heartbeat arrives.
- `LoginForm` gains a `Create session` / `Join session` radio and a `join_admin_cn` text field. `show_main` renders a session badge above the existing status bar.

## What's deferred
- Persistence (#73 — still in-memory).
- Explicit admit / deny (#72 — auto-admit stays).
- ACL JSON byte-identical (#74 — `build_acl_json` not touched).

## Test plan
- [x] `cargo build --workspace` clean
- [x] Admin `alice` + Client `bob` joining alice → mesh
- [x] Admin `alice` + Admin `carol` (different sessions) → no mesh; log shows `skipping peer carol (session="carol", ours="alice")`
- [x] Old `config.toml` without `session_role` loads as Admin without re-login
