### PR TITLE
feat(gui): split agent topics into Publishes vs Subscribes (closes #94)

### DIFF
--- a/documents/adr/ADR-020.md
+++ b/documents/adr/ADR-020.md
@@ -1,0 +1,92 @@
+# ADR-020: Split agent topics into `Publishes` and `Subscribes`
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+PR #92 (ADR-018) introduced the per-node agent inventory: each agent announces its `key_exprs: Vec<String>` and the router GUI renders that list as bullets under each agent row.
+
+The flat list cannot answer the first question a user asks when they look at it: *"is this agent producing on that topic, or consuming from it?"* For a ping ↔ pong pair the list reads as:
+
+```
+ping  (v0.1)
+  • dverse/ping
+  • dverse/pong
+pong  (v0.1)
+  • dverse/ping
+  • dverse/pong
+```
+
+The two agents look interchangeable, even though their roles are inverted on each key. Anyone reading the GUI for the first time has to guess which side of the round-trip they're staring at. This is the user-facing acceptance gate for issue #94 ("agent role visibility in inventory").
+
+The pre-release status means there's no installed deployment whose payload format we have to preserve. The fix can change the wire schema directly.
+
+## Decision
+
+Split `key_exprs` into two parallel fields on every layer that touches the announcement — wire, router cache, and GUI render.
+
+**Wire (`bot_framework::announce::AgentAnnounce`).**
+
+```
+pub publishes:  Vec<String>,
+pub subscribes: Vec<String>,
+```
+
+replace the single `key_exprs`. `AgentInfo` (the input struct callers pass to `AgentAnnouncer::start`) splits the same way. No `key_exprs` field is kept for compatibility — old payloads fail JSON parse and hit the existing "ignored unparseable announce from CN=X" log-once-per-CN warning from ADR-018. Since both sides of the wire ship from this workspace, there is no migration window.
+
+**Router cache (`zenoh_router::state::AgentInfo`).**
+
+```
+pub publishes:  Vec<String>,
+pub subscribes: Vec<String>,
+```
+
+cached separately so the GUI can render each list independently without re-classifying on every paint.
+
+**GUI (`zenoh_router::gui::show_main`).**
+
+Under each agent row, two labeled sub-sections:
+
+```
+ping  (v0.1)  • Online  • 2s ago
+  Publishes
+    → dverse/ping
+  Subscribes
+    ← dverse/pong
+```
+
+* `→` (arrow out) for publishes, `←` (arrow in) for subscribes. Direction is read from the GUI's frame of reference: outbound traffic leaves the agent on a publish, inbound traffic arrives at the agent from a subscribe.
+* Either section is skipped entirely when its list is empty, so single-direction agents stay visually compact.
+
+**Call sites.** `ping/main.rs` and `pong/main.rs` are updated to declare the inverse roles — ping publishes `dverse/ping` and subscribes `dverse/pong`, pong is the mirror.
+
+The `run_demo` fake entry under `alice/ping` splits the same way so `cargo run -p zenoh-router -- --demo` exercises the new render.
+
+## Alternatives
+
+**Keep `key_exprs` and add a parallel `roles: HashMap<String, Direction>`.** Rejected. Two sources of truth for the same fact (a topic and its direction). Risk of `roles` drifting out of sync with `key_exprs`.
+
+**Inline the direction into each string (`"+dverse/ping"`, `"-dverse/pong"`).** Rejected. Encoding side-information into a string is the schema design that always loses — every consumer would need to parse the prefix, and there's no compile-time check that the prefix exists.
+
+**Compute publish-vs-subscribe at the router from Zenoh's own session metadata.** Rejected. Zenoh tracks routing-layer publishers and subscribers, but mapping those back to the announcing agent identity would require a separate lookup that doesn't exist today and isn't a problem worth solving for one piece of metadata that's free to ship in the announce payload.
+
+**Keep the flat list and let users mentally parse it.** Rejected. This is the existing state and it is the bug being fixed.
+
+## Consequences
+
+**Positive**
+* The GUI answers the role question at a glance. ping → / pong ← visibility is the user-facing acceptance criterion for #94.
+* The wire schema makes the direction explicit and type-checked at the serde layer. No string-encoding tricks.
+* Empty-section omission keeps single-direction agents compact, so the change is purely additive in information for agents that have a mix.
+* `run_demo` exercises the new render path, so the GUI is testable offline without a live ping ↔ pong.
+
+**Negative**
+* Wire schema break. Old binaries publishing `key_exprs` will produce a JSON parse error on the new router and land in the legacy-payload log line from ADR-018. Acceptable: pre-release, both sides ship from this workspace, no install base to maintain.
+* The `→` / `←` arrow direction is from the GUI viewer's frame, not from the agent's. A reader on the lookout for "subscribes" might expect `→` (data flowing toward the agent); a viewer-frame inversion is the alternative. We picked the agent's-output frame because it matches every other place in the project that uses the direction (e.g. how ACL rules read). Documented in the module comment.
+* Three Rust types now mirror each other (`bot_framework::AgentInfo`, wire `AgentAnnounce`, router `AgentInfo`). A schema change has to update all three. The redundancy is the cost of keeping the wire and the cache decoupled from each other.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/bot_framework/src/announce.rs
+++ b/src/bot_framework/src/announce.rs
@@ -31,10 +31,15 @@ pub struct AgentAnnounce {
     pub agent_name: String,
     /// Agent's `CARGO_PKG_VERSION`.
     pub version: String,
-    /// Zenoh key expressions the agent uses — typically the topics it
-    /// publishes to plus those it subscribes from.  Surfaced in the router
-    /// GUI so a user can see "who provides what".
-    pub key_exprs: Vec<String>,
+    /// Zenoh key expressions the agent **publishes on** (i.e. calls
+    /// `session.put(key, ...)` for).  Rendered with a `→` arrow in the
+    /// router GUI so a user can see this agent as a source of those keys.
+    pub publishes: Vec<String>,
+    /// Zenoh key expressions the agent **subscribes from** (i.e. calls
+    /// `session.declare_subscriber(key)` for).  Rendered with a `←` arrow
+    /// in the router GUI so a user can see this agent as a consumer of
+    /// those keys.
+    pub subscribes: Vec<String>,
     /// Self-reported status.  Authoritative status is computed router-side
     /// from `last_seen`; agents only ever report `Online`.
     pub status: AgentStatusWire,
@@ -61,7 +66,10 @@ pub struct AgentInfo<'a> {
     pub cn: &'a str,
     pub agent_name: &'a str,
     pub version: &'a str,
-    pub key_exprs: Vec<String>,
+    /// Zenoh key expressions this agent publishes on.
+    pub publishes: Vec<String>,
+    /// Zenoh key expressions this agent subscribes from.
+    pub subscribes: Vec<String>,
 }
 
 /// Handle for an in-progress announcer.  Drop to stop the heartbeat —
@@ -83,7 +91,8 @@ impl AgentAnnouncer {
             cn: info.cn.to_string(),
             agent_name: info.agent_name.to_string(),
             version: info.version.to_string(),
-            key_exprs: info.key_exprs.clone(),
+            publishes: info.publishes.clone(),
+            subscribes: info.subscribes.clone(),
             status: AgentStatusWire::Online,
             announced_at: None,
         };

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -50,7 +50,8 @@ async fn main() -> Result<()> {
             cn: &cn,
             agent_name: NODE_NAME,
             version: env!("CARGO_PKG_VERSION"),
-            key_exprs: vec!["dverse/ping".into(), "dverse/pong".into()],
+            publishes: vec!["dverse/ping".into()],
+            subscribes: vec!["dverse/pong".into()],
         },
     );
 

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -50,7 +50,8 @@ async fn main() -> Result<()> {
             cn: &cn,
             agent_name: NODE_NAME,
             version: env!("CARGO_PKG_VERSION"),
-            key_exprs: vec!["dverse/ping".into(), "dverse/pong".into()],
+            publishes: vec!["dverse/pong".into()],
+            subscribes: vec!["dverse/ping".into()],
         },
     );
 

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -595,10 +595,19 @@ fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
                                     ui.weak("·");
                                     ui.weak(format_ago(now.saturating_duration_since(ag.last_seen)));
                                 });
-                                if !ag.key_expressions.is_empty() {
+                                if !ag.publishes.is_empty() || !ag.subscribes.is_empty() {
                                     ui.indent(format!("ke_{cn}_{name}"), |ui| {
-                                        for ke in &ag.key_expressions {
-                                            ui.monospace(format!("• {ke}"));
+                                        if !ag.publishes.is_empty() {
+                                            ui.weak("Publishes");
+                                            for ke in &ag.publishes {
+                                                ui.monospace(format!("  → {ke}"));
+                                            }
+                                        }
+                                        if !ag.subscribes.is_empty() {
+                                            ui.weak("Subscribes");
+                                            for ke in &ag.subscribes {
+                                                ui.monospace(format!("  ← {ke}"));
+                                            }
                                         }
                                     });
                                 }

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -61,7 +61,8 @@ fn run_demo() {
         "ping".to_string(),
         AgentInfo {
             version: "0.1.0".into(),
-            key_expressions: vec!["dverse/ping".into(), "dverse/pong".into()],
+            publishes: vec!["dverse/ping".into()],
+            subscribes: vec!["dverse/pong".into()],
             status: AgentStatus::Online,
             last_seen: now,
         },

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -54,7 +54,12 @@ pub struct NodeInfo {
 #[derive(Debug, Clone)]
 pub struct AgentInfo {
     pub version: String,
-    pub key_expressions: Vec<String>,
+    /// Zenoh key expressions this agent publishes on (`session.put`).
+    /// Rendered with a `→` arrow in the GUI tree.
+    pub publishes: Vec<String>,
+    /// Zenoh key expressions this agent subscribes from
+    /// (`session.declare_subscriber`).  Rendered with a `←` arrow in the GUI.
+    pub subscribes: Vec<String>,
     pub status: AgentStatus,
     pub last_seen: Instant,
 }
@@ -129,7 +134,8 @@ impl AppState {
             ann.agent_name.clone(),
             AgentInfo {
                 version: ann.version.clone(),
-                key_expressions: ann.key_exprs.clone(),
+                publishes: ann.publishes.clone(),
+                subscribes: ann.subscribes.clone(),
                 status: AgentStatus::Online,
                 last_seen: now,
             },


### PR DESCRIPTION
## Summary

Splits `key_exprs: Vec<String>` into `publishes` and `subscribes` across the wire, the router cache, and the GUI render. Closes #94.

Full reasoning + alternatives (parallel `roles: HashMap`, inline prefix encoding, derive from Zenoh routing-layer metadata): **`documents/adr/ADR-020.md`**.

## Why

Before this PR, the agent tree in the router GUI rendered every key an agent touched as a flat bullet list. For a ping ↔ pong pair, both agents showed identical bullets — there was no indication of who was producer and who was consumer. At a glance, you couldn't tell which side of a round-trip you were looking at.

## What changed

**Wire (`bot_framework::announce`).** `AgentAnnounce` and `AgentInfo` replace `key_exprs` with parallel `publishes: Vec<String>` and `subscribes: Vec<String>`. No backward-compat field — old payloads fail JSON parse and hit the existing log-once-per-CN warning from PR #92. Pre-release, both sides ship from this workspace.

**Router cache (`zenoh_router::state::AgentInfo`).** Mirrors the wire — `publishes` / `subscribes` cached separately.

**GUI (`zenoh_router::gui::show_main`).**

```
ping  (v0.1)  • Online  • 2s ago
  Publishes
    → dverse/ping
  Subscribes
    ← dverse/pong
```

`→` for publishes (outbound from the agent), `←` for subscribes (inbound to the agent). Either section is skipped entirely when empty so single-direction agents stay compact.

**Call sites.** ping declares `publishes=[dverse/ping] subscribes=[dverse/pong]`; pong is the inverse. `run_demo` updated so `cargo run -p zenoh-router -- --demo` exercises the new render.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo run -p zenoh-router -- --demo` — alice/ping shows the split sections
- [x] Live ping ↔ pong on two machines — each side shows the opposite role
