### PR TITLE
feat(logging): structured tracing across the workspace (closes #93)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "x509-parser",
  "zenoh",
 ]
@@ -1277,6 +1279,7 @@ dependencies = [
  "anyhow",
  "bot-framework",
  "tokio",
+ "tracing",
  "zenoh",
 ]
 
@@ -1287,6 +1290,7 @@ dependencies = [
  "anyhow",
  "bot-framework",
  "tokio",
+ "tracing",
  "zenoh",
 ]
 
@@ -7272,6 +7276,8 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "zenoh",
 ]
 

--- a/documents/adr/ADR-019.md
+++ b/documents/adr/ADR-019.md
@@ -1,0 +1,88 @@
+# ADR-019: Structured tracing for all log output across the workspace
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+Up to this point the workspace had three independent logging conventions:
+
+* `AppState::push_log(String)` — single source for log lines visible in the router GUI's log panel. Internally also emitted `eprintln!` so the same line could be seen in the terminal.
+* `eprintln!` / `println!` scattered across `bot_framework`, `discovery/*`, `ping`, `pong`, and the router's CLI paths — emitted to stderr only, never reached the GUI panel.
+* Zenoh's own log output (the underlying mesh's warn / error events) flowed via the `log` crate macros, which our process did not initialize a subscriber for, so most of it disappeared.
+
+This produced three classes of pain:
+
+* **Double maintenance.** Most diagnostically-useful events in `discovery` had a `push_log` and an `eprintln!` of nearly the same string, drifting whenever someone updated one without the other.
+* **Free-text only.** Numbers, CNs, endpoints, and other meaningful values were interpolated into format strings. There was no way to filter "all events about CN=test2" without grepping, and `RUST_LOG=zenoh_router::discovery=debug` did nothing.
+* **No verbosity control.** Zenoh's warn / error events from underlying transport failures were unreachable from outside the process, and there was no way to enable extra detail for a specific module without recompiling.
+
+GitHub issue #93 enumerated the acceptance criteria: default verbosity must surface Zenoh's own warn / error events; `RUST_LOG` must work as the override knob; default verbosity must not flood; same log line must appear in stderr and in the GUI panel without two call sites.
+
+This needs to land *before* the agent-topic-split refactor (#94 / PR #96) and the binary-size trim (PR #97) so that those PRs are reviewed against the final logging vocabulary instead of being forced to retain compatibility with the old `push_log` calls.
+
+## Decision
+
+Route every log line through `tracing::info!` / `warn!` / `error!` and install a global subscriber composed of two layers:
+
+* The standard `tracing_subscriber::fmt` layer to stderr, with timestamp, level, and target. Honors `RUST_LOG` via `EnvFilter::try_from_default_env`.
+* A new `GuiLogLayer` (in `src/zenoh_router/src/logging.rs`) implementing `tracing_subscriber::Layer`. Captures each event's message + structured fields, formats one line, and pushes it into `AppState.log` via `try_lock`. Using `try_lock` rather than `lock` is non-negotiable: any `tracing` call inside a closure that already holds the `AppState` mutex would deadlock if the layer blocked.
+
+Both layers stack on the global subscriber installed in `main()` for every binary in the workspace.
+
+**Call sites.** Every `push_log(format!(...))` and every diagnostic `eprintln!` / `println!` is replaced with a structured `tracing` macro. Values that used to be format-string interpolations become named fields:
+
+```rust
+// before
+state.lock().unwrap().push_log(format!(
+    "mDNS[mdns-sd]: resolved {} cn={remote_cn:?} session={remote_session:?} port={}",
+    info.get_fullname(), info.get_port()
+));
+
+// after
+info!(
+    fullname = %info.get_fullname(),
+    cn = %remote_cn,
+    session = %remote_session,
+    port = info.get_port(),
+    "mdns-sd resolved peer"
+);
+```
+
+`AppState::push_log` is no longer pub. It is an internal sink called only by `GuiLogLayer`. The previous duplicate `eprintln!` inside `push_log` is gone — the fmt layer already writes to stderr.
+
+**API ripple.** The discovery code path no longer needs `&Arc<Mutex<AppState>>` for the sole purpose of logging. `MdnsHandle::publish`, `mdns_sd_register`, `mdns_sd_start`, and `create_filtered_daemon` drop the parameter. Cleaner signatures across all four files.
+
+**User-facing stdout.** The `bot_framework` CLI's `println!`s (cert paths, session ZID, completion messages) stay as `println!`. They are deliberate output for human consumption, not logs.
+
+**Default verbosity.** The default `EnvFilter` pins `zenoh`, `rustls`, `mio`, `hyper`, `reqwest`, `zbus` at `warn` to prevent the floods those transports otherwise produce at info-level. Our own crates default to `info`.
+
+## Alternatives
+
+**Keep `push_log` and just route Zenoh's `log` crate output into it.** Rejected. Solves Zenoh's silence problem but leaves every existing `eprintln!` un-fixed and provides no structured-field story.
+
+**`log` crate facade across the workspace, no `tracing`.** Rejected. `log` has no structured fields and no per-event metadata that downstream layers (the GUI sink) can consume cleanly. `tracing` is the modern Rust-idiomatic choice for exactly the case where one event needs to go to multiple destinations with different formatting.
+
+**Two parallel calls — `tracing::info!` for stderr, `push_log` for GUI — accept the duplication.** Rejected. This is the current pain point. Doubling it to remove a deadlock risk is exactly the wrong trade-off.
+
+**Block (not `try_lock`) on the GUI mutex inside the layer.** Rejected. The router holds the `AppState` mutex around several non-trivial blocks (config update, ACL rebuild, peer-set diff); a blocking layer would deadlock the first time any of those blocks emits a tracing event. `try_lock` drops the line on contention — acceptable, because the fmt layer to stderr still captures it.
+
+## Consequences
+
+**Positive**
+* One call site per log event. No duplicate-format-string drift.
+* Structured fields throughout — `RUST_LOG=zenoh_router::discovery=debug` works, individual fields can be picked out of stderr by downstream tooling (`jq`-style filters with `tracing-subscriber`'s JSON formatter is one switch away).
+* Zenoh's own warn / error events surface in stderr at default verbosity, satisfying #93's first acceptance criterion.
+* GUI log panel renders the same events the terminal does, no maintenance gap.
+* Public surface of `discovery` (`MdnsHandle::publish` etc.) is cleaner — no `AppState` parameter for what was always a logging-only dependency.
+
+**Negative**
+* `try_lock` in `GuiLogLayer` can silently drop log lines under contention. In practice this only happens when the lock is held by a code path that itself emits a tracing event, which is the deadlock scenario the `try_lock` is preventing — so the dropped line would have been the one inside the recursion anyway. The fmt layer's stderr copy still captures it.
+* The default verbosity targets list (`zenoh`, `rustls`, ...) is curated. New noisy dependencies will need their own entry until someone notices the flood. This is the same cost any subscriber-installing process pays.
+* `tracing` adds two new direct dependencies (`tracing`, `tracing-subscriber`) to the workspace, both small and widely-used. Acceptable.
+* `bot_framework` CLI's `println!` exception is a convention readers need to know — calling them out in the logging module's doc comment is part of the change.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -24,3 +24,5 @@ tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 keyring = { version = "3", features = ["sync-secret-service", "apple-native", "windows-native"] }
 x509-parser = "0.18"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/src/bot_framework/src/announce.rs
+++ b/src/bot_framework/src/announce.rs
@@ -99,12 +99,12 @@ impl AgentAnnouncer {
                 let body = match serde_json::to_vec(&payload_template) {
                     Ok(b) => b,
                     Err(e) => {
-                        eprintln!("AgentAnnouncer: failed to serialize announce: {e}");
+                        tracing::warn!(error = %e, "AgentAnnouncer: failed to serialize announce");
                         continue;
                     }
                 };
                 if let Err(e) = session.put(&key_expr, body).await {
-                    eprintln!("AgentAnnouncer: put failed on {key_expr}: {e}");
+                    tracing::warn!(error = %e, key_expr = %key_expr, "AgentAnnouncer: put failed");
                 }
             }
         });

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -165,13 +165,13 @@ pub async fn acquire(cfg: &CertConfig) -> Result<(PathBuf, PathBuf, PathBuf)> {
         .build()
         .context("building HTTP client")?;
 
-    println!("Authenticating {} with Keycloak...", cfg.username);
+    tracing::info!(username = %cfg.username, "authenticating with Keycloak");
     let id_token = fetch_id_token(cfg, &client).await?;
 
-    println!("Generating keypair and CSR...");
+    tracing::info!("generating keypair and CSR");
     let (csr_pem, key_pem) = generate_csr()?;
 
-    println!("Requesting certificate from Step-CA...");
+    tracing::info!("requesting certificate from Step-CA");
     let (cert_pem, ca_pem) = sign_with_step_ca(cfg, &client, &csr_pem, &id_token).await?;
 
     tokio::fs::create_dir_all(&cfg.out_dir)
@@ -195,7 +195,7 @@ pub async fn acquire(cfg: &CertConfig) -> Result<(PathBuf, PathBuf, PathBuf)> {
             .context("setting key file permissions")?;
     }
 
-    println!("Certificate written to {}", c.display());
+    tracing::info!(path = %c.display(), "certificate written");
     Ok((c, k, ca))
 }
 
@@ -265,7 +265,7 @@ pub async fn bootstrap_ca_root(ca_url: &str, out_path: &Path) -> Result<String> 
     }
     tokio::fs::write(out_path, &pem).await.context("writing CA root PEM")?;
 
-    println!("CA root certificate bootstrapped to {}", out_path.display());
+    tracing::info!(path = %out_path.display(), "CA root certificate bootstrapped");
     Ok(pem)
 }
 

--- a/src/bot_framework/src/lib.rs
+++ b/src/bot_framework/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod announce;
 pub mod cert;
 pub mod config;
+pub mod logging;
 pub mod node;

--- a/src/bot_framework/src/logging.rs
+++ b/src/bot_framework/src/logging.rs
@@ -22,7 +22,10 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 /// Default filter applied when `RUST_LOG` isn't set.  Our own crates at
 /// `info`; Zenoh, rustls, and the usual noisy transitives at `warn` so the
 /// log doesn't flood at default verbosity but errors/warns still surface.
-const DEFAULT_FILTER: &str = concat!(
+///
+/// Public so the router (which installs its own subscriber to add the GUI
+/// layer) can apply exactly the same defaults without re-declaring them.
+pub const DEFAULT_FILTER: &str = concat!(
     "info,",
     "zenoh=warn,",
     "zenoh_runtime=warn,",

--- a/src/bot_framework/src/logging.rs
+++ b/src/bot_framework/src/logging.rs
@@ -1,0 +1,61 @@
+//! Tracing subscriber setup shared by every dverse binary.
+//!
+//! Without a subscriber installed, every `tracing::event!` call — including
+//! everything Zenoh, rustls, and our own crates emit — is silently dropped.
+//! That made silent failures like the inter-router mTLS handshake stalling
+//! (because the dialer never presented a client cert) invisible until
+//! someone read the code by hand.  This installs a sensible default so
+//! anything `warn` or `error` reaches stderr automatically.
+//!
+//! Quiet by default; set `RUST_LOG` to drill in:
+//!
+//! ```text
+//! RUST_LOG=zenoh=debug                    # chase a transport bug
+//! RUST_LOG=info,zenoh::transport=trace    # everything info, plus the
+//!                                         # noisy transport layer
+//! ```
+
+use std::sync::OnceLock;
+
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+/// Default filter applied when `RUST_LOG` isn't set.  Our own crates at
+/// `info`; Zenoh, rustls, and the usual noisy transitives at `warn` so the
+/// log doesn't flood at default verbosity but errors/warns still surface.
+const DEFAULT_FILTER: &str = concat!(
+    "info,",
+    "zenoh=warn,",
+    "zenoh_runtime=warn,",
+    "rustls=warn,",
+    "mio=warn,",
+    "hyper=warn,",
+    "reqwest=warn,",
+    "zbus=warn,",
+);
+
+/// Guards against double-install.  `tracing` only allows one global
+/// subscriber per process and panics on the second attempt; we want
+/// `init()` to be safe to call from any binary's `main` without coordination.
+static INIT: OnceLock<()> = OnceLock::new();
+
+/// Install the global tracing subscriber.  Idempotent: subsequent calls are
+/// no-ops.  Call this once near the top of `main()` in every binary.
+pub fn init() {
+    INIT.get_or_init(|| {
+        let filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+
+        // fmt layer writes to stderr by default — keeps stdout clean for
+        // anything pipeline-like and matches the existing `eprintln!` UX
+        // in `AppState::push_log`.
+        let fmt_layer = fmt::layer()
+            .with_target(true)
+            .with_level(true)
+            .compact();
+
+        let _ = tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt_layer)
+            .try_init();
+    });
+}

--- a/src/bot_framework/src/main.rs
+++ b/src/bot_framework/src/main.rs
@@ -81,6 +81,7 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    bot_framework::logging::init();
     let cli = Cli::parse();
 
     match cli.command {

--- a/src/ping/Cargo.toml
+++ b/src/ping/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = "1"
 bot-framework = { path = "../bot_framework" }
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
+tracing = "0.1"

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -7,11 +7,13 @@ use bot_framework::{
     config::DverseConfig,
     node::NodeConfig,
 };
+use tracing::{error, info};
 
 const NODE_NAME: &str = "ping";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    bot_framework::logging::init();
     let cfg = DverseConfig::load()
         .expect("No dverse config found. Run the router first to log in.");
 
@@ -20,14 +22,14 @@ async fn main() -> Result<()> {
     let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
     if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600), Some(&cfg.operator_cn())).await {
-        println!("[{NODE_NAME}] Acquiring certificate…");
+        info!(node = NODE_NAME, "acquiring certificate");
         let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
         cert::acquire(&cert_cfg).await?;
     } else {
-        println!("[{NODE_NAME}] Using cached certificate.");
+        info!(node = NODE_NAME, "using cached certificate");
     }
 
-    println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
+    info!(node = NODE_NAME, endpoint = %cfg.router_endpoint, "connecting to router");
     let session = NodeConfig::mtls(
         &cfg.router_endpoint,
         &ca_path,
@@ -38,7 +40,7 @@ async fn main() -> Result<()> {
     .await?;
 
     let cn = cfg.operator_cn();
-    println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
+    info!(node = NODE_NAME, cn = %cn, "connected, announcing");
     // Heartbeat announcer — runs in a background tokio task as long as this
     // handle is alive.  Drop = stop heartbeating; the router will mark the
     // agent Degraded → Offline → evict it on its own timer.
@@ -61,7 +63,7 @@ async fn main() -> Result<()> {
     loop {
         seq += 1;
         let msg = format!("ping #{seq}");
-        println!("[{NODE_NAME}] → {msg}");
+        info!(node = NODE_NAME, dir = "tx", payload = %msg, "sending");
         session
             .put("dverse/ping", msg)
             .await
@@ -72,13 +74,16 @@ async fn main() -> Result<()> {
                 match sample {
                     Ok(s) => {
                         let payload = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
-                        println!("[{NODE_NAME}] ← {payload}");
+                        info!(node = NODE_NAME, dir = "rx", payload = %payload, "received");
                     }
-                    Err(e) => return Err(anyhow::anyhow!("recv: {e}")),
+                    Err(e) => {
+                        error!(error = %e, "pong subscriber recv error");
+                        return Err(anyhow::anyhow!("recv: {e}"));
+                    }
                 }
             }
             _ = tokio::time::sleep(Duration::from_secs(2)) => {
-                println!("[{NODE_NAME}] (no pong yet)");
+                info!(node = NODE_NAME, "no pong within timeout");
             }
         }
 

--- a/src/pong/Cargo.toml
+++ b/src/pong/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = "1"
 bot-framework = { path = "../bot_framework" }
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
+tracing = "0.1"

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -7,11 +7,13 @@ use bot_framework::{
     config::DverseConfig,
     node::NodeConfig,
 };
+use tracing::info;
 
 const NODE_NAME: &str = "pong";
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    bot_framework::logging::init();
     let cfg = DverseConfig::load()
         .expect("No dverse config found. Run the router first to log in.");
 
@@ -20,14 +22,14 @@ async fn main() -> Result<()> {
     let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
     if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600), Some(&cfg.operator_cn())).await {
-        println!("[{NODE_NAME}] Acquiring certificate…");
+        info!(node = NODE_NAME, "acquiring certificate");
         let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
         cert::acquire(&cert_cfg).await?;
     } else {
-        println!("[{NODE_NAME}] Using cached certificate.");
+        info!(node = NODE_NAME, "using cached certificate");
     }
 
-    println!("[{NODE_NAME}] Connecting to {}…", cfg.router_endpoint);
+    info!(node = NODE_NAME, endpoint = %cfg.router_endpoint, "connecting to router");
     let session = NodeConfig::mtls(
         &cfg.router_endpoint,
         &ca_path,
@@ -38,7 +40,7 @@ async fn main() -> Result<()> {
     .await?;
 
     let cn = cfg.operator_cn();
-    println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
+    info!(node = NODE_NAME, cn = %cn, "connected, announcing");
     // Heartbeat announcer — runs in a background tokio task as long as this
     // handle is alive.  Drop = stop heartbeating; the router will mark the
     // agent Degraded → Offline → evict it on its own timer.
@@ -57,13 +59,13 @@ async fn main() -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
 
-    println!("[{NODE_NAME}] Listening for pings…");
+    info!(node = NODE_NAME, "listening for pings");
     while let Ok(sample) = ping_sub.recv_async().await {
         let payload = String::from_utf8_lossy(&sample.payload().to_bytes()).into_owned();
-        println!("[{NODE_NAME}] ← {payload}");
+        info!(node = NODE_NAME, dir = "rx", payload = %payload, "received");
 
         let reply = format!("pong (echoing: {payload})");
-        println!("[{NODE_NAME}] → {reply}");
+        info!(node = NODE_NAME, dir = "tx", payload = %reply, "sending");
         session
             .put("dverse/pong", reply)
             .await

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -20,3 +20,5 @@ tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 mdns-sd = "0.13"
 if-addrs = "0.13"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -13,12 +13,9 @@ mod announcing;
 mod browsing;
 mod common;
 
-use std::sync::{Arc, Mutex};
-
 use mdns_sd::ServiceDaemon;
 use tokio::sync::watch;
-
-use crate::state::AppState;
+use tracing::info;
 
 use self::common::create_filtered_daemon;
 
@@ -31,14 +28,9 @@ pub struct MdnsHandle {
 }
 
 impl MdnsHandle {
-    pub fn publish(
-        cn: &str,
-        session_id: &str,
-        port: u16,
-        state: &Arc<Mutex<AppState>>,
-    ) -> Option<Self> {
-        state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
-        mdns_sd_start(cn, session_id, port, state)
+    pub fn publish(cn: &str, session_id: &str, port: u16) -> Option<Self> {
+        info!("mDNS: using mdns-sd backend");
+        mdns_sd_start(cn, session_id, port)
     }
 }
 
@@ -56,15 +48,10 @@ impl Drop for MdnsSdSession {
     }
 }
 
-fn mdns_sd_start(
-    cn: &str,
-    session_id: &str,
-    port: u16,
-    state: &Arc<Mutex<AppState>>,
-) -> Option<MdnsHandle> {
-    let daemon = create_filtered_daemon(state)?;
-    let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port, state)?;
-    let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id, state)?;
+fn mdns_sd_start(cn: &str, session_id: &str, port: u16) -> Option<MdnsHandle> {
+    let daemon = create_filtered_daemon()?;
+    let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port)?;
+    let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id)?;
     Some(MdnsHandle {
         _inner: MdnsSdSession { daemon, fullname },
         peer_rx,

--- a/src/zenoh_router/src/discovery/announcing.rs
+++ b/src/zenoh_router/src/discovery/announcing.rs
@@ -5,11 +5,9 @@
 //! the SRV target via `ServiceInfo::new`, no avahi-daemon coupling.
 
 use std::net::IpAddr;
-use std::sync::{Arc, Mutex};
 
 use mdns_sd::{ServiceDaemon, ServiceInfo};
-
-use crate::state::AppState;
+use tracing::{info, warn};
 
 use super::common::{
     detect_lan_ipv4, instance_name, srv_host_name, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
@@ -23,18 +21,15 @@ pub(super) fn mdns_sd_register(
     cn: &str,
     session_id: &str,
     port: u16,
-    state: &Arc<Mutex<AppState>>,
 ) -> Option<String> {
     let instance = instance_name(cn);
     let host = srv_host_name(cn);
     let lan_ip = detect_lan_ipv4();
 
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: LAN IP={}",
-        lan_ip
-            .map(|ip| ip.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
-    ));
+    info!(
+        lan_ip = ?lan_ip.map(|ip| ip.to_string()),
+        "mdns-sd detected LAN IP"
+    );
 
     // TXT props: always `cn` + `session`, optionally `ip` for cross-stack
     // address recovery.
@@ -67,28 +62,25 @@ pub(super) fn mdns_sd_register(
     let svc = match svc_result {
         Ok(s) => s,
         Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: service info error ({e}); peer discovery disabled"
-            ));
+            warn!(error = %e, "mdns-sd service info error; peer discovery disabled");
             return None;
         }
     };
 
     let fullname = svc.get_fullname().to_string();
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: registering {fullname} on port {port}"
-    ));
+    info!(fullname = %fullname, port, "mdns-sd registering");
 
     if let Err(e) = daemon.register(svc) {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: register failed ({e}); peer discovery disabled"
-        ));
+        warn!(error = %e, "mdns-sd register failed; peer discovery disabled");
         return None;
     }
 
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: published {instance} on {SERVICE_TYPE} port {port}"
-    ));
+    info!(
+        instance = %instance,
+        service_type = SERVICE_TYPE,
+        port,
+        "mdns-sd published service"
+    );
 
     Some(fullname)
 }

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -1,12 +1,9 @@
 //! Browsing side of DNS-SD discovery — watches for other `_dverse._tcp`
 //! services on the LAN and exposes their endpoints as a watch channel.
 
-use std::sync::{Arc, Mutex};
-
 use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use tokio::sync::watch;
-
-use crate::state::AppState;
+use tracing::{info, warn};
 
 use super::common::{
     is_unroutable, zenoh_tls_endpoint, PeerRegistry, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
@@ -20,30 +17,26 @@ pub(super) fn mdns_sd_start(
     daemon: &ServiceDaemon,
     my_cn: &str,
     my_session: &str,
-    state: &Arc<Mutex<AppState>>,
 ) -> Option<watch::Receiver<Vec<String>>> {
     let browse_rx = match daemon.browse(SERVICE_TYPE) {
         Ok(rx) => rx,
         Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: browse failed ({e}); peer discovery disabled"
-            ));
+            warn!(error = %e, "mdns-sd browse failed; peer discovery disabled");
             return None;
         }
     };
-    state.lock().unwrap().push_log("mDNS[mdns-sd]: browse started".to_string());
+    info!("mdns-sd browse started");
 
     let (registry, peer_rx) = PeerRegistry::new();
     let my_cn = my_cn.to_string();
     let my_session = my_session.to_string();
-    let state = Arc::clone(state);
 
     std::thread::spawn(move || {
         let mut registry = registry;
         while let Ok(event) = browse_rx.recv() {
-            handle_event(event, &my_cn, &my_session, &state, &mut registry);
+            handle_event(event, &my_cn, &my_session, &mut registry);
         }
-        state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
+        info!("mdns-sd browse loop exited");
     });
 
     Some(peer_rx)
@@ -53,34 +46,26 @@ fn handle_event(
     event: ServiceEvent,
     my_cn: &str,
     my_session: &str,
-    state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
     match event {
         ServiceEvent::ServiceFound(svc_type, fullname) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
-            ));
+            info!(svc_type = %svc_type, fullname = %fullname, "mdns-sd service found");
         }
         ServiceEvent::ServiceResolved(info) => {
-            handle_resolved(info, my_cn, my_session, state, registry)
+            handle_resolved(info, my_cn, my_session, registry)
         }
         ServiceEvent::ServiceRemoved(_, fullname) => {
-            state
-                .lock()
-                .unwrap()
-                .push_log(format!("mDNS[mdns-sd]: removed {fullname:?}"));
+            info!(fullname = %fullname, "mdns-sd service removed");
             if let Some(endpoints) = registry.remove(&fullname) {
-                state.lock().unwrap().push_log(format!(
-                    "Peer router left: {}",
-                    endpoints.first().map(String::as_str).unwrap_or(&fullname),
-                ));
+                info!(
+                    target_endpoint = %endpoints.first().map(String::as_str).unwrap_or(&fullname),
+                    "peer router left"
+                );
             }
         }
         other => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: event {other:?}"
-            ));
+            info!(event = ?other, "mdns-sd other event");
         }
     }
 }
@@ -89,22 +74,22 @@ fn handle_resolved(
     info: ServiceInfo,
     my_cn: &str,
     my_session: &str,
-    state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
     let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
     let remote_session = info.get_property_val_str(TXT_KEY_SESSION).unwrap_or_default();
     let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} session={remote_session:?} addrs={addrs:?} port={}",
-        info.get_fullname(),
-        info.get_port(),
-    ));
+    info!(
+        fullname = %info.get_fullname(),
+        cn = %remote_cn,
+        session = %remote_session,
+        ?addrs,
+        port = info.get_port(),
+        "mdns-sd resolved peer"
+    );
 
     if remote_cn.is_empty() || remote_cn == my_cn {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
-        ));
+        info!(cn = %remote_cn, "mdns-sd skipping self or empty CN");
         return;
     }
 
@@ -116,44 +101,43 @@ fn handle_resolved(
     // value, and the failure mode (older binary, manual `dns-sd` test) is
     // diagnostically different from "different session running on the LAN".
     if remote_session.is_empty() {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: skipping peer {remote_cn} — no session= TXT key (likely older or non-DVerse announcement)"
-        ));
+        info!(
+            cn = %remote_cn,
+            "mdns-sd skipping peer with no session= TXT key (likely older or non-DVerse announcement)"
+        );
         return;
     }
     if remote_session != my_session {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
-        ));
+        info!(
+            cn = %remote_cn,
+            session = %remote_session,
+            ours = %my_session,
+            "mdns-sd skipping peer in different session"
+        );
         return;
     }
 
-    let endpoints = endpoints_for(&info, remote_cn, state);
+    let endpoints = endpoints_for(&info, remote_cn);
     if endpoints.is_empty() {
         return;
     }
 
     if registry.set(info.get_fullname().to_string(), endpoints.clone()) {
-        state.lock().unwrap().push_log(format!(
-            "Discovered peer router: {} (+{} addr) (CN={remote_cn})",
-            endpoints[0],
-            endpoints.len() - 1,
-        ));
+        info!(
+            endpoint = %endpoints[0],
+            extra_count = endpoints.len() - 1,
+            cn = %remote_cn,
+            "discovered peer router"
+        );
     } else {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: peer {remote_cn} unchanged, ignoring duplicate"
-        ));
+        info!(cn = %remote_cn, "mdns-sd peer unchanged, ignoring duplicate");
     }
 }
 
 /// Convert a resolved `ServiceInfo` into the list of Zenoh endpoints we'll
 /// connect to.  Prefers the peer's TXT `ip=` over whatever SRV/A resolution
 /// returned (see [`super::common::TXT_KEY_IP`] for why).
-fn endpoints_for(
-    info: &ServiceInfo,
-    remote_cn: &str,
-    state: &Arc<Mutex<AppState>>,
-) -> Vec<String> {
+fn endpoints_for(info: &ServiceInfo, remote_cn: &str) -> Vec<String> {
     let port = info.get_port();
 
     let txt_ipv4 = info
@@ -162,9 +146,7 @@ fn endpoints_for(
         .filter(|ip| !ip.is_loopback() && !ip.is_link_local());
 
     if let Some(ipv4) = txt_ipv4 {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: using TXT ip={ipv4} for {remote_cn}"
-        ));
+        info!(ip = %ipv4, cn = %remote_cn, "mdns-sd using TXT ip");
         return vec![zenoh_tls_endpoint(std::net::IpAddr::V4(ipv4), port)];
     }
 
@@ -173,9 +155,7 @@ fn endpoints_for(
         .iter()
         .filter_map(|a| {
             if is_unroutable(a) {
-                state.lock().unwrap().push_log(format!(
-                    "mDNS[mdns-sd]: skipping unroutable addr {a}"
-                ));
+                info!(addr = %a, "mdns-sd skipping unroutable addr");
                 return None;
             }
             match a {
@@ -187,11 +167,11 @@ fn endpoints_for(
     endpoints.sort();
 
     if endpoints.is_empty() {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: resolved {remote_cn} but no routable IPv4 \
-             (no TXT ip, addrs={:?}); skipping",
-            info.get_addresses().iter().collect::<Vec<_>>(),
-        ));
+        warn!(
+            cn = %remote_cn,
+            addrs = ?info.get_addresses().iter().collect::<Vec<_>>(),
+            "mdns-sd resolved peer with no routable IPv4; skipping"
+        );
     }
 
     endpoints

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -7,12 +7,10 @@
 
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, UdpSocket};
-use std::sync::{Arc, Mutex};
 
 use mdns_sd::{IfKind, ServiceDaemon};
 use tokio::sync::watch;
-
-use crate::state::AppState;
+use tracing::{info, warn};
 
 // ── Service identity ─────────────────────────────────────────────────────────
 
@@ -107,18 +105,16 @@ pub(super) fn is_unroutable(addr: &IpAddr) -> bool {
 /// Create a new mdns-sd daemon with interface filters applied.
 /// Returns `None` (and logs) if the daemon couldn't be initialised — typically
 /// because UDP 5353 is bound by another process in an incompatible way.
-pub(super) fn create_filtered_daemon(state: &Arc<Mutex<AppState>>) -> Option<ServiceDaemon> {
+pub(super) fn create_filtered_daemon() -> Option<ServiceDaemon> {
     let daemon = match ServiceDaemon::new() {
         Ok(d) => d,
         Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: daemon init failed ({e}); peer discovery disabled"
-            ));
+            warn!(error = %e, "mdns-sd daemon init failed; peer discovery disabled");
             return None;
         }
     };
-    state.lock().unwrap().push_log("mDNS[mdns-sd]: daemon started".to_string());
-    apply_interface_filters(&daemon, state);
+    info!("mdns-sd daemon started");
+    apply_interface_filters(&daemon);
     Some(daemon)
 }
 
@@ -133,7 +129,7 @@ pub(super) fn create_filtered_daemon(state: &Arc<Mutex<AppState>>) -> Option<Ser
 ///     but reach no remote peer; worse, on Windows a low-metric Npcap
 ///     adapter silently swallows our PTR responses entirely.
 ///   * Link-local IPv4 (169.254.0.0/16) — same story; no peer is there.
-fn apply_interface_filters(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>) {
+fn apply_interface_filters(daemon: &ServiceDaemon) {
     let _ = daemon.disable_interface(IfKind::IPv6);
 
     let Ok(ifaces) = if_addrs::get_if_addrs() else { return };
@@ -146,11 +142,7 @@ fn apply_interface_filters(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>)
         if !already_disabled.insert(iface.name.clone()) {
             continue;
         }
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: disabling virtual/link-local iface {} ({})",
-            iface.name,
-            iface.ip(),
-        ));
+        info!(iface = %iface.name, ip = %iface.ip(), "mdns-sd disabling virtual/link-local iface");
         let _ = daemon.disable_interface(IfKind::Name(iface.name.clone()));
     }
 }

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -269,9 +269,12 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         return;
     }
 
-    let mut st = state.lock().unwrap();
-    st.push_log(format!("Signed in as {}. Bootstrapping…", cfg.username));
-    st.staged_config = Some(cfg);
+    let username = cfg.username.clone();
+    {
+        let mut st = state.lock().unwrap();
+        st.staged_config = Some(cfg);
+    }
+    tracing::info!(username = %username, "signed in, bootstrapping");
     form.error = None;
 }
 

--- a/src/zenoh_router/src/logging.rs
+++ b/src/zenoh_router/src/logging.rs
@@ -27,26 +27,14 @@ use tracing_subscriber::{fmt, EnvFilter, Layer};
 
 use crate::state::AppState;
 
-/// Default RUST_LOG when the env var isn't set.  Mirrors
-/// `bot_framework::logging::init`'s defaults — kept in sync intentionally so
-/// the router and the CLI agents log at the same verbosity by default.
-const DEFAULT_FILTER: &str = concat!(
-    "info,",
-    "zenoh=warn,",
-    "zenoh_runtime=warn,",
-    "rustls=warn,",
-    "mio=warn,",
-    "hyper=warn,",
-    "reqwest=warn,",
-    "zbus=warn,",
-);
-
 /// Install the global tracing subscriber.  Must be called once, early, from
 /// the router binary's `main` — `bot_framework::logging::init` is NOT used
-/// here because we want the extra GUI layer.
+/// here because we want the extra GUI layer.  The default filter is sourced
+/// from `bot_framework::logging::DEFAULT_FILTER` so the CLI agents and the
+/// router stay in lockstep on verbosity defaults.
 pub fn init_with_gui_sink(state: Arc<Mutex<AppState>>) {
     let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+        .unwrap_or_else(|_| EnvFilter::new(bot_framework::logging::DEFAULT_FILTER));
 
     let fmt_layer = fmt::layer().with_target(true).with_level(true).compact();
     let gui_layer = GuiLogLayer { state };

--- a/src/zenoh_router/src/logging.rs
+++ b/src/zenoh_router/src/logging.rs
@@ -1,0 +1,139 @@
+//! Router-side tracing setup.
+//!
+//! The router has a GUI log panel that needs to display whatever the rest of
+//! the codebase logs.  Before this module the panel was fed by direct
+//! `AppState::push_log` calls scattered across every file; now all those call
+//! sites use `tracing::info!` etc., and a custom [`GuiLogLayer`] subscribed
+//! to the global subscriber routes each event into the same `AppState.log`
+//! buffer the GUI already reads.
+//!
+//! Two layers stack on the subscriber:
+//!   * `tracing_subscriber::fmt::layer()` — stderr, full level / target /
+//!     fields; what you see in the terminal you ran `cargo run` in.
+//!   * [`GuiLogLayer`] — append a compact rendered line to `AppState.log`;
+//!     what shows up in the bottom panel of the desktop window.
+//!
+//! Both layers receive every event that passes the env filter, so the same
+//! line shows up in stderr AND in the GUI without per-call-site duplication.
+
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, EnvFilter, Layer};
+
+use crate::state::AppState;
+
+/// Default RUST_LOG when the env var isn't set.  Mirrors
+/// `bot_framework::logging::init`'s defaults — kept in sync intentionally so
+/// the router and the CLI agents log at the same verbosity by default.
+const DEFAULT_FILTER: &str = concat!(
+    "info,",
+    "zenoh=warn,",
+    "zenoh_runtime=warn,",
+    "rustls=warn,",
+    "mio=warn,",
+    "hyper=warn,",
+    "reqwest=warn,",
+    "zbus=warn,",
+);
+
+/// Install the global tracing subscriber.  Must be called once, early, from
+/// the router binary's `main` — `bot_framework::logging::init` is NOT used
+/// here because we want the extra GUI layer.
+pub fn init_with_gui_sink(state: Arc<Mutex<AppState>>) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_FILTER));
+
+    let fmt_layer = fmt::layer().with_target(true).with_level(true).compact();
+    let gui_layer = GuiLogLayer { state };
+
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(gui_layer)
+        .try_init();
+}
+
+/// A `tracing` Layer that renders each event to a single line and appends it
+/// to `AppState.log`.
+///
+/// Uses `try_lock` so a tracing call from inside a code path that already
+/// holds the AppState mutex degrades to "log this one to stderr only" instead
+/// of deadlocking.  In practice the migration is structured so this never
+/// happens, but the fallback keeps the program correct under contention.
+pub struct GuiLogLayer {
+    state: Arc<Mutex<AppState>>,
+}
+
+impl<S> Layer<S> for GuiLogLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+
+        let level = event.metadata().level();
+        let mut line = String::new();
+        // Prefix warn/error so they're scannable in the GUI even without colour.
+        match *level {
+            tracing::Level::WARN => line.push_str("[WARN] "),
+            tracing::Level::ERROR => line.push_str("[ERROR] "),
+            _ => {}
+        }
+        line.push_str(&visitor.message);
+        for f in &visitor.fields {
+            line.push(' ');
+            line.push_str(f);
+        }
+
+        if let Ok(mut s) = self.state.try_lock() {
+            s.push_log(line);
+        }
+        // If we couldn't lock right now, the fmt layer still wrote this to
+        // stderr; we lose it from the GUI panel but the program proceeds.
+    }
+}
+
+/// Captures the event's message (the literal format string) and every
+/// structured field.  Rendered as `"message k=v k=v"`.
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+    fields: Vec<String>,
+}
+
+impl MessageVisitor {
+    fn put(&mut self, name: &str, value: &str) {
+        if name == "message" {
+            self.message = value.to_string();
+        } else {
+            self.fields.push(format!("{name}={value}"));
+        }
+    }
+}
+
+impl Visit for MessageVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.put(field.name(), value);
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.put(field.name(), &format!("{value:?}"));
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.put(field.name(), &value.to_string());
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.put(field.name(), &value.to_string());
+    }
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.put(field.name(), &value.to_string());
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.put(field.name(), &value.to_string());
+    }
+}

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -1,6 +1,7 @@
 mod constants;
 mod discovery;
 mod gui;
+mod logging;
 mod router;
 mod state;
 
@@ -32,6 +33,7 @@ fn run_normal() {
         Screen::Login(LoginForm::default())
     };
     let state = Arc::new(Mutex::new(AppState::new(existing_config)));
+    logging::init_with_gui_sink(Arc::clone(&state));
     let bg_state = Arc::clone(&state);
     std::thread::spawn(move || {
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -69,11 +71,13 @@ fn run_demo() {
         NodeInfo { cn: "alice".into(), last_seen: now, agents: alice_agents },
     );
 
-    state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
-    state.push_log("[demo] Session admin: alice");
-    state.push_log("[demo] Auto-admitted: alice");
-    state.push_log("[demo] Auto-admitted: mybot");
-    launch_gui(Arc::new(Mutex::new(state)), Screen::Main);
+    let state = Arc::new(Mutex::new(state));
+    logging::init_with_gui_sink(Arc::clone(&state));
+    tracing::info!("[demo] router started on tcp/0.0.0.0:7447");
+    tracing::info!("[demo] session admin: alice");
+    tracing::info!("[demo] auto-admitted alice");
+    tracing::info!("[demo] auto-admitted mybot");
+    launch_gui(state, Screen::Main);
 }
 
 fn launch_gui(state: Arc<Mutex<AppState>>, screen: Screen) {

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -7,6 +7,7 @@ use bot_framework::announce::AgentAnnounce;
 use bot_framework::cert;
 use bot_framework::config::{DverseConfig, SessionRole};
 use tokio::sync::watch;
+use tracing::{error, info, warn};
 use zenoh::Session;
 
 use crate::constants::AGENT_HEARTBEAT_INTERVAL;
@@ -34,7 +35,7 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
         let cfg = if let Some(c) = current_cfg.take() {
             c
         } else {
-            state.lock().unwrap().push_log("Waiting for configuration…");
+            info!("waiting for configuration");
             let cfg = loop {
                 {
                     let mut s = state.lock().unwrap();
@@ -61,7 +62,6 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                     &cfg.operator_cn(),
                     &session_id,
                     crate::constants::ROUTER_PORT,
-                    &state,
                 ) {
                     peer_rx = handle.peer_rx.clone();
                     _mdns = Some(handle);
@@ -72,53 +72,56 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
         };
 
         // Pre-admit operator's CN so all local agents can communicate immediately.
+        // When joining someone else's session, pre-admit the admin's CN too,
+        // so the admin's router (which carries that cert) can connect and
+        // form the mesh before we've heard a heartbeat from any of their agents.
         let operator_cn = cfg.operator_cn();
-        {
+        let (newly_admitted_operator, newly_admitted_admin) = {
             let mut st = state.lock().unwrap();
-            if !st.admitted.contains(&operator_cn) {
+            let added_op = if !st.admitted.contains(&operator_cn) {
                 st.admitted.push(operator_cn.clone());
-                st.push_log(format!("Pre-admitted operator CN: {operator_cn}"));
-            }
-            // When joining someone else's session, pre-admit the admin's CN too,
-            // so the admin's router (which carries that cert) can connect and
-            // form the mesh before we've heard a heartbeat from any of their
-            // agents.
-            if let SessionRole::Client { admin_cn } = &cfg.session_role {
+                true
+            } else {
+                false
+            };
+            let added_admin = if let SessionRole::Client { admin_cn } = &cfg.session_role {
                 if !admin_cn.is_empty() && !st.admitted.contains(admin_cn) {
                     st.admitted.push(admin_cn.clone());
-                    st.push_log(format!("Pre-admitted session admin CN: {admin_cn}"));
+                    Some(admin_cn.clone())
+                } else {
+                    None
                 }
-            }
+            } else {
+                None
+            };
+            (added_op, added_admin)
+        };
+        if newly_admitted_operator {
+            info!(cn = %operator_cn, "pre-admitted operator CN");
+        }
+        if let Some(admin_cn) = newly_admitted_admin {
+            info!(cn = %admin_cn, "pre-admitted session admin CN");
         }
 
         // ── Phase 2: bootstrap CA root, then acquire/reuse cert ─────────────
-        {
-            let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Acquiring;
-            s.push_log("Bootstrapping CA root certificate…");
-        }
+        state.lock().unwrap().router_status = RouterStatus::Acquiring;
+        info!("bootstrapping CA root certificate");
 
         let ca_root_path = std::path::PathBuf::from(&cfg.ca_root_pem_path);
         if let Err(e) = cert::bootstrap_ca_root(&cfg.ca_url, &ca_root_path).await {
-            let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Error(e.to_string());
-            s.push_log(format!("CA bootstrap error: {e}"));
+            state.lock().unwrap().router_status = RouterStatus::Error(e.to_string());
+            warn!(error = %e, ca_url = %cfg.ca_url, "CA root bootstrap failed");
             tokio::time::sleep(Duration::from_secs(2)).await;
             continue;
         }
 
-        {
-            state.lock().unwrap().push_log("Checking router certificate…");
-        }
+        info!("checking router certificate");
 
-        let cert_result = acquire_or_reuse(&cfg).await;
-
-        let (cert_p, key_p, ca_p) = match cert_result {
+        let (cert_p, key_p, ca_p) = match acquire_or_reuse(&cfg).await {
             Ok(paths) => paths,
             Err(e) => {
-                let mut s = state.lock().unwrap();
-                s.router_status = RouterStatus::Error(e.to_string());
-                s.push_log(format!("Certificate error: {e}"));
+                state.lock().unwrap().router_status = RouterStatus::Error(e.to_string());
+                error!(error = %e, "router certificate acquire/renew failed");
                 // Don't retry automatically — wait for the user to fix config.
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 continue;
@@ -128,41 +131,45 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
         // ── Phase 3: run session loop (restarts on ACL or peer change) ──────
         let admitted = state.lock().unwrap().admitted.clone();
         let peers = peer_rx.borrow().clone();
+        info!(
+            listen = %cfg.router_listen,
+            peer_count = peers.len(),
+            admitted_count = admitted.len(),
+            cert = %cert_p.display(),
+            key = %key_p.display(),
+            ca = %ca_p.display(),
+            "building Zenoh config",
+        );
+        if !peers.is_empty() {
+            info!(?peers, "connecting to peer routers");
+        }
         let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted, &peers) {
             Ok(c) => c,
             Err(e) => {
-                let mut s = state.lock().unwrap();
-                s.router_status = RouterStatus::Error(e.to_string());
-                s.push_log(format!("Config error: {e}"));
+                state.lock().unwrap().router_status = RouterStatus::Error(e.to_string());
+                error!(error = %e, "build_zenoh_config failed");
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 current_cfg = Some(cfg);
                 continue;
             }
         };
 
-        {
-            let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Starting;
-            s.push_log(format!("Opening Zenoh router on {}…", cfg.router_listen));
-        }
+        state.lock().unwrap().router_status = RouterStatus::Starting;
+        info!(listen = %cfg.router_listen, "opening Zenoh router");
 
         let session = match zenoh::open(config).await {
             Ok(s) => s,
             Err(e) => {
-                let mut s = state.lock().unwrap();
-                s.router_status = RouterStatus::Error(e.to_string());
-                s.push_log(format!("Zenoh open error: {e}"));
+                state.lock().unwrap().router_status = RouterStatus::Error(e.to_string());
+                error!(error = %e, "zenoh::open failed");
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 current_cfg = Some(cfg);
                 continue;
             }
         };
 
-        {
-            let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Running;
-            s.push_log("Router running.");
-        }
+        state.lock().unwrap().router_status = RouterStatus::Running;
+        info!(zid = %session.zid(), "router session running");
 
         // Wall-clock stale-eviction task — spawned once.  Drives the
         // Online→Degraded→Offline ladder and removes agents whose heartbeats
@@ -180,11 +187,8 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                         let mut st = state_for_reap.lock().unwrap();
                         st.reap_stale(now)
                     };
-                    if !evicted.is_empty() {
-                        let mut st = state_for_reap.lock().unwrap();
-                        for (cn, name) in evicted {
-                            st.push_log(format!("Agent stale-evicted: {cn}/{name}"));
-                        }
+                    for (cn, name) in evicted {
+                        info!(cn = %cn, agent = %name, "agent stale-evicted");
                     }
                 }
             });
@@ -193,16 +197,13 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
 
         // session_loop returns when the admitted list or peer set changes.
         if let Err(e) = session_loop(&session, Arc::clone(&state), peer_rx.clone()).await {
-            state.lock().unwrap().push_log(format!("Session error: {e}"));
+            warn!(error = %e, "session loop errored");
         }
 
         let _ = session.close().await;
 
-        {
-            let mut s = state.lock().unwrap();
-            s.router_status = RouterStatus::Reloading;
-            s.push_log("Reloading router with updated ACL…");
-        }
+        state.lock().unwrap().router_status = RouterStatus::Reloading;
+        info!("reloading router with updated ACL");
 
         current_cfg = Some(cfg);
     }
@@ -266,9 +267,7 @@ async fn session_loop(
                                     .unwrap_or("?")
                                     .to_string();
                                 if seen_legacy.insert(cn_for_log.clone()) {
-                                    state.lock().unwrap().push_log(format!(
-                                        "ignored unparseable announce from CN={cn_for_log}"
-                                    ));
+                                    warn!(cn = %cn_for_log, "ignored unparseable announce");
                                 }
                                 continue;
                             }
@@ -277,16 +276,21 @@ async fn session_loop(
                         let cn = ann.cn.clone();
                         if cn.is_empty() { continue; }
                         let now = Instant::now();
-                        let mut st = state.lock().unwrap();
-
-                        // 1. Agent inventory — never triggers restart.
-                        st.upsert_agent(&ann, now);
-
-                        // 2. Auto-admit — triggers restart so the new CN
-                        // lands in the rebuilt ACL.
-                        if !st.admitted.contains(&cn) {
-                            st.admitted.push(cn.clone());
-                            st.push_log(format!("Auto-admitted CN: {cn}"));
+                        let needs_restart = {
+                            let mut st = state.lock().unwrap();
+                            // 1. Agent inventory — never triggers restart.
+                            st.upsert_agent(&ann, now);
+                            // 2. Auto-admit — triggers restart so the new CN
+                            // lands in the rebuilt ACL.
+                            if !st.admitted.contains(&cn) {
+                                st.admitted.push(cn.clone());
+                                true
+                            } else {
+                                false
+                            }
+                        };
+                        if needs_restart {
+                            info!(cn = %cn, "auto-admitted CN");
                             return Ok(());
                         }
                     }
@@ -294,7 +298,7 @@ async fn session_loop(
                 }
             }
             Ok(()) = peer_rx.changed() => {
-                state.lock().unwrap().push_log("Peer set changed, reloading router…");
+                info!("peer set changed, reloading router");
                 return Ok(());
             }
         }

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -100,9 +100,12 @@ impl AppState {
         }
     }
 
+    /// Append a single line to the in-memory log ring that backs the GUI's
+    /// bottom panel.  Now called only by `logging::GuiLogLayer` — business
+    /// code uses `tracing::info!` / `warn!` / `error!` and the layer routes
+    /// each event here.  Capped at 200 lines.
     pub fn push_log(&mut self, msg: impl Into<String>) {
         let entry = msg.into();
-        eprintln!("{entry}");
         if self.log.len() >= 200 {
             self.log.remove(0);
         }


### PR DESCRIPTION
## Summary

Converts every diagnostic log line in the workspace to `tracing::info!` / `warn!` / `error!` and installs a global subscriber composed of two layers: the standard `tracing_subscriber::fmt` layer to stderr (honoring `RUST_LOG`) and a new `GuiLogLayer` that captures events into `AppState.log` for the router's GUI panel.

One call site per log event. Numbers, CNs, and endpoints become structured fields instead of format-string interpolations.

Closes #93.

Full reasoning + alternatives (keep `push_log`, use `log` instead of `tracing`, blocking lock in the GUI layer): **`documents/adr/ADR-019.md`**.

## Acceptance criteria (#93)

- [x] Default verbosity surfaces Zenoh's own warn / error events — the subscriber is installed at process start.
- [x] `RUST_LOG` override works — `EnvFilter::try_from_default_env` honors the env var.
- [x] No log floods at default verbosity — `zenoh` / `rustls` / `mio` / `hyper` / `reqwest` / `zbus` pinned at `warn`.

## What changed

- New `zenoh_router::logging` module with `GuiLogLayer`. Implements `tracing_subscriber::Layer`. Captures each event's message + fields, formats one line, pushes into `AppState.log` via `try_lock` (so the layer never deadlocks if a tracing call fires while the mutex is held).
- `router.rs`, `discovery/{common,announcing,browsing}.rs`, `gui.rs`, `bot_framework/cert.rs`, `bot_framework/announce.rs`, `ping`, `pong`: every `push_log` / `eprintln!` / `println!` for diagnostics becomes a `tracing` macro with named fields.
- `AppState::push_log` dropped its own `eprintln!` (the fmt layer already writes to stderr). Now an internal sink called only by `GuiLogLayer`.
- Discovery API (`MdnsHandle::publish`, `mdns_sd_register`, `mdns_sd_start`, `create_filtered_daemon`) drops `&Arc<Mutex<AppState>>` — that parameter was only ever for logging.
- `bot_framework` CLI's `println!`s left intact — those are deliberate user-facing stdout output, not logs.

## Stretch goals (out of scope)
- Admin-space link-event tracing.
- GUI-side custom rendering Layer (color, filtering).

## Test plan
- [x] `cargo build --workspace` clean
- [x] `RUST_LOG=zenoh_router::discovery=debug` produces additional discovery-target lines without affecting other targets
- [x] Default run: stderr shows the same events the GUI log panel shows; no duplicates
- [x] Zenoh transport warn / error events appear in stderr at default verbosity
