### PR TITLE
chore(discovery): drop avahi D-Bus backend, use mdns-sd on all platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,6 +7266,7 @@ dependencies = [
  "dirs 5.0.1",
  "eframe",
  "egui",
+ "if-addrs",
  "mdns-sd",
  "reqwest",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,7 +7271,6 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
- "zbus",
  "zenoh",
 ]
 

--- a/src/bot_framework/src/config.rs
+++ b/src/bot_framework/src/config.rs
@@ -2,6 +2,25 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Whether this dverse install hosts its own session (Admin) or joins
+/// another user's session (Client of some admin CN).
+///
+/// Persisted in `DverseConfig`. Old config files without this field load as
+/// `Admin` via the `Default` impl + `#[serde(default)]` — so single-machine
+/// setups keep working unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "admin_cn", rename_all = "snake_case")]
+pub enum SessionRole {
+    Admin,
+    Client { admin_cn: String },
+}
+
+impl Default for SessionRole {
+    fn default() -> Self {
+        Self::Admin
+    }
+}
+
 /// Machine-wide dverse configuration, stored at `~/.config/dverse/config.toml`.
 /// Only one user session is supported per machine.
 ///
@@ -24,6 +43,10 @@ pub struct DverseConfig {
     pub router_listen: String,
     /// Zenoh connect endpoint used by local agents (client side).
     pub router_endpoint: String,
+    /// Whether this user creates a new session or joins someone else's.
+    /// Missing from old configs → `Admin` by default.
+    #[serde(default)]
+    pub session_role: SessionRole,
 }
 
 impl DverseConfig {
@@ -83,6 +106,17 @@ impl DverseConfig {
             .next()
             .unwrap_or(&self.username)
             .to_string()
+    }
+
+    /// Identifier shared by every router participating in the same session.
+    /// Equals our own CN when we host (Admin), the admin's CN when we joined
+    /// (Client). Used as the `session=` TXT entry in DNS-SD and to filter
+    /// peers — two routers with different session_ids never auto-mesh.
+    pub fn session_id(&self) -> String {
+        match &self.session_role {
+            SessionRole::Admin => self.operator_cn(),
+            SessionRole::Client { admin_cn } => admin_cn.clone(),
+        }
     }
 
     /// Build a `CertConfig` for the given node name using the stored credentials.

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -19,6 +19,7 @@ egui = "0.31"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 mdns-sd = "0.13"
+if-addrs = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = { version = "4", default-features = false, features = ["blocking"] }

--- a/src/zenoh_router/Cargo.toml
+++ b/src/zenoh_router/Cargo.toml
@@ -20,6 +20,3 @@ tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 mdns-sd = "0.13"
 if-addrs = "0.13"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-zbus = { version = "4", default-features = false, features = ["blocking"] }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -39,11 +39,16 @@ pub struct MdnsHandle {
 }
 
 impl MdnsHandle {
-    pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
+    pub fn publish(
+        cn: &str,
+        session_id: &str,
+        port: u16,
+        state: &Arc<Mutex<AppState>>,
+    ) -> Option<Self> {
         #[cfg(target_os = "linux")]
         {
             state.lock().unwrap().push_log("mDNS: trying avahi D-Bus backend…".to_string());
-            if let Some(handle) = linux_avahi_start(cn, port, Arc::clone(state)) {
+            if let Some(handle) = linux_avahi_start(cn, session_id, port, Arc::clone(state)) {
                 return Some(handle);
             }
             state.lock().unwrap().push_log(
@@ -52,7 +57,7 @@ impl MdnsHandle {
         }
         #[cfg(not(target_os = "linux"))]
         state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
-        mdns_sd_start(cn, port, state)
+        mdns_sd_start(cn, session_id, port, state)
     }
 }
 
@@ -83,7 +88,12 @@ impl Drop for MdnsSdSession {
 // ── Linux: avahi D-Bus for publish AND browse ────────────────────────────────
 
 #[cfg(target_os = "linux")]
-fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option<MdnsHandle> {
+fn linux_avahi_start(
+    cn: &str,
+    session_id: &str,
+    port: u16,
+    state: Arc<Mutex<AppState>>,
+) -> Option<MdnsHandle> {
     use zbus::blocking::Connection;
 
     let publish_conn = match Connection::system() {
@@ -96,19 +106,19 @@ fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option
         }
     };
 
-    if let Err(e) = announcing::avahi_register(cn, port, &publish_conn) {
+    if let Err(e) = announcing::avahi_register(cn, session_id, port, &publish_conn) {
         state.lock().unwrap().push_log(format!("mDNS[avahi]: publish failed ({e})"));
         return None;
     }
     state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: published {} on {SERVICE_TYPE} port {port} addr={}",
+        "mDNS[avahi]: published {} on {SERVICE_TYPE} port {port} addr={} session={session_id}",
         instance_name(cn),
         detect_lan_ipv4()
             .map(|ip| ip.to_string())
             .unwrap_or_else(|| "unknown".to_string()),
     ));
 
-    match browsing::avahi_start(cn, Arc::clone(&state)) {
+    match browsing::avahi_start(cn, session_id, Arc::clone(&state)) {
         Some((browse_conn, peer_rx)) => {
             state.lock().unwrap().push_log("mDNS[avahi]: browse started".to_string());
             Some(MdnsHandle {
@@ -128,10 +138,15 @@ fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option
 
 // ── Cross-platform: one mdns-sd daemon for both publish and browse ───────────
 
-fn mdns_sd_start(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsHandle> {
+fn mdns_sd_start(
+    cn: &str,
+    session_id: &str,
+    port: u16,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<MdnsHandle> {
     let daemon = create_filtered_daemon(state)?;
-    let fullname = announcing::mdns_sd_register(&daemon, cn, port, state)?;
-    let peer_rx = browsing::mdns_sd_start(&daemon, cn, state)?;
+    let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port, state)?;
+    let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id, state)?;
     Some(MdnsHandle {
         _inner: Inner::MdnsSd(MdnsSdSession { daemon, fullname }),
         peer_rx,

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -1,114 +1,56 @@
-use mdns_sd::{ServiceDaemon, ServiceInfo};
+use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent, ServiceInfo};
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use tokio::sync::watch;
 
 use crate::state::AppState;
 
 const SERVICE_TYPE: &str = "_dverse._tcp.local.";
 
-/// Registers this router as a `_dverse._tcp` DNS-SD service.
+/// Registers this router as a `_dverse._tcp` DNS-SD service and browses for peers.
 ///
-/// On Linux: uses the avahi D-Bus API so avahi-daemon owns the mDNS socket.
-/// Falls back to mdns-sd if avahi is absent, or on non-Linux platforms.
+/// Backend selection:
+///   - Linux:   try avahi D-Bus for both publish AND browse (so avahi-daemon is the
+///              single mDNS responder on the host).  Fall back to mdns-sd if the
+///              system bus or avahi is unavailable.
+///   - Windows / macOS:  mdns-sd for both publish and browse — one `ServiceDaemon`
+///              to avoid UDP-5353 socket conflicts between two daemons.
 ///
-/// The record is withdrawn when this handle is dropped.
+/// `peer_rx` carries the current set of peer connect-endpoints as
+/// `tls/<ip>:<port>` strings ready for Zenoh `connect/endpoints`.
+/// The service record and browse are withdrawn when this handle is dropped.
 pub struct MdnsHandle {
     _inner: Inner,
-}
-
-enum Inner {
-    #[cfg(target_os = "linux")]
-    Avahi(AvahiHandle),
-    MdnsSd(MdnsSdHandle),
+    pub peer_rx: watch::Receiver<Vec<String>>,
 }
 
 impl MdnsHandle {
     pub fn publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<Self> {
         #[cfg(target_os = "linux")]
         {
-            match linux::publish(cn, port) {
-                Ok(handle) => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS: published DVerse ({cn}) on {SERVICE_TYPE} port {port} (via avahi)"
-                    ));
-                    return Some(Self { _inner: Inner::Avahi(handle) });
-                }
-                Err(e) => {
-                    state.lock().unwrap().push_log(format!(
-                        "Warning: avahi D-Bus unavailable ({e}); falling back to mdns-sd"
-                    ));
-                }
+            state.lock().unwrap().push_log("mDNS: trying avahi D-Bus backend…".to_string());
+            if let Some(handle) = linux_avahi_start(cn, port, Arc::clone(state)) {
+                return Some(handle);
             }
+            state.lock().unwrap().push_log(
+                "mDNS: avahi unavailable, falling back to mdns-sd".to_string(),
+            );
         }
-
-        mdns_sd_publish(cn, port, state).map(|h| Self { _inner: Inner::MdnsSd(h) })
+        #[cfg(not(target_os = "linux"))]
+        state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
+        mdns_sd_start(cn, port, state)
     }
 }
 
-// ── Linux: avahi D-Bus ────────────────────────────────────────────────────────
-
-#[cfg(target_os = "linux")]
-struct AvahiHandle {
-    // Keeping the connection alive: avahi-daemon removes services automatically
-    // when the owning D-Bus connection closes.
-    _conn: zbus::blocking::Connection,
+#[allow(dead_code)]
+enum Inner {
+    #[cfg(target_os = "linux")]
+    Avahi {
+        _publish_conn: zbus::blocking::Connection,
+        _browse_conn: zbus::blocking::Connection,
+    },
+    MdnsSd(MdnsSdHandle),
 }
-
-#[cfg(target_os = "linux")]
-mod linux {
-    use super::AvahiHandle;
-    use anyhow::Result;
-    use zbus::blocking::Connection;
-
-    pub fn publish(cn: &str, port: u16) -> Result<AvahiHandle> {
-        let conn = Connection::system()?;
-
-        let group_path: zbus::zvariant::OwnedObjectPath = conn
-            .call_method(
-                Some("org.freedesktop.Avahi"),
-                "/",
-                Some("org.freedesktop.Avahi.Server"),
-                "EntryGroupNew",
-                &(),
-            )?
-            .body()
-            .deserialize()?;
-
-        // AddService(interface, protocol, flags, name, type, domain, host, port, txt)
-        // interface=-1 (AVAHI_IF_UNSPEC), protocol=-1 (AVAHI_PROTO_UNSPEC)
-        let name = format!("DVerse ({cn})");
-        let txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
-
-        conn.call_method(
-            Some("org.freedesktop.Avahi"),
-            group_path.as_str(),
-            Some("org.freedesktop.Avahi.EntryGroup"),
-            "AddService",
-            &(
-                -1i32,
-                -1i32,
-                0u32,
-                name.as_str(),
-                "_dverse._tcp",
-                "",
-                "",
-                port,
-                &txt,
-            ),
-        )?;
-
-        conn.call_method(
-            Some("org.freedesktop.Avahi"),
-            group_path.as_str(),
-            Some("org.freedesktop.Avahi.EntryGroup"),
-            "Commit",
-            &(),
-        )?;
-
-        Ok(AvahiHandle { _conn: conn })
-    }
-}
-
-// ── mdns-sd (non-Linux or avahi-absent fallback) ──────────────────────────────
 
 struct MdnsSdHandle {
     daemon: ServiceDaemon,
@@ -122,43 +64,690 @@ impl Drop for MdnsSdHandle {
     }
 }
 
-fn mdns_sd_publish(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsSdHandle> {
+/// Detect the machine's LAN IPv4 address (the one used to reach the internet).
+/// Uses a UDP socket routing trick — no packet is actually sent.
+fn detect_lan_ipv4() -> Option<std::net::Ipv4Addr> {
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("1.1.1.1:53").ok()?;
+    match sock.local_addr().ok()? {
+        std::net::SocketAddr::V4(a) if !a.ip().is_loopback() && !a.ip().is_link_local() => {
+            Some(*a.ip())
+        }
+        _ => None,
+    }
+}
+
+fn mdns_sd_start(
+    cn: &str,
+    port: u16,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<MdnsHandle> {
     let daemon = match ServiceDaemon::new() {
         Ok(d) => d,
         Err(e) => {
             state.lock().unwrap().push_log(format!(
-                "Warning: mDNS unavailable ({e}); peer discovery disabled"
+                "mDNS[mdns-sd]: daemon init failed ({e}); peer discovery disabled"
             ));
             return None;
         }
     };
 
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: daemon started".to_string());
+
+    configure_daemon(&daemon, state);
+
     let instance = format!("DVerse ({cn})");
     let host = format!("zenoh-{cn}.local.");
-    let props: &[(&str, &str)] = &[("cn", cn)];
+    let lan_ip = detect_lan_ipv4();
 
-    let svc = match ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props) {
+    // Embed the LAN IPv4 in the TXT record so peers that receive only an IPv6
+    // address from mDNS can still build a valid tls/<ipv4>:<port> endpoint.
+    let ip_str;
+    let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
+        ip_str = ip.to_string();
+        &[("cn", cn), ("ip", &ip_str)]
+    } else {
+        &[("cn", cn)]
+    };
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: LAN IP={}",
+        lan_ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+
+    // Pin the service's A record to the LAN IPv4 explicitly.  Without this,
+    // mdns-sd auto-populates A records from every active interface (loopback,
+    // docker bridges, etc.) and the resulting set is unhelpful to remote peers.
+    let svc_result = match lan_ip {
+        Some(ip) => ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance,
+            &host,
+            std::net::IpAddr::V4(ip),
+            port,
+            props,
+        ),
+        None => ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props),
+    };
+    let svc = match svc_result {
         Ok(s) => s,
         Err(e) => {
             state.lock().unwrap().push_log(format!(
-                "Warning: mDNS service info error ({e}); peer discovery disabled"
+                "mDNS[mdns-sd]: service info error ({e}); peer discovery disabled"
             ));
             return None;
         }
     };
 
     let fullname = svc.get_fullname().to_string();
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: registering {fullname} on port {port}"
+    ));
 
     if let Err(e) = daemon.register(svc) {
         state.lock().unwrap().push_log(format!(
-            "Warning: mDNS register failed ({e}); peer discovery disabled"
+            "mDNS[mdns-sd]: register failed ({e}); peer discovery disabled"
         ));
         return None;
     }
 
     state.lock().unwrap().push_log(format!(
-        "mDNS: published {instance} on {SERVICE_TYPE} port {port}"
+        "mDNS[mdns-sd]: published {instance} on {SERVICE_TYPE} port {port}"
     ));
 
-    Some(MdnsSdHandle { daemon, fullname })
+    let browse_rx = match daemon.browse(SERVICE_TYPE) {
+        Ok(rx) => rx,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: browse failed ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: browse started".to_string());
+
+    let (peer_tx, peer_rx) = watch::channel(vec![]);
+    spawn_browse_thread(browse_rx, cn.to_string(), Arc::clone(state), peer_tx);
+
+    Some(MdnsHandle {
+        _inner: Inner::MdnsSd(MdnsSdHandle { daemon, fullname }),
+        peer_rx,
+    })
+}
+
+/// Apply interface filters to an mdns-sd daemon.
+///
+/// Disables IPv6 (Zenoh peer endpoints are IPv4-only) and any virtual or
+/// link-local IPv4 adapters.  On Windows the Npcap Loopback Adapter (installed
+/// by Wireshark) shows up as a link-local 169.254.x.x interface; if mdns-sd
+/// joins its multicast group, PTR responses go out via Npcap and never reach
+/// the real LAN.  On Linux the docker0 bridge and wireguard tunnels create
+/// similar phantom interfaces that flood the multicast group with traffic
+/// that no peer is on.
+fn configure_daemon(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>) {
+    let _ = daemon.disable_interface(IfKind::IPv6);
+
+    if let Ok(ifaces) = if_addrs::get_if_addrs() {
+        let mut disabled_names: std::collections::HashSet<String> = Default::default();
+
+        for iface in &ifaces {
+            let name_lower = iface.name.to_lowercase();
+            let is_virtual = name_lower.contains("npcap")
+                || name_lower.contains("loopback")
+                || name_lower.contains("vethernet")
+                || name_lower.contains("hyper-v")
+                || name_lower.contains("vmware")
+                || name_lower.contains("virtualbox")
+                || name_lower.contains("docker")
+                || name_lower.starts_with("br-")   // Docker overlay bridge networks
+                || name_lower.starts_with("veth")  // Docker/container veth pairs
+                || name_lower.starts_with("wg");   // WireGuard tunnels
+
+            let is_link_local_v4 = matches!(
+                &iface.addr,
+                if_addrs::IfAddr::V4(v4) if v4.ip.is_link_local()
+            );
+
+            if (is_virtual || is_link_local_v4) && disabled_names.insert(iface.name.clone()) {
+                state.lock().unwrap().push_log(format!(
+                    "mDNS[mdns-sd]: disabling virtual/link-local iface {} ({})",
+                    iface.name,
+                    iface.ip(),
+                ));
+                let _ = daemon.disable_interface(IfKind::Name(iface.name.clone()));
+            }
+        }
+    }
+}
+
+/// Spawn a background thread that drains a `ServiceEvent` channel and updates
+/// `peer_tx` with the current set of reachable peer endpoints.
+fn spawn_browse_thread(
+    browse_rx: mdns_sd::Receiver<ServiceEvent>,
+    my_cn: String,
+    state: Arc<Mutex<AppState>>,
+    peer_tx: watch::Sender<Vec<String>>,
+) {
+    std::thread::spawn(move || {
+        let mut peers: HashMap<String, Vec<String>> = HashMap::new();
+
+        while let Ok(event) = browse_rx.recv() {
+            match event {
+                ServiceEvent::ServiceFound(svc_type, fullname) => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
+                    ));
+                }
+                ServiceEvent::ServiceResolved(info) => {
+                    let remote_cn = info.get_property_val_str("cn").unwrap_or_default();
+                    let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
+                        info.get_fullname(),
+                        info.get_port(),
+                    ));
+
+                    if remote_cn.is_empty() || remote_cn == my_cn {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
+                        ));
+                        continue;
+                    }
+
+                    let port = info.get_port();
+
+                    // Prefer the IPv4 embedded in the TXT record (set by the remote
+                    // router at publish time). This sidesteps the problem where mdns-sd
+                    // resolves via IPv6 first and only reports the link-local AAAA address.
+                    let txt_ipv4 = info
+                        .get_property_val_str("ip")
+                        .and_then(|s| s.parse::<std::net::Ipv4Addr>().ok())
+                        .filter(|ip| !ip.is_loopback() && !ip.is_link_local());
+
+                    let mut endpoints: Vec<String> = if let Some(ipv4) = txt_ipv4 {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[mdns-sd]: using TXT ip={ipv4} for {remote_cn}"
+                        ));
+                        vec![format!("tls/{ipv4}:{port}")]
+                    } else {
+                        info.get_addresses()
+                            .iter()
+                            .filter_map(|a| {
+                                if is_unroutable(a) {
+                                    state.lock().unwrap().push_log(format!(
+                                        "mDNS[mdns-sd]: skipping unroutable addr {a}"
+                                    ));
+                                    return None;
+                                }
+                                match a {
+                                    std::net::IpAddr::V4(v4) => {
+                                        Some(format!("tls/{v4}:{port}"))
+                                    }
+                                    _ => None,
+                                }
+                            })
+                            .collect()
+                    };
+                    endpoints.sort();
+
+                    if endpoints.is_empty() {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[mdns-sd]: resolved {remote_cn} but no routable IPv4 \
+                             (no TXT ip, addrs={:?}); skipping",
+                            info.get_addresses().iter().collect::<Vec<_>>(),
+                        ));
+                        continue;
+                    }
+
+                    if peers.get(info.get_fullname()) == Some(&endpoints) {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[mdns-sd]: peer {remote_cn} unchanged, ignoring duplicate"
+                        ));
+                        continue;
+                    }
+
+                    peers.insert(info.get_fullname().to_string(), endpoints.clone());
+                    state.lock().unwrap().push_log(format!(
+                        "Discovered peer router: {} (+{} addr) (CN={remote_cn})",
+                        endpoints[0],
+                        endpoints.len() - 1,
+                    ));
+                    let _ = peer_tx.send(peers.values().flatten().cloned().collect());
+                }
+                ServiceEvent::ServiceRemoved(_, fullname) => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[mdns-sd]: removed {fullname:?}"
+                    ));
+                    if let Some(endpoints) = peers.remove(&fullname) {
+                        state.lock().unwrap().push_log(format!(
+                            "Peer router left: {}",
+                            endpoints.first().map(String::as_str).unwrap_or(&fullname),
+                        ));
+                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
+                    }
+                }
+                other => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[mdns-sd]: event {other:?}"
+                    ));
+                }
+            }
+        }
+
+        state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
+    });
+}
+
+fn is_unroutable(addr: &std::net::IpAddr) -> bool {
+    match addr {
+        std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_link_local(),
+        std::net::IpAddr::V6(v6) => {
+            v6.is_loopback() || (v6.segments()[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+// ── Linux: avahi D-Bus (publish + browse) ────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option<MdnsHandle> {
+    use zbus::blocking::Connection;
+
+    let publish_conn = match Connection::system() {
+        Ok(c) => c,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: D-Bus system bus unavailable ({e})"
+            ));
+            return None;
+        }
+    };
+
+    if let Err(e) = linux_avahi_publish(cn, port, &publish_conn) {
+        state.lock().unwrap().push_log(format!("mDNS[avahi]: publish failed ({e})"));
+        return None;
+    }
+    state.lock().unwrap().push_log(format!(
+        "mDNS[avahi]: published DVerse ({cn}) on {SERVICE_TYPE} port {port} addr={}",
+        detect_lan_ipv4()
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+
+    match linux_avahi_browse(cn, Arc::clone(&state)) {
+        Some((browse_conn, peer_rx)) => {
+            state.lock().unwrap().push_log("mDNS[avahi]: browse started".to_string());
+            Some(MdnsHandle {
+                _inner: Inner::Avahi {
+                    _publish_conn: publish_conn,
+                    _browse_conn: browse_conn,
+                },
+                peer_rx,
+            })
+        }
+        None => {
+            state.lock().unwrap().push_log("mDNS[avahi]: browse failed".to_string());
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_avahi_publish(
+    cn: &str,
+    port: u16,
+    conn: &zbus::blocking::Connection,
+) -> anyhow::Result<()> {
+    let group_path: zbus::zvariant::OwnedObjectPath = conn
+        .call_method(
+            Some("org.freedesktop.Avahi"),
+            "/",
+            Some("org.freedesktop.Avahi.Server"),
+            "EntryGroupNew",
+            &(),
+        )?
+        .body()
+        .deserialize()?;
+
+    let name = format!("DVerse ({cn})");
+    let local_ip = detect_lan_ipv4();
+
+    // Embed the LAN IPv4 in the TXT record so remote peers that resolve via IPv6
+    // first (or via the machine's default hostname) can still build a usable
+    // tls/<ipv4>:<port> endpoint.
+    let mut txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
+    if let Some(ipv4) = local_ip {
+        txt.push(format!("ip={ipv4}").into_bytes());
+    }
+
+    // Best-effort: register a dedicated A record `dverse-<cn>.local.` pointing at
+    // the LAN IPv4, so SRV resolution gives a single, routable address.  Fails
+    // with a CollisionError if a stale record exists from a previous run — fall
+    // back to avahi's default hostname in that case.
+    let custom_host = format!("dverse-{cn}.local.");
+    let use_custom = if let Some(ipv4) = local_ip {
+        let res = conn.call_method(
+            Some("org.freedesktop.Avahi"),
+            group_path.as_str(),
+            Some("org.freedesktop.Avahi.EntryGroup"),
+            "AddAddress",
+            &(-1i32, 0i32, 0u32, custom_host.as_str(), ipv4.to_string().as_str()),
+        );
+        match res {
+            Ok(_) => true,
+            Err(e) => {
+                eprintln!(
+                    "mDNS[avahi]: AddAddress for {custom_host} failed ({e}); using default host"
+                );
+                false
+            }
+        }
+    } else {
+        false
+    };
+
+    let host = if use_custom { custom_host.as_str() } else { "" };
+
+    conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        group_path.as_str(),
+        Some("org.freedesktop.Avahi.EntryGroup"),
+        "AddService",
+        &(-1i32, -1i32, 0u32, name.as_str(), "_dverse._tcp", "", host, port, &txt),
+    )?;
+
+    conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        group_path.as_str(),
+        Some("org.freedesktop.Avahi.EntryGroup"),
+        "Commit",
+        &(),
+    )?;
+
+    Ok(())
+}
+
+/// Browse `_dverse._tcp` via avahi's D-Bus `ServiceBrowser` interface.
+///
+/// Critical ordering: the `MessageIterator` (D-Bus `AddMatch`) MUST be registered
+/// BEFORE `ServiceBrowserNew` is called.  avahi fires `ItemNew` signals for any
+/// already-cached services immediately after the browser is created; if we only
+/// set up the subscription afterwards we miss those signals.
+///
+/// Implementation: spawn the thread first, register a broad match rule from
+/// inside the thread (no path filter — we don't know the browser path yet),
+/// THEN call `ServiceBrowserNew`, and filter in code by browser_path.  A
+/// `mpsc::channel` synchronises the caller so it waits for setup to complete.
+#[cfg(target_os = "linux")]
+fn linux_avahi_browse(
+    my_cn: &str,
+    state: Arc<Mutex<AppState>>,
+) -> Option<(zbus::blocking::Connection, watch::Receiver<Vec<String>>)> {
+    use zbus::blocking::Connection;
+
+    let conn = match Connection::system() {
+        Ok(c) => c,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: browse D-Bus conn failed ({e})"
+            ));
+            return None;
+        }
+    };
+    let conn_resolve = match Connection::system() {
+        Ok(c) => c,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: resolve D-Bus conn failed ({e})"
+            ));
+            return None;
+        }
+    };
+
+    let conn_keepalive = conn.clone();
+    let (peer_tx, peer_rx) = watch::channel(vec![]);
+    let my_cn = my_cn.to_string();
+
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<String, String>>();
+
+    std::thread::spawn(move || {
+        // Step 1: register the broad match rule BEFORE creating the browser.
+        // No `.path()` filter — we don't know the browser's path yet, and we
+        // must not miss signals fired during/immediately after browser creation.
+        let rule = match (|| -> zbus::Result<_> {
+            Ok(zbus::MatchRule::builder()
+                .msg_type(zbus::message::Type::Signal)
+                .sender("org.freedesktop.Avahi")?
+                .interface("org.freedesktop.Avahi.ServiceBrowser")?
+                .build())
+        })() {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = format!("mDNS[avahi]: match rule error ({e})");
+                state.lock().unwrap().push_log(msg.clone());
+                ready_tx.send(Err(msg)).ok();
+                return;
+            }
+        };
+
+        let iter = match zbus::blocking::MessageIterator::for_match_rule(rule, &conn, Some(64)) {
+            Ok(i) => i,
+            Err(e) => {
+                let msg = format!("mDNS[avahi]: iterator error ({e})");
+                state.lock().unwrap().push_log(msg.clone());
+                ready_tx.send(Err(msg)).ok();
+                return;
+            }
+        };
+
+        // Step 2: NOW create the browser — signals are already queued.
+        let browser_path: zbus::zvariant::OwnedObjectPath = match conn
+            .call_method(
+                Some("org.freedesktop.Avahi"),
+                "/",
+                Some("org.freedesktop.Avahi.Server"),
+                "ServiceBrowserNew",
+                &(-1i32, -1i32, "_dverse._tcp", "local", 0u32),
+            )
+            .and_then(|r| r.body().deserialize().map_err(Into::into))
+        {
+            Ok(p) => p,
+            Err(e) => {
+                let msg = format!("mDNS[avahi]: ServiceBrowserNew failed ({e})");
+                state.lock().unwrap().push_log(msg.clone());
+                ready_tx.send(Err(msg)).ok();
+                return;
+            }
+        };
+
+        let browser_path_str = browser_path.as_str().to_string();
+        state
+            .lock()
+            .unwrap()
+            .push_log(format!("mDNS[avahi]: browser at {browser_path_str}"));
+        ready_tx.send(Ok(browser_path_str.clone())).ok();
+
+        let mut peers: HashMap<String, Vec<String>> = HashMap::new();
+
+        for msg_result in iter {
+            let msg = match msg_result {
+                Ok(m) => m,
+                Err(e) => {
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[avahi]: D-Bus error ({e}); stopping"
+                    ));
+                    break;
+                }
+            };
+
+            // Filter to signals from our specific ServiceBrowser object — the
+            // broad match rule may also deliver signals from other browsers if
+            // multiple `ServiceBrowserNew` instances exist on the bus.
+            let msg_path = msg.header().path().map(|p| p.as_str().to_owned());
+            if msg_path.as_deref() != Some(browser_path_str.as_str()) {
+                continue;
+            }
+
+            let Some(member) = msg.header().member().map(|m| m.to_owned()) else { continue };
+
+            match member.as_str() {
+                "ItemNew" => {
+                    let body: zbus::Result<(i32, i32, String, String, String, u32)> =
+                        msg.body().deserialize();
+                    let Ok((svc_iface, svc_proto, name, svc_type, domain, _)) = body else {
+                        state
+                            .lock()
+                            .unwrap()
+                            .push_log("mDNS[avahi]: ItemNew body parse failed".to_string());
+                        continue;
+                    };
+
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[avahi]: ItemNew iface={svc_iface} proto={svc_proto} \
+                         name={name:?} type={svc_type:?} domain={domain:?}"
+                    ));
+
+                    let resolve = conn_resolve.call_method(
+                        Some("org.freedesktop.Avahi"),
+                        "/",
+                        Some("org.freedesktop.Avahi.Server"),
+                        "ResolveService",
+                        &(
+                            svc_iface,
+                            svc_proto,
+                            name.as_str(),
+                            svc_type.as_str(),
+                            domain.as_str(),
+                            -1i32,
+                            0u32,
+                        ),
+                    );
+                    let reply = match resolve {
+                        Ok(r) => r,
+                        Err(e) => {
+                            state.lock().unwrap().push_log(format!(
+                                "mDNS[avahi]: ResolveService error ({e})"
+                            ));
+                            continue;
+                        }
+                    };
+
+                    type Resolved = (
+                        i32, i32, String, String, String, String,
+                        i32, String, u16, Vec<Vec<u8>>, u32,
+                    );
+                    let body: zbus::Result<Resolved> = reply.body().deserialize();
+                    let Ok((_, _, _, _, _, host, _, address, port, txt, _)) = body else {
+                        state.lock().unwrap().push_log(
+                            "mDNS[avahi]: ResolveService body parse failed".to_string(),
+                        );
+                        continue;
+                    };
+
+                    let remote_cn: String = txt
+                        .iter()
+                        .find_map(|e| {
+                            std::str::from_utf8(e)
+                                .ok()
+                                .and_then(|s| s.strip_prefix("cn="))
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_default();
+                    let txt_ipv4: Option<std::net::Ipv4Addr> = txt.iter().find_map(|e| {
+                        std::str::from_utf8(e)
+                            .ok()
+                            .and_then(|s| s.strip_prefix("ip="))
+                            .and_then(|s| s.parse().ok())
+                    });
+
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[avahi]: resolved host={host:?} addr={address} port={port} \
+                         cn={remote_cn:?} txt_ip={txt_ipv4:?}"
+                    ));
+
+                    if remote_cn.is_empty() || remote_cn == my_cn {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[avahi]: skipping self or empty CN ({remote_cn:?})"
+                        ));
+                        continue;
+                    }
+
+                    // Prefer the IPv4 from the TXT record (peer published their own
+                    // routable LAN IP).  Fall back to the resolved A/AAAA address.
+                    let chosen_ip: std::net::IpAddr = if let Some(ipv4) = txt_ipv4 {
+                        if !ipv4.is_loopback() && !ipv4.is_link_local() {
+                            std::net::IpAddr::V4(ipv4)
+                        } else {
+                            match address.parse() {
+                                Ok(ip) => ip,
+                                Err(_) => {
+                                    state.lock().unwrap().push_log(format!(
+                                        "mDNS[avahi]: addr parse failed for {address:?}"
+                                    ));
+                                    continue;
+                                }
+                            }
+                        }
+                    } else {
+                        match address.parse() {
+                            Ok(ip) => ip,
+                            Err(_) => {
+                                state.lock().unwrap().push_log(format!(
+                                    "mDNS[avahi]: addr parse failed for {address:?}"
+                                ));
+                                continue;
+                            }
+                        }
+                    };
+
+                    if is_unroutable(&chosen_ip) {
+                        state.lock().unwrap().push_log(format!(
+                            "mDNS[avahi]: skipping unroutable addr {chosen_ip}"
+                        ));
+                        continue;
+                    }
+
+                    let endpoint = format!("tls/{chosen_ip}:{port}");
+                    let key = format!("{name}.{svc_type}.");
+
+                    let entry = peers.entry(key).or_default();
+                    if !entry.contains(&endpoint) {
+                        entry.push(endpoint.clone());
+                        entry.sort();
+                        state.lock().unwrap().push_log(format!(
+                            "Discovered peer router: {endpoint} (CN={remote_cn})"
+                        ));
+                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
+                    }
+                }
+                "ItemRemove" => {
+                    let body: zbus::Result<(i32, i32, String, String, String, u32)> =
+                        msg.body().deserialize();
+                    let Ok((_, _, name, svc_type, _, _)) = body else { continue };
+                    state.lock().unwrap().push_log(format!(
+                        "mDNS[avahi]: ItemRemove name={name:?} type={svc_type:?}"
+                    ));
+                    let key = format!("{name}.{svc_type}.");
+                    if let Some(endpoints) = peers.remove(&key) {
+                        state.lock().unwrap().push_log(format!(
+                            "Peer router left: {}",
+                            endpoints.first().map(String::as_str).unwrap_or(&key),
+                        ));
+                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        state.lock().unwrap().push_log("mDNS[avahi]: signal loop exited".to_string());
+    });
+
+    match ready_rx.recv() {
+        Ok(Ok(_)) => Some((conn_keepalive, peer_rx)),
+        Ok(Err(_)) | Err(_) => None,
+    }
 }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -1,24 +1,38 @@
-use mdns_sd::{IfKind, ServiceDaemon, ServiceEvent, ServiceInfo};
-use std::collections::HashMap;
+//! DNS-SD peer discovery for the Zenoh router.
+//!
+//! Public entry point: [`MdnsHandle::publish`].  Drop the handle to withdraw
+//! the service record and stop browsing.
+//!
+//! Backend selection:
+//!   * Linux:   try avahi D-Bus (publish + browse) so avahi-daemon is the
+//!              single mDNS responder on the host.  Fall back to mdns-sd if
+//!              the system bus or avahi is unavailable.
+//!   * Windows / macOS:  mdns-sd for both publish and browse — one
+//!              `ServiceDaemon` to avoid UDP-5353 socket conflicts.
+//!
+//! Internals are split across three sibling modules:
+//!   * [`common`]     — shared constants, format helpers, IP detection,
+//!                      mdns-sd daemon setup, peer registry.
+//!   * [`announcing`] — registers our service.
+//!   * [`browsing`]   — watches for other services and tracks endpoints.
+
+mod announcing;
+mod browsing;
+mod common;
+
 use std::sync::{Arc, Mutex};
+
+use mdns_sd::ServiceDaemon;
 use tokio::sync::watch;
 
 use crate::state::AppState;
 
-const SERVICE_TYPE: &str = "_dverse._tcp.local.";
+use self::common::{create_filtered_daemon, detect_lan_ipv4, instance_name, SERVICE_TYPE};
 
-/// Registers this router as a `_dverse._tcp` DNS-SD service and browses for peers.
-///
-/// Backend selection:
-///   - Linux:   try avahi D-Bus for both publish AND browse (so avahi-daemon is the
-///              single mDNS responder on the host).  Fall back to mdns-sd if the
-///              system bus or avahi is unavailable.
-///   - Windows / macOS:  mdns-sd for both publish and browse — one `ServiceDaemon`
-///              to avoid UDP-5353 socket conflicts between two daemons.
-///
-/// `peer_rx` carries the current set of peer connect-endpoints as
-/// `tls/<ip>:<port>` strings ready for Zenoh `connect/endpoints`.
-/// The service record and browse are withdrawn when this handle is dropped.
+/// Discovery handle.  Holds backend resources alive (D-Bus connections,
+/// mdns-sd daemon) and exposes a `peer_rx` watch channel listing the current
+/// peer endpoints as `tls/<ip>:<port>` strings ready for Zenoh's
+/// `connect/endpoints`.
 pub struct MdnsHandle {
     _inner: Inner,
     pub peer_rx: watch::Receiver<Vec<String>>,
@@ -49,308 +63,24 @@ enum Inner {
         _publish_conn: zbus::blocking::Connection,
         _browse_conn: zbus::blocking::Connection,
     },
-    MdnsSd(MdnsSdHandle),
+    MdnsSd(MdnsSdSession),
 }
 
-struct MdnsSdHandle {
+/// Owns the mdns-sd daemon + the registered service fullname so we can
+/// unregister cleanly on drop.
+struct MdnsSdSession {
     daemon: ServiceDaemon,
     fullname: String,
 }
 
-impl Drop for MdnsSdHandle {
+impl Drop for MdnsSdSession {
     fn drop(&mut self) {
         let _ = self.daemon.unregister(&self.fullname);
         let _ = self.daemon.shutdown();
     }
 }
 
-/// Detect the machine's LAN IPv4 address (the one used to reach the internet).
-/// Uses a UDP socket routing trick — no packet is actually sent.
-fn detect_lan_ipv4() -> Option<std::net::Ipv4Addr> {
-    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-    sock.connect("1.1.1.1:53").ok()?;
-    match sock.local_addr().ok()? {
-        std::net::SocketAddr::V4(a) if !a.ip().is_loopback() && !a.ip().is_link_local() => {
-            Some(*a.ip())
-        }
-        _ => None,
-    }
-}
-
-fn mdns_sd_start(
-    cn: &str,
-    port: u16,
-    state: &Arc<Mutex<AppState>>,
-) -> Option<MdnsHandle> {
-    let daemon = match ServiceDaemon::new() {
-        Ok(d) => d,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: daemon init failed ({e}); peer discovery disabled"
-            ));
-            return None;
-        }
-    };
-
-    state.lock().unwrap().push_log("mDNS[mdns-sd]: daemon started".to_string());
-
-    configure_daemon(&daemon, state);
-
-    let instance = format!("DVerse ({cn})");
-    let host = format!("zenoh-{cn}.local.");
-    let lan_ip = detect_lan_ipv4();
-
-    // Embed the LAN IPv4 in the TXT record so peers that receive only an IPv6
-    // address from mDNS can still build a valid tls/<ipv4>:<port> endpoint.
-    let ip_str;
-    let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
-        ip_str = ip.to_string();
-        &[("cn", cn), ("ip", &ip_str)]
-    } else {
-        &[("cn", cn)]
-    };
-
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: LAN IP={}",
-        lan_ip
-            .map(|ip| ip.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
-    ));
-
-    // Pin the service's A record to the LAN IPv4 explicitly.  Without this,
-    // mdns-sd auto-populates A records from every active interface (loopback,
-    // docker bridges, etc.) and the resulting set is unhelpful to remote peers.
-    let svc_result = match lan_ip {
-        Some(ip) => ServiceInfo::new(
-            SERVICE_TYPE,
-            &instance,
-            &host,
-            std::net::IpAddr::V4(ip),
-            port,
-            props,
-        ),
-        None => ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props),
-    };
-    let svc = match svc_result {
-        Ok(s) => s,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: service info error ({e}); peer discovery disabled"
-            ));
-            return None;
-        }
-    };
-
-    let fullname = svc.get_fullname().to_string();
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: registering {fullname} on port {port}"
-    ));
-
-    if let Err(e) = daemon.register(svc) {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[mdns-sd]: register failed ({e}); peer discovery disabled"
-        ));
-        return None;
-    }
-
-    state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: published {instance} on {SERVICE_TYPE} port {port}"
-    ));
-
-    let browse_rx = match daemon.browse(SERVICE_TYPE) {
-        Ok(rx) => rx,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[mdns-sd]: browse failed ({e}); peer discovery disabled"
-            ));
-            return None;
-        }
-    };
-
-    state.lock().unwrap().push_log("mDNS[mdns-sd]: browse started".to_string());
-
-    let (peer_tx, peer_rx) = watch::channel(vec![]);
-    spawn_browse_thread(browse_rx, cn.to_string(), Arc::clone(state), peer_tx);
-
-    Some(MdnsHandle {
-        _inner: Inner::MdnsSd(MdnsSdHandle { daemon, fullname }),
-        peer_rx,
-    })
-}
-
-/// Apply interface filters to an mdns-sd daemon.
-///
-/// Disables IPv6 (Zenoh peer endpoints are IPv4-only) and any virtual or
-/// link-local IPv4 adapters.  On Windows the Npcap Loopback Adapter (installed
-/// by Wireshark) shows up as a link-local 169.254.x.x interface; if mdns-sd
-/// joins its multicast group, PTR responses go out via Npcap and never reach
-/// the real LAN.  On Linux the docker0 bridge and wireguard tunnels create
-/// similar phantom interfaces that flood the multicast group with traffic
-/// that no peer is on.
-fn configure_daemon(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>) {
-    let _ = daemon.disable_interface(IfKind::IPv6);
-
-    if let Ok(ifaces) = if_addrs::get_if_addrs() {
-        let mut disabled_names: std::collections::HashSet<String> = Default::default();
-
-        for iface in &ifaces {
-            let name_lower = iface.name.to_lowercase();
-            let is_virtual = name_lower.contains("npcap")
-                || name_lower.contains("loopback")
-                || name_lower.contains("vethernet")
-                || name_lower.contains("hyper-v")
-                || name_lower.contains("vmware")
-                || name_lower.contains("virtualbox")
-                || name_lower.contains("docker")
-                || name_lower.starts_with("br-")   // Docker overlay bridge networks
-                || name_lower.starts_with("veth")  // Docker/container veth pairs
-                || name_lower.starts_with("wg");   // WireGuard tunnels
-
-            let is_link_local_v4 = matches!(
-                &iface.addr,
-                if_addrs::IfAddr::V4(v4) if v4.ip.is_link_local()
-            );
-
-            if (is_virtual || is_link_local_v4) && disabled_names.insert(iface.name.clone()) {
-                state.lock().unwrap().push_log(format!(
-                    "mDNS[mdns-sd]: disabling virtual/link-local iface {} ({})",
-                    iface.name,
-                    iface.ip(),
-                ));
-                let _ = daemon.disable_interface(IfKind::Name(iface.name.clone()));
-            }
-        }
-    }
-}
-
-/// Spawn a background thread that drains a `ServiceEvent` channel and updates
-/// `peer_tx` with the current set of reachable peer endpoints.
-fn spawn_browse_thread(
-    browse_rx: mdns_sd::Receiver<ServiceEvent>,
-    my_cn: String,
-    state: Arc<Mutex<AppState>>,
-    peer_tx: watch::Sender<Vec<String>>,
-) {
-    std::thread::spawn(move || {
-        let mut peers: HashMap<String, Vec<String>> = HashMap::new();
-
-        while let Ok(event) = browse_rx.recv() {
-            match event {
-                ServiceEvent::ServiceFound(svc_type, fullname) => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
-                    ));
-                }
-                ServiceEvent::ServiceResolved(info) => {
-                    let remote_cn = info.get_property_val_str("cn").unwrap_or_default();
-                    let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
-                        info.get_fullname(),
-                        info.get_port(),
-                    ));
-
-                    if remote_cn.is_empty() || remote_cn == my_cn {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
-                        ));
-                        continue;
-                    }
-
-                    let port = info.get_port();
-
-                    // Prefer the IPv4 embedded in the TXT record (set by the remote
-                    // router at publish time). This sidesteps the problem where mdns-sd
-                    // resolves via IPv6 first and only reports the link-local AAAA address.
-                    let txt_ipv4 = info
-                        .get_property_val_str("ip")
-                        .and_then(|s| s.parse::<std::net::Ipv4Addr>().ok())
-                        .filter(|ip| !ip.is_loopback() && !ip.is_link_local());
-
-                    let mut endpoints: Vec<String> = if let Some(ipv4) = txt_ipv4 {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[mdns-sd]: using TXT ip={ipv4} for {remote_cn}"
-                        ));
-                        vec![format!("tls/{ipv4}:{port}")]
-                    } else {
-                        info.get_addresses()
-                            .iter()
-                            .filter_map(|a| {
-                                if is_unroutable(a) {
-                                    state.lock().unwrap().push_log(format!(
-                                        "mDNS[mdns-sd]: skipping unroutable addr {a}"
-                                    ));
-                                    return None;
-                                }
-                                match a {
-                                    std::net::IpAddr::V4(v4) => {
-                                        Some(format!("tls/{v4}:{port}"))
-                                    }
-                                    _ => None,
-                                }
-                            })
-                            .collect()
-                    };
-                    endpoints.sort();
-
-                    if endpoints.is_empty() {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[mdns-sd]: resolved {remote_cn} but no routable IPv4 \
-                             (no TXT ip, addrs={:?}); skipping",
-                            info.get_addresses().iter().collect::<Vec<_>>(),
-                        ));
-                        continue;
-                    }
-
-                    if peers.get(info.get_fullname()) == Some(&endpoints) {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[mdns-sd]: peer {remote_cn} unchanged, ignoring duplicate"
-                        ));
-                        continue;
-                    }
-
-                    peers.insert(info.get_fullname().to_string(), endpoints.clone());
-                    state.lock().unwrap().push_log(format!(
-                        "Discovered peer router: {} (+{} addr) (CN={remote_cn})",
-                        endpoints[0],
-                        endpoints.len() - 1,
-                    ));
-                    let _ = peer_tx.send(peers.values().flatten().cloned().collect());
-                }
-                ServiceEvent::ServiceRemoved(_, fullname) => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[mdns-sd]: removed {fullname:?}"
-                    ));
-                    if let Some(endpoints) = peers.remove(&fullname) {
-                        state.lock().unwrap().push_log(format!(
-                            "Peer router left: {}",
-                            endpoints.first().map(String::as_str).unwrap_or(&fullname),
-                        ));
-                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
-                    }
-                }
-                other => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[mdns-sd]: event {other:?}"
-                    ));
-                }
-            }
-        }
-
-        state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
-    });
-}
-
-fn is_unroutable(addr: &std::net::IpAddr) -> bool {
-    match addr {
-        std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_link_local(),
-        std::net::IpAddr::V6(v6) => {
-            v6.is_loopback() || (v6.segments()[0] & 0xffc0) == 0xfe80
-        }
-    }
-}
-
-// ── Linux: avahi D-Bus (publish + browse) ────────────────────────────────────
+// ── Linux: avahi D-Bus for publish AND browse ────────────────────────────────
 
 #[cfg(target_os = "linux")]
 fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option<MdnsHandle> {
@@ -366,18 +96,19 @@ fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option
         }
     };
 
-    if let Err(e) = linux_avahi_publish(cn, port, &publish_conn) {
+    if let Err(e) = announcing::avahi_register(cn, port, &publish_conn) {
         state.lock().unwrap().push_log(format!("mDNS[avahi]: publish failed ({e})"));
         return None;
     }
     state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: published DVerse ({cn}) on {SERVICE_TYPE} port {port} addr={}",
+        "mDNS[avahi]: published {} on {SERVICE_TYPE} port {port} addr={}",
+        instance_name(cn),
         detect_lan_ipv4()
             .map(|ip| ip.to_string())
-            .unwrap_or_else(|| "unknown".to_string())
+            .unwrap_or_else(|| "unknown".to_string()),
     ));
 
-    match linux_avahi_browse(cn, Arc::clone(&state)) {
+    match browsing::avahi_start(cn, Arc::clone(&state)) {
         Some((browse_conn, peer_rx)) => {
             state.lock().unwrap().push_log("mDNS[avahi]: browse started".to_string());
             Some(MdnsHandle {
@@ -395,359 +126,14 @@ fn linux_avahi_start(cn: &str, port: u16, state: Arc<Mutex<AppState>>) -> Option
     }
 }
 
-#[cfg(target_os = "linux")]
-fn linux_avahi_publish(
-    cn: &str,
-    port: u16,
-    conn: &zbus::blocking::Connection,
-) -> anyhow::Result<()> {
-    let group_path: zbus::zvariant::OwnedObjectPath = conn
-        .call_method(
-            Some("org.freedesktop.Avahi"),
-            "/",
-            Some("org.freedesktop.Avahi.Server"),
-            "EntryGroupNew",
-            &(),
-        )?
-        .body()
-        .deserialize()?;
+// ── Cross-platform: one mdns-sd daemon for both publish and browse ───────────
 
-    let name = format!("DVerse ({cn})");
-    let local_ip = detect_lan_ipv4();
-
-    // Embed the LAN IPv4 in the TXT record so remote peers that resolve via IPv6
-    // first (or via the machine's default hostname) can still build a usable
-    // tls/<ipv4>:<port> endpoint.
-    let mut txt: Vec<Vec<u8>> = vec![format!("cn={cn}").into_bytes()];
-    if let Some(ipv4) = local_ip {
-        txt.push(format!("ip={ipv4}").into_bytes());
-    }
-
-    // Best-effort: register a dedicated A record `dverse-<cn>.local.` pointing at
-    // the LAN IPv4, so SRV resolution gives a single, routable address.  Fails
-    // with a CollisionError if a stale record exists from a previous run — fall
-    // back to avahi's default hostname in that case.
-    let custom_host = format!("dverse-{cn}.local.");
-    let use_custom = if let Some(ipv4) = local_ip {
-        let res = conn.call_method(
-            Some("org.freedesktop.Avahi"),
-            group_path.as_str(),
-            Some("org.freedesktop.Avahi.EntryGroup"),
-            "AddAddress",
-            &(-1i32, 0i32, 0u32, custom_host.as_str(), ipv4.to_string().as_str()),
-        );
-        match res {
-            Ok(_) => true,
-            Err(e) => {
-                eprintln!(
-                    "mDNS[avahi]: AddAddress for {custom_host} failed ({e}); using default host"
-                );
-                false
-            }
-        }
-    } else {
-        false
-    };
-
-    let host = if use_custom { custom_host.as_str() } else { "" };
-
-    conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        group_path.as_str(),
-        Some("org.freedesktop.Avahi.EntryGroup"),
-        "AddService",
-        &(-1i32, -1i32, 0u32, name.as_str(), "_dverse._tcp", "", host, port, &txt),
-    )?;
-
-    conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        group_path.as_str(),
-        Some("org.freedesktop.Avahi.EntryGroup"),
-        "Commit",
-        &(),
-    )?;
-
-    Ok(())
-}
-
-/// Browse `_dverse._tcp` via avahi's D-Bus `ServiceBrowser` interface.
-///
-/// Critical ordering: the `MessageIterator` (D-Bus `AddMatch`) MUST be registered
-/// BEFORE `ServiceBrowserNew` is called.  avahi fires `ItemNew` signals for any
-/// already-cached services immediately after the browser is created; if we only
-/// set up the subscription afterwards we miss those signals.
-///
-/// Implementation: spawn the thread first, register a broad match rule from
-/// inside the thread (no path filter — we don't know the browser path yet),
-/// THEN call `ServiceBrowserNew`, and filter in code by browser_path.  A
-/// `mpsc::channel` synchronises the caller so it waits for setup to complete.
-#[cfg(target_os = "linux")]
-fn linux_avahi_browse(
-    my_cn: &str,
-    state: Arc<Mutex<AppState>>,
-) -> Option<(zbus::blocking::Connection, watch::Receiver<Vec<String>>)> {
-    use zbus::blocking::Connection;
-
-    let conn = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: browse D-Bus conn failed ({e})"
-            ));
-            return None;
-        }
-    };
-    let conn_resolve = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: resolve D-Bus conn failed ({e})"
-            ));
-            return None;
-        }
-    };
-
-    let conn_keepalive = conn.clone();
-    let (peer_tx, peer_rx) = watch::channel(vec![]);
-    let my_cn = my_cn.to_string();
-
-    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<String, String>>();
-
-    std::thread::spawn(move || {
-        // Step 1: register the broad match rule BEFORE creating the browser.
-        // No `.path()` filter — we don't know the browser's path yet, and we
-        // must not miss signals fired during/immediately after browser creation.
-        let rule = match (|| -> zbus::Result<_> {
-            Ok(zbus::MatchRule::builder()
-                .msg_type(zbus::message::Type::Signal)
-                .sender("org.freedesktop.Avahi")?
-                .interface("org.freedesktop.Avahi.ServiceBrowser")?
-                .build())
-        })() {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = format!("mDNS[avahi]: match rule error ({e})");
-                state.lock().unwrap().push_log(msg.clone());
-                ready_tx.send(Err(msg)).ok();
-                return;
-            }
-        };
-
-        let iter = match zbus::blocking::MessageIterator::for_match_rule(rule, &conn, Some(64)) {
-            Ok(i) => i,
-            Err(e) => {
-                let msg = format!("mDNS[avahi]: iterator error ({e})");
-                state.lock().unwrap().push_log(msg.clone());
-                ready_tx.send(Err(msg)).ok();
-                return;
-            }
-        };
-
-        // Step 2: NOW create the browser — signals are already queued.
-        let browser_path: zbus::zvariant::OwnedObjectPath = match conn
-            .call_method(
-                Some("org.freedesktop.Avahi"),
-                "/",
-                Some("org.freedesktop.Avahi.Server"),
-                "ServiceBrowserNew",
-                &(-1i32, -1i32, "_dverse._tcp", "local", 0u32),
-            )
-            .and_then(|r| r.body().deserialize().map_err(Into::into))
-        {
-            Ok(p) => p,
-            Err(e) => {
-                let msg = format!("mDNS[avahi]: ServiceBrowserNew failed ({e})");
-                state.lock().unwrap().push_log(msg.clone());
-                ready_tx.send(Err(msg)).ok();
-                return;
-            }
-        };
-
-        let browser_path_str = browser_path.as_str().to_string();
-        state
-            .lock()
-            .unwrap()
-            .push_log(format!("mDNS[avahi]: browser at {browser_path_str}"));
-        ready_tx.send(Ok(browser_path_str.clone())).ok();
-
-        let mut peers: HashMap<String, Vec<String>> = HashMap::new();
-
-        for msg_result in iter {
-            let msg = match msg_result {
-                Ok(m) => m,
-                Err(e) => {
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[avahi]: D-Bus error ({e}); stopping"
-                    ));
-                    break;
-                }
-            };
-
-            // Filter to signals from our specific ServiceBrowser object — the
-            // broad match rule may also deliver signals from other browsers if
-            // multiple `ServiceBrowserNew` instances exist on the bus.
-            let msg_path = msg.header().path().map(|p| p.as_str().to_owned());
-            if msg_path.as_deref() != Some(browser_path_str.as_str()) {
-                continue;
-            }
-
-            let Some(member) = msg.header().member().map(|m| m.to_owned()) else { continue };
-
-            match member.as_str() {
-                "ItemNew" => {
-                    let body: zbus::Result<(i32, i32, String, String, String, u32)> =
-                        msg.body().deserialize();
-                    let Ok((svc_iface, svc_proto, name, svc_type, domain, _)) = body else {
-                        state
-                            .lock()
-                            .unwrap()
-                            .push_log("mDNS[avahi]: ItemNew body parse failed".to_string());
-                        continue;
-                    };
-
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[avahi]: ItemNew iface={svc_iface} proto={svc_proto} \
-                         name={name:?} type={svc_type:?} domain={domain:?}"
-                    ));
-
-                    let resolve = conn_resolve.call_method(
-                        Some("org.freedesktop.Avahi"),
-                        "/",
-                        Some("org.freedesktop.Avahi.Server"),
-                        "ResolveService",
-                        &(
-                            svc_iface,
-                            svc_proto,
-                            name.as_str(),
-                            svc_type.as_str(),
-                            domain.as_str(),
-                            -1i32,
-                            0u32,
-                        ),
-                    );
-                    let reply = match resolve {
-                        Ok(r) => r,
-                        Err(e) => {
-                            state.lock().unwrap().push_log(format!(
-                                "mDNS[avahi]: ResolveService error ({e})"
-                            ));
-                            continue;
-                        }
-                    };
-
-                    type Resolved = (
-                        i32, i32, String, String, String, String,
-                        i32, String, u16, Vec<Vec<u8>>, u32,
-                    );
-                    let body: zbus::Result<Resolved> = reply.body().deserialize();
-                    let Ok((_, _, _, _, _, host, _, address, port, txt, _)) = body else {
-                        state.lock().unwrap().push_log(
-                            "mDNS[avahi]: ResolveService body parse failed".to_string(),
-                        );
-                        continue;
-                    };
-
-                    let remote_cn: String = txt
-                        .iter()
-                        .find_map(|e| {
-                            std::str::from_utf8(e)
-                                .ok()
-                                .and_then(|s| s.strip_prefix("cn="))
-                                .map(str::to_string)
-                        })
-                        .unwrap_or_default();
-                    let txt_ipv4: Option<std::net::Ipv4Addr> = txt.iter().find_map(|e| {
-                        std::str::from_utf8(e)
-                            .ok()
-                            .and_then(|s| s.strip_prefix("ip="))
-                            .and_then(|s| s.parse().ok())
-                    });
-
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[avahi]: resolved host={host:?} addr={address} port={port} \
-                         cn={remote_cn:?} txt_ip={txt_ipv4:?}"
-                    ));
-
-                    if remote_cn.is_empty() || remote_cn == my_cn {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[avahi]: skipping self or empty CN ({remote_cn:?})"
-                        ));
-                        continue;
-                    }
-
-                    // Prefer the IPv4 from the TXT record (peer published their own
-                    // routable LAN IP).  Fall back to the resolved A/AAAA address.
-                    let chosen_ip: std::net::IpAddr = if let Some(ipv4) = txt_ipv4 {
-                        if !ipv4.is_loopback() && !ipv4.is_link_local() {
-                            std::net::IpAddr::V4(ipv4)
-                        } else {
-                            match address.parse() {
-                                Ok(ip) => ip,
-                                Err(_) => {
-                                    state.lock().unwrap().push_log(format!(
-                                        "mDNS[avahi]: addr parse failed for {address:?}"
-                                    ));
-                                    continue;
-                                }
-                            }
-                        }
-                    } else {
-                        match address.parse() {
-                            Ok(ip) => ip,
-                            Err(_) => {
-                                state.lock().unwrap().push_log(format!(
-                                    "mDNS[avahi]: addr parse failed for {address:?}"
-                                ));
-                                continue;
-                            }
-                        }
-                    };
-
-                    if is_unroutable(&chosen_ip) {
-                        state.lock().unwrap().push_log(format!(
-                            "mDNS[avahi]: skipping unroutable addr {chosen_ip}"
-                        ));
-                        continue;
-                    }
-
-                    let endpoint = format!("tls/{chosen_ip}:{port}");
-                    let key = format!("{name}.{svc_type}.");
-
-                    let entry = peers.entry(key).or_default();
-                    if !entry.contains(&endpoint) {
-                        entry.push(endpoint.clone());
-                        entry.sort();
-                        state.lock().unwrap().push_log(format!(
-                            "Discovered peer router: {endpoint} (CN={remote_cn})"
-                        ));
-                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
-                    }
-                }
-                "ItemRemove" => {
-                    let body: zbus::Result<(i32, i32, String, String, String, u32)> =
-                        msg.body().deserialize();
-                    let Ok((_, _, name, svc_type, _, _)) = body else { continue };
-                    state.lock().unwrap().push_log(format!(
-                        "mDNS[avahi]: ItemRemove name={name:?} type={svc_type:?}"
-                    ));
-                    let key = format!("{name}.{svc_type}.");
-                    if let Some(endpoints) = peers.remove(&key) {
-                        state.lock().unwrap().push_log(format!(
-                            "Peer router left: {}",
-                            endpoints.first().map(String::as_str).unwrap_or(&key),
-                        ));
-                        let _ = peer_tx.send(peers.values().flatten().cloned().collect());
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        state.lock().unwrap().push_log("mDNS[avahi]: signal loop exited".to_string());
-    });
-
-    match ready_rx.recv() {
-        Ok(Ok(_)) => Some((conn_keepalive, peer_rx)),
-        Ok(Err(_)) | Err(_) => None,
-    }
+fn mdns_sd_start(cn: &str, port: u16, state: &Arc<Mutex<AppState>>) -> Option<MdnsHandle> {
+    let daemon = create_filtered_daemon(state)?;
+    let fullname = announcing::mdns_sd_register(&daemon, cn, port, state)?;
+    let peer_rx = browsing::mdns_sd_start(&daemon, cn, state)?;
+    Some(MdnsHandle {
+        _inner: Inner::MdnsSd(MdnsSdSession { daemon, fullname }),
+        peer_rx,
+    })
 }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -3,12 +3,13 @@
 //! Public entry point: [`MdnsHandle::publish`].  Drop the handle to withdraw
 //! the service record and stop browsing.
 //!
-//! Backend selection:
-//!   * Linux:   try avahi D-Bus (publish + browse) so avahi-daemon is the
-//!              single mDNS responder on the host.  Fall back to mdns-sd if
-//!              the system bus or avahi is unavailable.
-//!   * Windows / macOS:  mdns-sd for both publish and browse — one
-//!              `ServiceDaemon` to avoid UDP-5353 socket conflicts.
+//! Backend: one `mdns_sd::ServiceDaemon` per router process, used for both
+//! publishing and browsing.  We previously had a Linux-specific avahi D-Bus
+//! path but removed it after repeated cross-platform flakiness — Chromium's
+//! bundled mDNS responder, the 0.9-rc avahi-daemon's conflict-detection
+//! regression, and the avahi-vs-cert SAN hostname disagreements all
+//! conspired to make it unusable.  mdns-sd works the same on every platform
+//! and runs entirely in-process.
 //!
 //! Internals are split across three sibling modules:
 //!   * [`common`]     — shared constants, format helpers, IP detection,
@@ -27,14 +28,13 @@ use tokio::sync::watch;
 
 use crate::state::AppState;
 
-use self::common::{create_filtered_daemon, detect_lan_ipv4, instance_name, SERVICE_TYPE};
+use self::common::create_filtered_daemon;
 
-/// Discovery handle.  Holds backend resources alive (D-Bus connections,
-/// mdns-sd daemon) and exposes a `peer_rx` watch channel listing the current
-/// peer endpoints as `tls/<ip>:<port>` strings ready for Zenoh's
-/// `connect/endpoints`.
+/// Discovery handle.  Holds the mdns-sd daemon alive and exposes a `peer_rx`
+/// watch channel listing the current peer endpoints as `tls/<ip>:<port>`
+/// strings, ready for Zenoh's `connect/endpoints`.
 pub struct MdnsHandle {
-    _inner: Inner,
+    _inner: MdnsSdSession,
     pub peer_rx: watch::Receiver<Vec<String>>,
 }
 
@@ -45,30 +45,9 @@ impl MdnsHandle {
         port: u16,
         state: &Arc<Mutex<AppState>>,
     ) -> Option<Self> {
-        #[cfg(target_os = "linux")]
-        {
-            state.lock().unwrap().push_log("mDNS: trying avahi D-Bus backend…".to_string());
-            if let Some(handle) = linux_avahi_start(cn, session_id, port, Arc::clone(state)) {
-                return Some(handle);
-            }
-            state.lock().unwrap().push_log(
-                "mDNS: avahi unavailable, falling back to mdns-sd".to_string(),
-            );
-        }
-        #[cfg(not(target_os = "linux"))]
         state.lock().unwrap().push_log("mDNS: using mdns-sd backend".to_string());
         mdns_sd_start(cn, session_id, port, state)
     }
-}
-
-#[allow(dead_code)]
-enum Inner {
-    #[cfg(target_os = "linux")]
-    Avahi {
-        _publish_conn: zbus::blocking::Connection,
-        _browse_conn: zbus::blocking::Connection,
-    },
-    MdnsSd(MdnsSdSession),
 }
 
 /// Owns the mdns-sd daemon + the registered service fullname so we can
@@ -85,59 +64,6 @@ impl Drop for MdnsSdSession {
     }
 }
 
-// ── Linux: avahi D-Bus for publish AND browse ────────────────────────────────
-
-#[cfg(target_os = "linux")]
-fn linux_avahi_start(
-    cn: &str,
-    session_id: &str,
-    port: u16,
-    state: Arc<Mutex<AppState>>,
-) -> Option<MdnsHandle> {
-    use zbus::blocking::Connection;
-
-    let publish_conn = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: D-Bus system bus unavailable ({e})"
-            ));
-            return None;
-        }
-    };
-
-    if let Err(e) = announcing::avahi_register(cn, session_id, port, &publish_conn) {
-        state.lock().unwrap().push_log(format!("mDNS[avahi]: publish failed ({e})"));
-        return None;
-    }
-    state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: published {} on {SERVICE_TYPE} port {port} addr={} session={session_id}",
-        instance_name(cn),
-        detect_lan_ipv4()
-            .map(|ip| ip.to_string())
-            .unwrap_or_else(|| "unknown".to_string()),
-    ));
-
-    match browsing::avahi_start(cn, session_id, Arc::clone(&state)) {
-        Some((browse_conn, peer_rx)) => {
-            state.lock().unwrap().push_log("mDNS[avahi]: browse started".to_string());
-            Some(MdnsHandle {
-                _inner: Inner::Avahi {
-                    _publish_conn: publish_conn,
-                    _browse_conn: browse_conn,
-                },
-                peer_rx,
-            })
-        }
-        None => {
-            state.lock().unwrap().push_log("mDNS[avahi]: browse failed".to_string());
-            None
-        }
-    }
-}
-
-// ── Cross-platform: one mdns-sd daemon for both publish and browse ───────────
-
 fn mdns_sd_start(
     cn: &str,
     session_id: &str,
@@ -148,7 +74,7 @@ fn mdns_sd_start(
     let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port, state)?;
     let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id, state)?;
     Some(MdnsHandle {
-        _inner: Inner::MdnsSd(MdnsSdSession { daemon, fullname }),
+        _inner: MdnsSdSession { daemon, fullname },
         peer_rx,
     })
 }

--- a/src/zenoh_router/src/discovery/announcing.rs
+++ b/src/zenoh_router/src/discovery/announcing.rs
@@ -15,8 +15,8 @@ use crate::state::AppState;
 
 use super::common::{
     detect_lan_ipv4, instance_name, pinned_a_record_host, srv_host_name, txt_cn_entry,
-    txt_ip_entry, AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_INET, AVAHI_PROTO_UNSPEC,
-    SERVICE_NAME, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    txt_ip_entry, txt_session_entry, AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_INET,
+    AVAHI_PROTO_UNSPEC, SERVICE_NAME, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP, TXT_KEY_SESSION,
 };
 
 // ── mdns-sd ──────────────────────────────────────────────────────────────────
@@ -26,6 +26,7 @@ use super::common::{
 pub(super) fn mdns_sd_register(
     daemon: &ServiceDaemon,
     cn: &str,
+    session_id: &str,
     port: u16,
     state: &Arc<Mutex<AppState>>,
 ) -> Option<String> {
@@ -40,13 +41,18 @@ pub(super) fn mdns_sd_register(
             .unwrap_or_else(|| "unknown".to_string())
     ));
 
-    // TXT props: always `cn`, optionally `ip` for cross-stack address recovery.
+    // TXT props: always `cn` + `session`, optionally `ip` for cross-stack
+    // address recovery.
     let ip_str;
     let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
         ip_str = ip.to_string();
-        &[(TXT_KEY_CN, cn), (TXT_KEY_IP, &ip_str)]
+        &[
+            (TXT_KEY_CN, cn),
+            (TXT_KEY_SESSION, session_id),
+            (TXT_KEY_IP, &ip_str),
+        ]
     } else {
-        &[(TXT_KEY_CN, cn)]
+        &[(TXT_KEY_CN, cn), (TXT_KEY_SESSION, session_id)]
     };
 
     // Pin the A record to the LAN IPv4 explicitly; without this mdns-sd
@@ -100,6 +106,7 @@ pub(super) fn mdns_sd_register(
 #[cfg(target_os = "linux")]
 pub(super) fn avahi_register(
     cn: &str,
+    session_id: &str,
     port: u16,
     conn: &zbus::blocking::Connection,
 ) -> anyhow::Result<()> {
@@ -117,7 +124,7 @@ pub(super) fn avahi_register(
     let instance = instance_name(cn);
     let lan_ip = detect_lan_ipv4();
 
-    let mut txt: Vec<Vec<u8>> = vec![txt_cn_entry(cn)];
+    let mut txt: Vec<Vec<u8>> = vec![txt_cn_entry(cn), txt_session_entry(session_id)];
     if let Some(ipv4) = lan_ip {
         txt.push(txt_ip_entry(ipv4));
     }

--- a/src/zenoh_router/src/discovery/announcing.rs
+++ b/src/zenoh_router/src/discovery/announcing.rs
@@ -1,0 +1,196 @@
+//! Publishing side of DNS-SD discovery — registers this router as a
+//! `_dverse._tcp` service so peers can find us.
+//!
+//! Two backends:
+//!   * Linux: [`avahi_register`] calls avahi-daemon's D-Bus EntryGroup API.
+//!   * Cross-platform: [`mdns_sd_register`] adds a service to a mdns-sd
+//!     daemon (created by [`super::common::create_filtered_daemon`]).
+
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+
+use crate::state::AppState;
+
+use super::common::{
+    detect_lan_ipv4, instance_name, pinned_a_record_host, srv_host_name, txt_cn_entry,
+    txt_ip_entry, AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_INET, AVAHI_PROTO_UNSPEC,
+    SERVICE_NAME, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+};
+
+// ── mdns-sd ──────────────────────────────────────────────────────────────────
+
+/// Register our service on the given mdns-sd daemon.  Returns the fullname
+/// so the caller can `unregister` it on shutdown.
+pub(super) fn mdns_sd_register(
+    daemon: &ServiceDaemon,
+    cn: &str,
+    port: u16,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<String> {
+    let instance = instance_name(cn);
+    let host = srv_host_name(cn);
+    let lan_ip = detect_lan_ipv4();
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: LAN IP={}",
+        lan_ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+
+    // TXT props: always `cn`, optionally `ip` for cross-stack address recovery.
+    let ip_str;
+    let props: &[(&str, &str)] = if let Some(ip) = lan_ip {
+        ip_str = ip.to_string();
+        &[(TXT_KEY_CN, cn), (TXT_KEY_IP, &ip_str)]
+    } else {
+        &[(TXT_KEY_CN, cn)]
+    };
+
+    // Pin the A record to the LAN IPv4 explicitly; without this mdns-sd
+    // populates it with every active interface address — loopback / docker /
+    // VPN — and the resulting set is unhelpful to remote peers.
+    let svc_result = match lan_ip {
+        Some(ip) => ServiceInfo::new(
+            SERVICE_TYPE,
+            &instance,
+            &host,
+            IpAddr::V4(ip),
+            port,
+            props,
+        ),
+        None => ServiceInfo::new(SERVICE_TYPE, &instance, &host, (), port, props),
+    };
+    let svc = match svc_result {
+        Ok(s) => s,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: service info error ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+
+    let fullname = svc.get_fullname().to_string();
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: registering {fullname} on port {port}"
+    ));
+
+    if let Err(e) = daemon.register(svc) {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: register failed ({e}); peer discovery disabled"
+        ));
+        return None;
+    }
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: published {instance} on {SERVICE_TYPE} port {port}"
+    ));
+
+    Some(fullname)
+}
+
+// ── Linux: avahi D-Bus EntryGroup ────────────────────────────────────────────
+
+/// Publish our service via avahi-daemon's D-Bus interface.
+/// On success the EntryGroup is committed; on Drop of the bus connection
+/// avahi will withdraw the record.
+#[cfg(target_os = "linux")]
+pub(super) fn avahi_register(
+    cn: &str,
+    port: u16,
+    conn: &zbus::blocking::Connection,
+) -> anyhow::Result<()> {
+    let group_path: zbus::zvariant::OwnedObjectPath = conn
+        .call_method(
+            Some("org.freedesktop.Avahi"),
+            "/",
+            Some("org.freedesktop.Avahi.Server"),
+            "EntryGroupNew",
+            &(),
+        )?
+        .body()
+        .deserialize()?;
+
+    let instance = instance_name(cn);
+    let lan_ip = detect_lan_ipv4();
+
+    let mut txt: Vec<Vec<u8>> = vec![txt_cn_entry(cn)];
+    if let Some(ipv4) = lan_ip {
+        txt.push(txt_ip_entry(ipv4));
+    }
+
+    // Try to claim a dedicated A record so SRV resolution lands on the
+    // LAN IPv4 only.  Falls back to avahi's default machine hostname on
+    // collision (stale entry from a prior crash, etc.).
+    let custom_host = pinned_a_record_host(cn);
+    let custom_host_registered = lan_ip
+        .map(|ipv4| try_register_pinned_a(conn, &group_path, &custom_host, ipv4))
+        .unwrap_or(false);
+    let srv_host = if custom_host_registered { custom_host.as_str() } else { "" };
+
+    conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        group_path.as_str(),
+        Some("org.freedesktop.Avahi.EntryGroup"),
+        "AddService",
+        &(
+            AVAHI_IF_UNSPEC,
+            AVAHI_PROTO_UNSPEC,
+            AVAHI_NO_FLAGS,
+            instance.as_str(),
+            SERVICE_NAME,
+            "",  // sub-type: none
+            srv_host,
+            port,
+            &txt,
+        ),
+    )?;
+
+    conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        group_path.as_str(),
+        Some("org.freedesktop.Avahi.EntryGroup"),
+        "Commit",
+        &(),
+    )?;
+
+    Ok(())
+}
+
+/// Best-effort registration of an A record (`hostname → ipv4`) in the given
+/// EntryGroup.  Returns `true` on success.  Failure (typically a stale-name
+/// `CollisionError`) is logged to stderr and reported as `false` so the
+/// caller can fall back to avahi's default hostname behaviour.
+#[cfg(target_os = "linux")]
+fn try_register_pinned_a(
+    conn: &zbus::blocking::Connection,
+    group_path: &zbus::zvariant::OwnedObjectPath,
+    hostname: &str,
+    ipv4: std::net::Ipv4Addr,
+) -> bool {
+    let res = conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        group_path.as_str(),
+        Some("org.freedesktop.Avahi.EntryGroup"),
+        "AddAddress",
+        &(
+            AVAHI_IF_UNSPEC,
+            AVAHI_PROTO_INET,
+            AVAHI_NO_FLAGS,
+            hostname,
+            ipv4.to_string().as_str(),
+        ),
+    );
+    match res {
+        Ok(_) => true,
+        Err(e) => {
+            eprintln!(
+                "mDNS[avahi]: AddAddress for {hostname} failed ({e}); using default host"
+            );
+            false
+        }
+    }
+}

--- a/src/zenoh_router/src/discovery/announcing.rs
+++ b/src/zenoh_router/src/discovery/announcing.rs
@@ -1,10 +1,12 @@
 //! Publishing side of DNS-SD discovery — registers this router as a
 //! `_dverse._tcp` service so peers can find us.
 //!
-//! Two backends:
-//!   * Linux: [`avahi_register`] calls avahi-daemon's D-Bus EntryGroup API.
-//!   * Cross-platform: [`mdns_sd_register`] adds a service to a mdns-sd
-//!     daemon (created by [`super::common::create_filtered_daemon`]).
+//! Single backend: mdns-sd.  The avahi D-Bus path was removed because of
+//! repeated cross-platform flakiness — Chromium's bundled mDNS responder
+//! claims `.local` names, the 0.9-rc avahi-daemon has a conflict-detection
+//! regression that rejects every custom `AddAddress`, and avahi's docs
+//! disagree with our needs on trailing dots and SAN-matching hostnames.
+//! mdns-sd does the same job in-process, on every platform.
 
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
@@ -14,12 +16,9 @@ use mdns_sd::{ServiceDaemon, ServiceInfo};
 use crate::state::AppState;
 
 use super::common::{
-    detect_lan_ipv4, instance_name, pinned_a_record_host, srv_host_name, txt_cn_entry,
-    txt_ip_entry, txt_session_entry, AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_INET,
-    AVAHI_PROTO_UNSPEC, SERVICE_NAME, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP, TXT_KEY_SESSION,
+    detect_lan_ipv4, instance_name, srv_host_name, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    TXT_KEY_SESSION,
 };
-
-// ── mdns-sd ──────────────────────────────────────────────────────────────────
 
 /// Register our service on the given mdns-sd daemon.  Returns the fullname
 /// so the caller can `unregister` it on shutdown.
@@ -96,108 +95,4 @@ pub(super) fn mdns_sd_register(
     ));
 
     Some(fullname)
-}
-
-// ── Linux: avahi D-Bus EntryGroup ────────────────────────────────────────────
-
-/// Publish our service via avahi-daemon's D-Bus interface.
-/// On success the EntryGroup is committed; on Drop of the bus connection
-/// avahi will withdraw the record.
-#[cfg(target_os = "linux")]
-pub(super) fn avahi_register(
-    cn: &str,
-    session_id: &str,
-    port: u16,
-    conn: &zbus::blocking::Connection,
-) -> anyhow::Result<()> {
-    let group_path: zbus::zvariant::OwnedObjectPath = conn
-        .call_method(
-            Some("org.freedesktop.Avahi"),
-            "/",
-            Some("org.freedesktop.Avahi.Server"),
-            "EntryGroupNew",
-            &(),
-        )?
-        .body()
-        .deserialize()?;
-
-    let instance = instance_name(cn);
-    let lan_ip = detect_lan_ipv4();
-
-    let mut txt: Vec<Vec<u8>> = vec![txt_cn_entry(cn), txt_session_entry(session_id)];
-    if let Some(ipv4) = lan_ip {
-        txt.push(txt_ip_entry(ipv4));
-    }
-
-    // Try to claim a dedicated A record so SRV resolution lands on the
-    // LAN IPv4 only.  Falls back to avahi's default machine hostname on
-    // collision (stale entry from a prior crash, etc.).
-    let custom_host = pinned_a_record_host(cn);
-    let custom_host_registered = lan_ip
-        .map(|ipv4| try_register_pinned_a(conn, &group_path, &custom_host, ipv4))
-        .unwrap_or(false);
-    let srv_host = if custom_host_registered { custom_host.as_str() } else { "" };
-
-    conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        group_path.as_str(),
-        Some("org.freedesktop.Avahi.EntryGroup"),
-        "AddService",
-        &(
-            AVAHI_IF_UNSPEC,
-            AVAHI_PROTO_UNSPEC,
-            AVAHI_NO_FLAGS,
-            instance.as_str(),
-            SERVICE_NAME,
-            "",  // sub-type: none
-            srv_host,
-            port,
-            &txt,
-        ),
-    )?;
-
-    conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        group_path.as_str(),
-        Some("org.freedesktop.Avahi.EntryGroup"),
-        "Commit",
-        &(),
-    )?;
-
-    Ok(())
-}
-
-/// Best-effort registration of an A record (`hostname → ipv4`) in the given
-/// EntryGroup.  Returns `true` on success.  Failure (typically a stale-name
-/// `CollisionError`) is logged to stderr and reported as `false` so the
-/// caller can fall back to avahi's default hostname behaviour.
-#[cfg(target_os = "linux")]
-fn try_register_pinned_a(
-    conn: &zbus::blocking::Connection,
-    group_path: &zbus::zvariant::OwnedObjectPath,
-    hostname: &str,
-    ipv4: std::net::Ipv4Addr,
-) -> bool {
-    let res = conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        group_path.as_str(),
-        Some("org.freedesktop.Avahi.EntryGroup"),
-        "AddAddress",
-        &(
-            AVAHI_IF_UNSPEC,
-            AVAHI_PROTO_INET,
-            AVAHI_NO_FLAGS,
-            hostname,
-            ipv4.to_string().as_str(),
-        ),
-    );
-    match res {
-        Ok(_) => true,
-        Err(e) => {
-            eprintln!(
-                "mDNS[avahi]: AddAddress for {hostname} failed ({e}); using default host"
-            );
-            false
-        }
-    }
 }

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -1,0 +1,523 @@
+//! Browsing side of DNS-SD discovery — watches for other `_dverse._tcp`
+//! services on the LAN and exposes their endpoints as a watch channel.
+//!
+//! Two backends, mirroring announcing.rs:
+//!   * Linux: avahi D-Bus `ServiceBrowser` + `ResolveService`.
+//!   * Cross-platform: mdns-sd `browse()` + `ServiceEvent` channel.
+
+use std::sync::{Arc, Mutex};
+
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use tokio::sync::watch;
+
+use crate::state::AppState;
+
+use super::common::{
+    is_unroutable, peer_cache_key, zenoh_tls_endpoint, PeerRegistry, MDNS_DOMAIN,
+    AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_UNSPEC, SERVICE_NAME,
+    DBUS_MATCH_QUEUE_DEPTH, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+};
+
+// ── mdns-sd browse ───────────────────────────────────────────────────────────
+
+/// Start browsing for peers on the given mdns-sd daemon and return a watch
+/// receiver of the current endpoint list.  Spawns a background thread that
+/// drains the daemon's event channel.
+pub(super) fn mdns_sd_start(
+    daemon: &ServiceDaemon,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<watch::Receiver<Vec<String>>> {
+    let browse_rx = match daemon.browse(SERVICE_TYPE) {
+        Ok(rx) => rx,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: browse failed ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: browse started".to_string());
+
+    let (registry, peer_rx) = PeerRegistry::new();
+    let my_cn = my_cn.to_string();
+    let state = Arc::clone(state);
+
+    std::thread::spawn(move || {
+        let mut registry = registry;
+        while let Ok(event) = browse_rx.recv() {
+            handle_mdns_sd_event(event, &my_cn, &state, &mut registry);
+        }
+        state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
+    });
+
+    Some(peer_rx)
+}
+
+fn handle_mdns_sd_event(
+    event: ServiceEvent,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    match event {
+        ServiceEvent::ServiceFound(svc_type, fullname) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
+            ));
+        }
+        ServiceEvent::ServiceResolved(info) => handle_resolved(info, my_cn, state, registry),
+        ServiceEvent::ServiceRemoved(_, fullname) => {
+            state
+                .lock()
+                .unwrap()
+                .push_log(format!("mDNS[mdns-sd]: removed {fullname:?}"));
+            if let Some(endpoints) = registry.remove(&fullname) {
+                state.lock().unwrap().push_log(format!(
+                    "Peer router left: {}",
+                    endpoints.first().map(String::as_str).unwrap_or(&fullname),
+                ));
+            }
+        }
+        other => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: event {other:?}"
+            ));
+        }
+    }
+}
+
+fn handle_resolved(
+    info: ServiceInfo,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
+    let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
+    state.lock().unwrap().push_log(format!(
+        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
+        info.get_fullname(),
+        info.get_port(),
+    ));
+
+    if remote_cn.is_empty() || remote_cn == my_cn {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    let endpoints = endpoints_for(&info, remote_cn, state);
+    if endpoints.is_empty() {
+        return;
+    }
+
+    if registry.set(info.get_fullname().to_string(), endpoints.clone()) {
+        state.lock().unwrap().push_log(format!(
+            "Discovered peer router: {} (+{} addr) (CN={remote_cn})",
+            endpoints[0],
+            endpoints.len() - 1,
+        ));
+    } else {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: peer {remote_cn} unchanged, ignoring duplicate"
+        ));
+    }
+}
+
+/// Convert a resolved `ServiceInfo` into the list of Zenoh endpoints we'll
+/// connect to.  Prefers the peer's TXT `ip=` over whatever SRV/A resolution
+/// returned (see [`super::common::TXT_KEY_IP`] for why).
+fn endpoints_for(
+    info: &ServiceInfo,
+    remote_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> Vec<String> {
+    let port = info.get_port();
+
+    let txt_ipv4 = info
+        .get_property_val_str(TXT_KEY_IP)
+        .and_then(|s| s.parse::<std::net::Ipv4Addr>().ok())
+        .filter(|ip| !ip.is_loopback() && !ip.is_link_local());
+
+    if let Some(ipv4) = txt_ipv4 {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: using TXT ip={ipv4} for {remote_cn}"
+        ));
+        return vec![zenoh_tls_endpoint(std::net::IpAddr::V4(ipv4), port)];
+    }
+
+    let mut endpoints: Vec<String> = info
+        .get_addresses()
+        .iter()
+        .filter_map(|a| {
+            if is_unroutable(a) {
+                state.lock().unwrap().push_log(format!(
+                    "mDNS[mdns-sd]: skipping unroutable addr {a}"
+                ));
+                return None;
+            }
+            match a {
+                std::net::IpAddr::V4(_) => Some(zenoh_tls_endpoint(*a, port)),
+                _ => None,
+            }
+        })
+        .collect();
+    endpoints.sort();
+
+    if endpoints.is_empty() {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: resolved {remote_cn} but no routable IPv4 \
+             (no TXT ip, addrs={:?}); skipping",
+            info.get_addresses().iter().collect::<Vec<_>>(),
+        ));
+    }
+
+    endpoints
+}
+
+// ── Linux: avahi D-Bus ServiceBrowser ────────────────────────────────────────
+
+/// Subscribe to avahi's `_dverse._tcp` ServiceBrowser via D-Bus.  Returns the
+/// D-Bus connection (caller keeps it alive) and a watch receiver carrying
+/// the current peer endpoint list.
+///
+/// Critical ordering: the D-Bus signal subscription is registered BEFORE
+/// `ServiceBrowserNew` is called.  avahi fires `ItemNew` signals for any
+/// already-cached services immediately after the browser is created; if we
+/// only set up the subscription afterwards we miss those signals.
+///
+/// Implementation: the worker thread registers a broad MatchRule (no `path`
+/// filter — we don't know the browser's object path yet), THEN calls
+/// `ServiceBrowserNew`, THEN filters incoming signals by `browser_path`.
+/// A `mpsc::channel` blocks the caller until setup is complete.
+#[cfg(target_os = "linux")]
+pub(super) fn avahi_start(
+    my_cn: &str,
+    state: Arc<Mutex<AppState>>,
+) -> Option<(zbus::blocking::Connection, watch::Receiver<Vec<String>>)> {
+    use zbus::blocking::Connection;
+
+    let conn = match Connection::system() {
+        Ok(c) => c,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: browse D-Bus conn failed ({e})"
+            ));
+            return None;
+        }
+    };
+    // Resolve calls block on D-Bus replies; using a separate connection
+    // prevents them from interleaving with the incoming signal stream.
+    let conn_resolve = match Connection::system() {
+        Ok(c) => c,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: resolve D-Bus conn failed ({e})"
+            ));
+            return None;
+        }
+    };
+
+    let conn_keepalive = conn.clone();
+    let (registry, peer_rx) = PeerRegistry::new();
+    let my_cn = my_cn.to_string();
+
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<String, String>>();
+
+    std::thread::spawn(move || {
+        run_avahi_browse_thread(conn, conn_resolve, my_cn, state, registry, ready_tx);
+    });
+
+    match ready_rx.recv() {
+        Ok(Ok(_)) => Some((conn_keepalive, peer_rx)),
+        Ok(Err(_)) | Err(_) => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_avahi_browse_thread(
+    conn: zbus::blocking::Connection,
+    conn_resolve: zbus::blocking::Connection,
+    my_cn: String,
+    state: Arc<Mutex<AppState>>,
+    mut registry: PeerRegistry,
+    ready_tx: std::sync::mpsc::Sender<Result<String, String>>,
+) {
+    // Step 1: subscribe to ServiceBrowser signals BEFORE creating the browser.
+    let iter = match subscribe_to_service_browser_signals(&conn) {
+        Ok(i) => i,
+        Err(msg) => {
+            state.lock().unwrap().push_log(msg.clone());
+            ready_tx.send(Err(msg)).ok();
+            return;
+        }
+    };
+
+    // Step 2: NOW create the browser — signals are already queued.
+    let browser_path = match create_service_browser(&conn) {
+        Ok(path) => path,
+        Err(msg) => {
+            state.lock().unwrap().push_log(msg.clone());
+            ready_tx.send(Err(msg)).ok();
+            return;
+        }
+    };
+
+    state.lock().unwrap().push_log(format!("mDNS[avahi]: browser at {browser_path}"));
+    ready_tx.send(Ok(browser_path.clone())).ok();
+
+    drain_avahi_signals(iter, &browser_path, &conn_resolve, &my_cn, &state, &mut registry);
+    state.lock().unwrap().push_log("mDNS[avahi]: signal loop exited".to_string());
+}
+
+#[cfg(target_os = "linux")]
+fn subscribe_to_service_browser_signals(
+    conn: &zbus::blocking::Connection,
+) -> Result<zbus::blocking::MessageIterator, String> {
+    let rule = zbus::MatchRule::builder()
+        .msg_type(zbus::message::Type::Signal)
+        .sender("org.freedesktop.Avahi")
+        .map_err(|e| format!("mDNS[avahi]: match rule sender error ({e})"))?
+        .interface("org.freedesktop.Avahi.ServiceBrowser")
+        .map_err(|e| format!("mDNS[avahi]: match rule iface error ({e})"))?
+        .build();
+
+    zbus::blocking::MessageIterator::for_match_rule(rule, conn, Some(DBUS_MATCH_QUEUE_DEPTH))
+        .map_err(|e| format!("mDNS[avahi]: iterator error ({e})"))
+}
+
+#[cfg(target_os = "linux")]
+fn create_service_browser(conn: &zbus::blocking::Connection) -> Result<String, String> {
+    let path: zbus::zvariant::OwnedObjectPath = conn
+        .call_method(
+            Some("org.freedesktop.Avahi"),
+            "/",
+            Some("org.freedesktop.Avahi.Server"),
+            "ServiceBrowserNew",
+            &(
+                AVAHI_IF_UNSPEC,
+                AVAHI_PROTO_UNSPEC,
+                SERVICE_NAME,
+                MDNS_DOMAIN,
+                AVAHI_NO_FLAGS,
+            ),
+        )
+        .and_then(|r| r.body().deserialize().map_err(Into::into))
+        .map_err(|e| format!("mDNS[avahi]: ServiceBrowserNew failed ({e})"))?;
+    Ok(path.as_str().to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn drain_avahi_signals(
+    iter: zbus::blocking::MessageIterator,
+    browser_path: &str,
+    conn_resolve: &zbus::blocking::Connection,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    for msg_result in iter {
+        let msg = match msg_result {
+            Ok(m) => m,
+            Err(e) => {
+                state.lock().unwrap().push_log(format!(
+                    "mDNS[avahi]: D-Bus error ({e}); stopping"
+                ));
+                break;
+            }
+        };
+
+        // Filter: only handle signals from OUR ServiceBrowser object — the
+        // broad MatchRule above can deliver signals from any browser on the
+        // bus if multiple `ServiceBrowserNew` instances exist.
+        let msg_path = msg.header().path().map(|p| p.as_str().to_owned());
+        if msg_path.as_deref() != Some(browser_path) {
+            continue;
+        }
+        let Some(member) = msg.header().member().map(|m| m.to_owned()) else { continue };
+
+        match member.as_str() {
+            "ItemNew" => handle_avahi_item_new(&msg, conn_resolve, my_cn, state, registry),
+            "ItemRemove" => handle_avahi_item_remove(&msg, state, registry),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn handle_avahi_item_new(
+    msg: &zbus::Message,
+    conn_resolve: &zbus::blocking::Connection,
+    my_cn: &str,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    let body: zbus::Result<(i32, i32, String, String, String, u32)> = msg.body().deserialize();
+    let Ok((svc_iface, svc_proto, name, svc_type, domain, _)) = body else {
+        state
+            .lock()
+            .unwrap()
+            .push_log("mDNS[avahi]: ItemNew body parse failed".to_string());
+        return;
+    };
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[avahi]: ItemNew iface={svc_iface} proto={svc_proto} \
+         name={name:?} type={svc_type:?} domain={domain:?}"
+    ));
+
+    let Some((host, address, port, remote_cn, txt_ipv4)) =
+        resolve_avahi_service(conn_resolve, svc_iface, svc_proto, &name, &svc_type, &domain, state)
+    else {
+        return;
+    };
+
+    state.lock().unwrap().push_log(format!(
+        "mDNS[avahi]: resolved host={host:?} addr={address} port={port} \
+         cn={remote_cn:?} txt_ip={txt_ipv4:?}"
+    ));
+
+    if remote_cn.is_empty() || remote_cn == my_cn {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[avahi]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    let Some(chosen_ip) = pick_peer_address(&address, txt_ipv4, state) else {
+        return;
+    };
+    if is_unroutable(&chosen_ip) {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[avahi]: skipping unroutable addr {chosen_ip}"
+        ));
+        return;
+    }
+
+    let endpoint = zenoh_tls_endpoint(chosen_ip, port);
+    let key = peer_cache_key(&name, &svc_type);
+    if registry.add_one(key, endpoint.clone()) {
+        state.lock().unwrap().push_log(format!(
+            "Discovered peer router: {endpoint} (CN={remote_cn})"
+        ));
+    }
+}
+
+/// Tuple returned by avahi `ResolveService`: `(host, address, port, cn, txt_ipv4)`.
+#[cfg(target_os = "linux")]
+fn resolve_avahi_service(
+    conn: &zbus::blocking::Connection,
+    iface: i32,
+    proto: i32,
+    name: &str,
+    svc_type: &str,
+    domain: &str,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<(String, String, u16, String, Option<std::net::Ipv4Addr>)> {
+    let reply = match conn.call_method(
+        Some("org.freedesktop.Avahi"),
+        "/",
+        Some("org.freedesktop.Avahi.Server"),
+        "ResolveService",
+        &(
+            iface,
+            proto,
+            name,
+            svc_type,
+            domain,
+            AVAHI_PROTO_UNSPEC,
+            AVAHI_NO_FLAGS,
+        ),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: ResolveService error ({e})"
+            ));
+            return None;
+        }
+    };
+
+    type Resolved = (
+        i32, i32, String, String, String, String,
+        i32, String, u16, Vec<Vec<u8>>, u32,
+    );
+    let body: zbus::Result<Resolved> = reply.body().deserialize();
+    let Ok((_, _, _, _, _, host, _, address, port, txt, _)) = body else {
+        state.lock().unwrap().push_log(
+            "mDNS[avahi]: ResolveService body parse failed".to_string(),
+        );
+        return None;
+    };
+
+    let (remote_cn, txt_ipv4) = parse_dverse_txt(&txt);
+    Some((host, address, port, remote_cn, txt_ipv4))
+}
+
+/// Extract our DVerse-specific TXT entries (`cn=…`, `ip=…`) from the raw
+/// byte vectors avahi hands us.
+#[cfg(target_os = "linux")]
+fn parse_dverse_txt(txt: &[Vec<u8>]) -> (String, Option<std::net::Ipv4Addr>) {
+    let cn_prefix = format!("{TXT_KEY_CN}=");
+    let ip_prefix = format!("{TXT_KEY_IP}=");
+    let mut cn = String::new();
+    let mut ip = None;
+    for entry in txt {
+        let Ok(s) = std::str::from_utf8(entry) else { continue };
+        if let Some(rest) = s.strip_prefix(&cn_prefix) {
+            cn = rest.to_string();
+        } else if let Some(rest) = s.strip_prefix(&ip_prefix) {
+            if let Ok(parsed) = rest.parse::<std::net::Ipv4Addr>() {
+                ip = Some(parsed);
+            }
+        }
+    }
+    (cn, ip)
+}
+
+/// Choose the address for the peer endpoint:
+///   - Prefer TXT `ip=` if it's a routable IPv4.
+///   - Otherwise parse the address avahi resolved (could be v4 or v6).
+#[cfg(target_os = "linux")]
+fn pick_peer_address(
+    avahi_address: &str,
+    txt_ipv4: Option<std::net::Ipv4Addr>,
+    state: &Arc<Mutex<AppState>>,
+) -> Option<std::net::IpAddr> {
+    if let Some(ipv4) = txt_ipv4 {
+        if !ipv4.is_loopback() && !ipv4.is_link_local() {
+            return Some(std::net::IpAddr::V4(ipv4));
+        }
+    }
+    match avahi_address.parse() {
+        Ok(ip) => Some(ip),
+        Err(_) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[avahi]: addr parse failed for {avahi_address:?}"
+            ));
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn handle_avahi_item_remove(
+    msg: &zbus::Message,
+    state: &Arc<Mutex<AppState>>,
+    registry: &mut PeerRegistry,
+) {
+    let body: zbus::Result<(i32, i32, String, String, String, u32)> = msg.body().deserialize();
+    let Ok((_, _, name, svc_type, _, _)) = body else { return };
+    state.lock().unwrap().push_log(format!(
+        "mDNS[avahi]: ItemRemove name={name:?} type={svc_type:?}"
+    ));
+    let key = peer_cache_key(&name, &svc_type);
+    if let Some(endpoints) = registry.remove(&key) {
+        state.lock().unwrap().push_log(format!(
+            "Peer router left: {}",
+            endpoints.first().map(String::as_str).unwrap_or(&key),
+        ));
+    }
+}

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -1,9 +1,9 @@
 //! Browsing side of DNS-SD discovery — watches for other `_dverse._tcp`
 //! services on the LAN and exposes their endpoints as a watch channel.
 //!
-//! Two backends, mirroring announcing.rs:
-//!   * Linux: avahi D-Bus `ServiceBrowser` + `ResolveService`.
-//!   * Cross-platform: mdns-sd `browse()` + `ServiceEvent` channel.
+//! Single backend: mdns-sd `browse()` + `ServiceEvent` channel.  The avahi
+//! D-Bus path was removed; see the announcing module's header comment for
+//! the rationale.
 
 use std::sync::{Arc, Mutex};
 
@@ -13,12 +13,9 @@ use tokio::sync::watch;
 use crate::state::AppState;
 
 use super::common::{
-    is_unroutable, peer_cache_key, zenoh_tls_endpoint, PeerRegistry, MDNS_DOMAIN,
-    AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_UNSPEC, SERVICE_NAME,
-    DBUS_MATCH_QUEUE_DEPTH, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP, TXT_KEY_SESSION,
+    is_unroutable, zenoh_tls_endpoint, PeerRegistry, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    TXT_KEY_SESSION,
 };
-
-// ── mdns-sd browse ───────────────────────────────────────────────────────────
 
 /// Start browsing for peers on the given mdns-sd daemon and return a watch
 /// receiver of the current endpoint list.  Spawns a background thread that
@@ -48,7 +45,7 @@ pub(super) fn mdns_sd_start(
     std::thread::spawn(move || {
         let mut registry = registry;
         while let Ok(event) = browse_rx.recv() {
-            handle_mdns_sd_event(event, &my_cn, &my_session, &state, &mut registry);
+            handle_event(event, &my_cn, &my_session, &state, &mut registry);
         }
         state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
     });
@@ -56,7 +53,7 @@ pub(super) fn mdns_sd_start(
     Some(peer_rx)
 }
 
-fn handle_mdns_sd_event(
+fn handle_event(
     event: ServiceEvent,
     my_cn: &str,
     my_session: &str,
@@ -115,8 +112,8 @@ fn handle_resolved(
         return;
     }
 
-    // Session filter: skip peers that belong to a different session.  Without
-    // this, two unrelated users on the same LAN would auto-mesh their routers.
+    // Session filter: skip peers in a different session.  Without this two
+    // unrelated users on the same LAN would auto-mesh their routers.
     if remote_session != my_session {
         state.lock().unwrap().push_log(format!(
             "mDNS[mdns-sd]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
@@ -191,374 +188,4 @@ fn endpoints_for(
     }
 
     endpoints
-}
-
-// ── Linux: avahi D-Bus ServiceBrowser ────────────────────────────────────────
-
-/// Subscribe to avahi's `_dverse._tcp` ServiceBrowser via D-Bus.  Returns the
-/// D-Bus connection (caller keeps it alive) and a watch receiver carrying
-/// the current peer endpoint list.
-///
-/// Critical ordering: the D-Bus signal subscription is registered BEFORE
-/// `ServiceBrowserNew` is called.  avahi fires `ItemNew` signals for any
-/// already-cached services immediately after the browser is created; if we
-/// only set up the subscription afterwards we miss those signals.
-///
-/// Implementation: the worker thread registers a broad MatchRule (no `path`
-/// filter — we don't know the browser's object path yet), THEN calls
-/// `ServiceBrowserNew`, THEN filters incoming signals by `browser_path`.
-/// A `mpsc::channel` blocks the caller until setup is complete.
-#[cfg(target_os = "linux")]
-pub(super) fn avahi_start(
-    my_cn: &str,
-    my_session: &str,
-    state: Arc<Mutex<AppState>>,
-) -> Option<(zbus::blocking::Connection, watch::Receiver<Vec<String>>)> {
-    use zbus::blocking::Connection;
-
-    let conn = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: browse D-Bus conn failed ({e})"
-            ));
-            return None;
-        }
-    };
-    // Resolve calls block on D-Bus replies; using a separate connection
-    // prevents them from interleaving with the incoming signal stream.
-    let conn_resolve = match Connection::system() {
-        Ok(c) => c,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: resolve D-Bus conn failed ({e})"
-            ));
-            return None;
-        }
-    };
-
-    let conn_keepalive = conn.clone();
-    let (registry, peer_rx) = PeerRegistry::new();
-    let my_cn = my_cn.to_string();
-    let my_session = my_session.to_string();
-
-    let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<String, String>>();
-
-    std::thread::spawn(move || {
-        run_avahi_browse_thread(
-            conn, conn_resolve, my_cn, my_session, state, registry, ready_tx,
-        );
-    });
-
-    match ready_rx.recv() {
-        Ok(Ok(_)) => Some((conn_keepalive, peer_rx)),
-        Ok(Err(_)) | Err(_) => None,
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn run_avahi_browse_thread(
-    conn: zbus::blocking::Connection,
-    conn_resolve: zbus::blocking::Connection,
-    my_cn: String,
-    my_session: String,
-    state: Arc<Mutex<AppState>>,
-    mut registry: PeerRegistry,
-    ready_tx: std::sync::mpsc::Sender<Result<String, String>>,
-) {
-    // Step 1: subscribe to ServiceBrowser signals BEFORE creating the browser.
-    let iter = match subscribe_to_service_browser_signals(&conn) {
-        Ok(i) => i,
-        Err(msg) => {
-            state.lock().unwrap().push_log(msg.clone());
-            ready_tx.send(Err(msg)).ok();
-            return;
-        }
-    };
-
-    // Step 2: NOW create the browser — signals are already queued.
-    let browser_path = match create_service_browser(&conn) {
-        Ok(path) => path,
-        Err(msg) => {
-            state.lock().unwrap().push_log(msg.clone());
-            ready_tx.send(Err(msg)).ok();
-            return;
-        }
-    };
-
-    state.lock().unwrap().push_log(format!("mDNS[avahi]: browser at {browser_path}"));
-    ready_tx.send(Ok(browser_path.clone())).ok();
-
-    drain_avahi_signals(
-        iter, &browser_path, &conn_resolve, &my_cn, &my_session, &state, &mut registry,
-    );
-    state.lock().unwrap().push_log("mDNS[avahi]: signal loop exited".to_string());
-}
-
-#[cfg(target_os = "linux")]
-fn subscribe_to_service_browser_signals(
-    conn: &zbus::blocking::Connection,
-) -> Result<zbus::blocking::MessageIterator, String> {
-    let rule = zbus::MatchRule::builder()
-        .msg_type(zbus::message::Type::Signal)
-        .sender("org.freedesktop.Avahi")
-        .map_err(|e| format!("mDNS[avahi]: match rule sender error ({e})"))?
-        .interface("org.freedesktop.Avahi.ServiceBrowser")
-        .map_err(|e| format!("mDNS[avahi]: match rule iface error ({e})"))?
-        .build();
-
-    zbus::blocking::MessageIterator::for_match_rule(rule, conn, Some(DBUS_MATCH_QUEUE_DEPTH))
-        .map_err(|e| format!("mDNS[avahi]: iterator error ({e})"))
-}
-
-#[cfg(target_os = "linux")]
-fn create_service_browser(conn: &zbus::blocking::Connection) -> Result<String, String> {
-    let path: zbus::zvariant::OwnedObjectPath = conn
-        .call_method(
-            Some("org.freedesktop.Avahi"),
-            "/",
-            Some("org.freedesktop.Avahi.Server"),
-            "ServiceBrowserNew",
-            &(
-                AVAHI_IF_UNSPEC,
-                AVAHI_PROTO_UNSPEC,
-                SERVICE_NAME,
-                MDNS_DOMAIN,
-                AVAHI_NO_FLAGS,
-            ),
-        )
-        .and_then(|r| r.body().deserialize().map_err(Into::into))
-        .map_err(|e| format!("mDNS[avahi]: ServiceBrowserNew failed ({e})"))?;
-    Ok(path.as_str().to_string())
-}
-
-#[cfg(target_os = "linux")]
-fn drain_avahi_signals(
-    iter: zbus::blocking::MessageIterator,
-    browser_path: &str,
-    conn_resolve: &zbus::blocking::Connection,
-    my_cn: &str,
-    my_session: &str,
-    state: &Arc<Mutex<AppState>>,
-    registry: &mut PeerRegistry,
-) {
-    for msg_result in iter {
-        let msg = match msg_result {
-            Ok(m) => m,
-            Err(e) => {
-                state.lock().unwrap().push_log(format!(
-                    "mDNS[avahi]: D-Bus error ({e}); stopping"
-                ));
-                break;
-            }
-        };
-
-        // Filter: only handle signals from OUR ServiceBrowser object — the
-        // broad MatchRule above can deliver signals from any browser on the
-        // bus if multiple `ServiceBrowserNew` instances exist.
-        let msg_path = msg.header().path().map(|p| p.as_str().to_owned());
-        if msg_path.as_deref() != Some(browser_path) {
-            continue;
-        }
-        let Some(member) = msg.header().member().map(|m| m.to_owned()) else { continue };
-
-        match member.as_str() {
-            "ItemNew" => {
-                handle_avahi_item_new(&msg, conn_resolve, my_cn, my_session, state, registry)
-            }
-            "ItemRemove" => handle_avahi_item_remove(&msg, state, registry),
-            _ => {}
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn handle_avahi_item_new(
-    msg: &zbus::Message,
-    conn_resolve: &zbus::blocking::Connection,
-    my_cn: &str,
-    my_session: &str,
-    state: &Arc<Mutex<AppState>>,
-    registry: &mut PeerRegistry,
-) {
-    let body: zbus::Result<(i32, i32, String, String, String, u32)> = msg.body().deserialize();
-    let Ok((svc_iface, svc_proto, name, svc_type, domain, _)) = body else {
-        state
-            .lock()
-            .unwrap()
-            .push_log("mDNS[avahi]: ItemNew body parse failed".to_string());
-        return;
-    };
-
-    state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: ItemNew iface={svc_iface} proto={svc_proto} \
-         name={name:?} type={svc_type:?} domain={domain:?}"
-    ));
-
-    let Some((host, address, port, remote_cn, txt_ipv4, remote_session)) =
-        resolve_avahi_service(conn_resolve, svc_iface, svc_proto, &name, &svc_type, &domain, state)
-    else {
-        return;
-    };
-
-    state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: resolved host={host:?} addr={address} port={port} \
-         cn={remote_cn:?} session={remote_session:?} txt_ip={txt_ipv4:?}"
-    ));
-
-    if remote_cn.is_empty() || remote_cn == my_cn {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[avahi]: skipping self or empty CN ({remote_cn:?})"
-        ));
-        return;
-    }
-
-    // Session filter: skip peers that belong to a different session.  Without
-    // this, two unrelated users on the same LAN would auto-mesh their routers.
-    if remote_session != my_session {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[avahi]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
-        ));
-        return;
-    }
-
-    let Some(chosen_ip) = pick_peer_address(&address, txt_ipv4, state) else {
-        return;
-    };
-    if is_unroutable(&chosen_ip) {
-        state.lock().unwrap().push_log(format!(
-            "mDNS[avahi]: skipping unroutable addr {chosen_ip}"
-        ));
-        return;
-    }
-
-    let endpoint = zenoh_tls_endpoint(chosen_ip, port);
-    let key = peer_cache_key(&name, &svc_type);
-    if registry.add_one(key, endpoint.clone()) {
-        state.lock().unwrap().push_log(format!(
-            "Discovered peer router: {endpoint} (CN={remote_cn})"
-        ));
-    }
-}
-
-/// Tuple returned by avahi `ResolveService`:
-/// `(host, address, port, cn, txt_ipv4, session)`.
-#[cfg(target_os = "linux")]
-fn resolve_avahi_service(
-    conn: &zbus::blocking::Connection,
-    iface: i32,
-    proto: i32,
-    name: &str,
-    svc_type: &str,
-    domain: &str,
-    state: &Arc<Mutex<AppState>>,
-) -> Option<(String, String, u16, String, Option<std::net::Ipv4Addr>, String)> {
-    let reply = match conn.call_method(
-        Some("org.freedesktop.Avahi"),
-        "/",
-        Some("org.freedesktop.Avahi.Server"),
-        "ResolveService",
-        &(
-            iface,
-            proto,
-            name,
-            svc_type,
-            domain,
-            AVAHI_PROTO_UNSPEC,
-            AVAHI_NO_FLAGS,
-        ),
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: ResolveService error ({e})"
-            ));
-            return None;
-        }
-    };
-
-    type Resolved = (
-        i32, i32, String, String, String, String,
-        i32, String, u16, Vec<Vec<u8>>, u32,
-    );
-    let body: zbus::Result<Resolved> = reply.body().deserialize();
-    let Ok((_, _, _, _, _, host, _, address, port, txt, _)) = body else {
-        state.lock().unwrap().push_log(
-            "mDNS[avahi]: ResolveService body parse failed".to_string(),
-        );
-        return None;
-    };
-
-    let (remote_cn, txt_ipv4, remote_session) = parse_dverse_txt(&txt);
-    Some((host, address, port, remote_cn, txt_ipv4, remote_session))
-}
-
-/// Extract our DVerse-specific TXT entries (`cn=…`, `ip=…`, `session=…`)
-/// from the raw byte vectors avahi hands us.
-#[cfg(target_os = "linux")]
-fn parse_dverse_txt(txt: &[Vec<u8>]) -> (String, Option<std::net::Ipv4Addr>, String) {
-    let cn_prefix = format!("{TXT_KEY_CN}=");
-    let ip_prefix = format!("{TXT_KEY_IP}=");
-    let session_prefix = format!("{TXT_KEY_SESSION}=");
-    let mut cn = String::new();
-    let mut ip = None;
-    let mut session = String::new();
-    for entry in txt {
-        let Ok(s) = std::str::from_utf8(entry) else { continue };
-        if let Some(rest) = s.strip_prefix(&cn_prefix) {
-            cn = rest.to_string();
-        } else if let Some(rest) = s.strip_prefix(&ip_prefix) {
-            if let Ok(parsed) = rest.parse::<std::net::Ipv4Addr>() {
-                ip = Some(parsed);
-            }
-        } else if let Some(rest) = s.strip_prefix(&session_prefix) {
-            session = rest.to_string();
-        }
-    }
-    (cn, ip, session)
-}
-
-/// Choose the address for the peer endpoint:
-///   - Prefer TXT `ip=` if it's a routable IPv4.
-///   - Otherwise parse the address avahi resolved (could be v4 or v6).
-#[cfg(target_os = "linux")]
-fn pick_peer_address(
-    avahi_address: &str,
-    txt_ipv4: Option<std::net::Ipv4Addr>,
-    state: &Arc<Mutex<AppState>>,
-) -> Option<std::net::IpAddr> {
-    if let Some(ipv4) = txt_ipv4 {
-        if !ipv4.is_loopback() && !ipv4.is_link_local() {
-            return Some(std::net::IpAddr::V4(ipv4));
-        }
-    }
-    match avahi_address.parse() {
-        Ok(ip) => Some(ip),
-        Err(_) => {
-            state.lock().unwrap().push_log(format!(
-                "mDNS[avahi]: addr parse failed for {avahi_address:?}"
-            ));
-            None
-        }
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn handle_avahi_item_remove(
-    msg: &zbus::Message,
-    state: &Arc<Mutex<AppState>>,
-    registry: &mut PeerRegistry,
-) {
-    let body: zbus::Result<(i32, i32, String, String, String, u32)> = msg.body().deserialize();
-    let Ok((_, _, name, svc_type, _, _)) = body else { return };
-    state.lock().unwrap().push_log(format!(
-        "mDNS[avahi]: ItemRemove name={name:?} type={svc_type:?}"
-    ));
-    let key = peer_cache_key(&name, &svc_type);
-    if let Some(endpoints) = registry.remove(&key) {
-        state.lock().unwrap().push_log(format!(
-            "Peer router left: {}",
-            endpoints.first().map(String::as_str).unwrap_or(&key),
-        ));
-    }
 }

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -15,7 +15,7 @@ use crate::state::AppState;
 use super::common::{
     is_unroutable, peer_cache_key, zenoh_tls_endpoint, PeerRegistry, MDNS_DOMAIN,
     AVAHI_IF_UNSPEC, AVAHI_NO_FLAGS, AVAHI_PROTO_UNSPEC, SERVICE_NAME,
-    DBUS_MATCH_QUEUE_DEPTH, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
+    DBUS_MATCH_QUEUE_DEPTH, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP, TXT_KEY_SESSION,
 };
 
 // ── mdns-sd browse ───────────────────────────────────────────────────────────
@@ -26,6 +26,7 @@ use super::common::{
 pub(super) fn mdns_sd_start(
     daemon: &ServiceDaemon,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
 ) -> Option<watch::Receiver<Vec<String>>> {
     let browse_rx = match daemon.browse(SERVICE_TYPE) {
@@ -41,12 +42,13 @@ pub(super) fn mdns_sd_start(
 
     let (registry, peer_rx) = PeerRegistry::new();
     let my_cn = my_cn.to_string();
+    let my_session = my_session.to_string();
     let state = Arc::clone(state);
 
     std::thread::spawn(move || {
         let mut registry = registry;
         while let Ok(event) = browse_rx.recv() {
-            handle_mdns_sd_event(event, &my_cn, &state, &mut registry);
+            handle_mdns_sd_event(event, &my_cn, &my_session, &state, &mut registry);
         }
         state.lock().unwrap().push_log("mDNS[mdns-sd]: browse loop exited".to_string());
     });
@@ -57,6 +59,7 @@ pub(super) fn mdns_sd_start(
 fn handle_mdns_sd_event(
     event: ServiceEvent,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
@@ -66,7 +69,9 @@ fn handle_mdns_sd_event(
                 "mDNS[mdns-sd]: found {fullname:?} (type={svc_type:?})"
             ));
         }
-        ServiceEvent::ServiceResolved(info) => handle_resolved(info, my_cn, state, registry),
+        ServiceEvent::ServiceResolved(info) => {
+            handle_resolved(info, my_cn, my_session, state, registry)
+        }
         ServiceEvent::ServiceRemoved(_, fullname) => {
             state
                 .lock()
@@ -90,13 +95,15 @@ fn handle_mdns_sd_event(
 fn handle_resolved(
     info: ServiceInfo,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
     let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
+    let remote_session = info.get_property_val_str(TXT_KEY_SESSION).unwrap_or_default();
     let addrs: Vec<_> = info.get_addresses().iter().copied().collect();
     state.lock().unwrap().push_log(format!(
-        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} addrs={addrs:?} port={}",
+        "mDNS[mdns-sd]: resolved {:?} cn={remote_cn:?} session={remote_session:?} addrs={addrs:?} port={}",
         info.get_fullname(),
         info.get_port(),
     ));
@@ -104,6 +111,15 @@ fn handle_resolved(
     if remote_cn.is_empty() || remote_cn == my_cn {
         state.lock().unwrap().push_log(format!(
             "mDNS[mdns-sd]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    // Session filter: skip peers that belong to a different session.  Without
+    // this, two unrelated users on the same LAN would auto-mesh their routers.
+    if remote_session != my_session {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
         ));
         return;
     }
@@ -195,6 +211,7 @@ fn endpoints_for(
 #[cfg(target_os = "linux")]
 pub(super) fn avahi_start(
     my_cn: &str,
+    my_session: &str,
     state: Arc<Mutex<AppState>>,
 ) -> Option<(zbus::blocking::Connection, watch::Receiver<Vec<String>>)> {
     use zbus::blocking::Connection;
@@ -223,11 +240,14 @@ pub(super) fn avahi_start(
     let conn_keepalive = conn.clone();
     let (registry, peer_rx) = PeerRegistry::new();
     let my_cn = my_cn.to_string();
+    let my_session = my_session.to_string();
 
     let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<String, String>>();
 
     std::thread::spawn(move || {
-        run_avahi_browse_thread(conn, conn_resolve, my_cn, state, registry, ready_tx);
+        run_avahi_browse_thread(
+            conn, conn_resolve, my_cn, my_session, state, registry, ready_tx,
+        );
     });
 
     match ready_rx.recv() {
@@ -241,6 +261,7 @@ fn run_avahi_browse_thread(
     conn: zbus::blocking::Connection,
     conn_resolve: zbus::blocking::Connection,
     my_cn: String,
+    my_session: String,
     state: Arc<Mutex<AppState>>,
     mut registry: PeerRegistry,
     ready_tx: std::sync::mpsc::Sender<Result<String, String>>,
@@ -268,7 +289,9 @@ fn run_avahi_browse_thread(
     state.lock().unwrap().push_log(format!("mDNS[avahi]: browser at {browser_path}"));
     ready_tx.send(Ok(browser_path.clone())).ok();
 
-    drain_avahi_signals(iter, &browser_path, &conn_resolve, &my_cn, &state, &mut registry);
+    drain_avahi_signals(
+        iter, &browser_path, &conn_resolve, &my_cn, &my_session, &state, &mut registry,
+    );
     state.lock().unwrap().push_log("mDNS[avahi]: signal loop exited".to_string());
 }
 
@@ -315,6 +338,7 @@ fn drain_avahi_signals(
     browser_path: &str,
     conn_resolve: &zbus::blocking::Connection,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
@@ -339,7 +363,9 @@ fn drain_avahi_signals(
         let Some(member) = msg.header().member().map(|m| m.to_owned()) else { continue };
 
         match member.as_str() {
-            "ItemNew" => handle_avahi_item_new(&msg, conn_resolve, my_cn, state, registry),
+            "ItemNew" => {
+                handle_avahi_item_new(&msg, conn_resolve, my_cn, my_session, state, registry)
+            }
             "ItemRemove" => handle_avahi_item_remove(&msg, state, registry),
             _ => {}
         }
@@ -351,6 +377,7 @@ fn handle_avahi_item_new(
     msg: &zbus::Message,
     conn_resolve: &zbus::blocking::Connection,
     my_cn: &str,
+    my_session: &str,
     state: &Arc<Mutex<AppState>>,
     registry: &mut PeerRegistry,
 ) {
@@ -368,7 +395,7 @@ fn handle_avahi_item_new(
          name={name:?} type={svc_type:?} domain={domain:?}"
     ));
 
-    let Some((host, address, port, remote_cn, txt_ipv4)) =
+    let Some((host, address, port, remote_cn, txt_ipv4, remote_session)) =
         resolve_avahi_service(conn_resolve, svc_iface, svc_proto, &name, &svc_type, &domain, state)
     else {
         return;
@@ -376,12 +403,21 @@ fn handle_avahi_item_new(
 
     state.lock().unwrap().push_log(format!(
         "mDNS[avahi]: resolved host={host:?} addr={address} port={port} \
-         cn={remote_cn:?} txt_ip={txt_ipv4:?}"
+         cn={remote_cn:?} session={remote_session:?} txt_ip={txt_ipv4:?}"
     ));
 
     if remote_cn.is_empty() || remote_cn == my_cn {
         state.lock().unwrap().push_log(format!(
             "mDNS[avahi]: skipping self or empty CN ({remote_cn:?})"
+        ));
+        return;
+    }
+
+    // Session filter: skip peers that belong to a different session.  Without
+    // this, two unrelated users on the same LAN would auto-mesh their routers.
+    if remote_session != my_session {
+        state.lock().unwrap().push_log(format!(
+            "mDNS[avahi]: skipping peer {remote_cn} (session={remote_session:?}, ours={my_session:?})"
         ));
         return;
     }
@@ -405,7 +441,8 @@ fn handle_avahi_item_new(
     }
 }
 
-/// Tuple returned by avahi `ResolveService`: `(host, address, port, cn, txt_ipv4)`.
+/// Tuple returned by avahi `ResolveService`:
+/// `(host, address, port, cn, txt_ipv4, session)`.
 #[cfg(target_os = "linux")]
 fn resolve_avahi_service(
     conn: &zbus::blocking::Connection,
@@ -415,7 +452,7 @@ fn resolve_avahi_service(
     svc_type: &str,
     domain: &str,
     state: &Arc<Mutex<AppState>>,
-) -> Option<(String, String, u16, String, Option<std::net::Ipv4Addr>)> {
+) -> Option<(String, String, u16, String, Option<std::net::Ipv4Addr>, String)> {
     let reply = match conn.call_method(
         Some("org.freedesktop.Avahi"),
         "/",
@@ -452,18 +489,20 @@ fn resolve_avahi_service(
         return None;
     };
 
-    let (remote_cn, txt_ipv4) = parse_dverse_txt(&txt);
-    Some((host, address, port, remote_cn, txt_ipv4))
+    let (remote_cn, txt_ipv4, remote_session) = parse_dverse_txt(&txt);
+    Some((host, address, port, remote_cn, txt_ipv4, remote_session))
 }
 
-/// Extract our DVerse-specific TXT entries (`cn=…`, `ip=…`) from the raw
-/// byte vectors avahi hands us.
+/// Extract our DVerse-specific TXT entries (`cn=…`, `ip=…`, `session=…`)
+/// from the raw byte vectors avahi hands us.
 #[cfg(target_os = "linux")]
-fn parse_dverse_txt(txt: &[Vec<u8>]) -> (String, Option<std::net::Ipv4Addr>) {
+fn parse_dverse_txt(txt: &[Vec<u8>]) -> (String, Option<std::net::Ipv4Addr>, String) {
     let cn_prefix = format!("{TXT_KEY_CN}=");
     let ip_prefix = format!("{TXT_KEY_IP}=");
+    let session_prefix = format!("{TXT_KEY_SESSION}=");
     let mut cn = String::new();
     let mut ip = None;
+    let mut session = String::new();
     for entry in txt {
         let Ok(s) = std::str::from_utf8(entry) else { continue };
         if let Some(rest) = s.strip_prefix(&cn_prefix) {
@@ -472,9 +511,11 @@ fn parse_dverse_txt(txt: &[Vec<u8>]) -> (String, Option<std::net::Ipv4Addr>) {
             if let Ok(parsed) = rest.parse::<std::net::Ipv4Addr>() {
                 ip = Some(parsed);
             }
+        } else if let Some(rest) = s.strip_prefix(&session_prefix) {
+            session = rest.to_string();
         }
     }
-    (cn, ip)
+    (cn, ip, session)
 }
 
 /// Choose the address for the peer endpoint:

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -16,46 +16,9 @@ use crate::state::AppState;
 
 // ── Service identity ─────────────────────────────────────────────────────────
 
-/// Bare DNS-SD service name (RFC 6763) — `_<service>._<proto>`.
-/// Has no domain suffix; pair with [`MDNS_DOMAIN`] when an API expects them
-/// split (avahi D-Bus does), or use [`SERVICE_TYPE`] for the full form.
-pub(super) const SERVICE_NAME: &str = "_dverse._tcp";
-
-/// mDNS link-local domain (RFC 6762).  Always `"local"` for multicast DNS,
-/// regardless of which library publishes or browses.
-pub(super) const MDNS_DOMAIN: &str = "local";
-
-/// Fully-qualified DNS-SD service type with trailing dot, ready to drop into
-/// PTR record names or mdns-sd's `browse()` API.  Equals
-/// `concat!(SERVICE_NAME, ".", MDNS_DOMAIN, ".")` — kept as its own constant
-/// because `concat!` can only take literals.
+/// Fully-qualified DNS-SD service type with trailing dot, used as the PTR
+/// record name and the argument to mdns-sd's `browse()` / `ServiceInfo::new`.
 pub(super) const SERVICE_TYPE: &str = "_dverse._tcp.local.";
-
-// ── Avahi protocol sentinels ─────────────────────────────────────────────────
-// These are arbitrary numeric values defined by avahi's protocol enums in
-// <avahi-common/address.h> and <avahi-common/defs.h>.  They're not mDNS
-// standards — they're what the avahi D-Bus interface expects on the wire.
-
-/// `AvahiIfIndex` sentinel meaning "any/all interfaces" (`AVAHI_IF_UNSPEC`).
-pub(super) const AVAHI_IF_UNSPEC: i32 = -1;
-
-/// `AvahiProtocol` sentinel meaning "any address family" (`AVAHI_PROTO_UNSPEC`).
-pub(super) const AVAHI_PROTO_UNSPEC: i32 = -1;
-
-/// `AvahiProtocol` value for IPv4 (`AVAHI_PROTO_INET`).  Passed to
-/// `AddAddress` when we register an A record specifically (not AAAA).
-pub(super) const AVAHI_PROTO_INET: i32 = 0;
-
-/// `AvahiPublishFlags` / `AvahiLookupFlags` "none" value — we never need the
-/// publish/lookup/use_wide_area bits avahi defines.
-pub(super) const AVAHI_NO_FLAGS: u32 = 0;
-
-// ── D-Bus subscription tuning ────────────────────────────────────────────────
-
-/// Queue depth for the avahi ServiceBrowser D-Bus subscription.  64 covers
-/// the initial `ItemNew` cache-replay burst on busy mDNS networks with room
-/// to spare — typical announcement bursts are under ten messages.
-pub(super) const DBUS_MATCH_QUEUE_DEPTH: usize = 64;
 
 // ── TXT record keys ──────────────────────────────────────────────────────────
 
@@ -66,12 +29,9 @@ pub(super) const TXT_KEY_CN: &str = "cn";
 
 /// TXT key carrying the publisher's routable LAN IPv4.
 ///
-/// Workaround for two failure modes observed in testing:
-///   1. mdns-sd resolves via IPv6 first and reports only the link-local
-///      `fe80::` AAAA address — useless for cross-host TLS.
-///   2. avahi sometimes resolves SRV targets to loopback (`127.0.0.1`)
-///      when the local hostname has multiple A records.
-/// Embedding the LAN IPv4 directly in TXT bypasses both.
+/// Workaround for the failure mode where mdns-sd resolves via IPv6 first and
+/// reports only the link-local `fe80::` AAAA address — useless for cross-host
+/// TLS.  Embedding the LAN IPv4 directly in TXT bypasses it.
 pub(super) const TXT_KEY_IP: &str = "ip";
 
 /// TXT key carrying the session identifier — the admin's CN for everyone
@@ -88,52 +48,21 @@ pub(super) fn instance_name(cn: &str) -> String {
     format!("DVerse ({cn})")
 }
 
-/// SRV target hostname for our router instance.  Peers resolve this to
-/// our address records to find us at the network layer.  Per-CN (rather
-/// than the machine's default hostname) so multiple test routers on one
-/// host don't collide.
+/// SRV target hostname for our router instance.  Peers resolve this to the
+/// A record mdns-sd registers via `ServiceInfo::new`.  Per-CN (rather than
+/// the machine's default hostname) so multiple test routers on one host
+/// don't collide.
+///
+/// Matches the Step-CA x509 template's `SAN = DNS:zenoh-<cn>.local`, so the
+/// TLS handshake validates whether agents connect by hostname or by IP.
 pub(super) fn srv_host_name(cn: &str) -> String {
     format!("zenoh-{cn}.local.")
-}
-
-/// Custom A-record hostname registered alongside the avahi service,
-/// pinned to the detected LAN IPv4.  Pinning a dedicated A record makes
-/// SRV resolution deterministic — avahi's default hostname can resolve
-/// to loopback, link-local, and LAN addresses all at once.
-pub(super) fn pinned_a_record_host(cn: &str) -> String {
-    format!("dverse-{cn}.local.")
-}
-
-/// Cache key for tracking a discovered peer's endpoints.  avahi's
-/// `ItemNew` signal gives `(name, svc_type, domain)` separately — this
-/// re-assembles them into the same fullname mdns-sd reports, so both
-/// backends share the same key shape.
-pub(super) fn peer_cache_key(name: &str, svc_type: &str) -> String {
-    format!("{name}.{svc_type}.")
 }
 
 /// Zenoh endpoint URI for the router's `connect/endpoints` config.
 /// Zenoh's URI form is `<protocol>/<host>:<port>`; dverse runs mTLS.
 pub(super) fn zenoh_tls_endpoint(ip: IpAddr, port: u16) -> String {
     format!("tls/{ip}:{port}")
-}
-
-// ── TXT entry builders ───────────────────────────────────────────────────────
-
-/// `cn=<value>` TXT entry, byte-encoded for avahi `AddService`.
-/// (mdns-sd takes `(&str, &str)` tuples instead; see [`TXT_KEY_CN`].)
-pub(super) fn txt_cn_entry(cn: &str) -> Vec<u8> {
-    format!("{TXT_KEY_CN}={cn}").into_bytes()
-}
-
-/// `ip=<value>` TXT entry, byte-encoded for avahi `AddService`.
-pub(super) fn txt_ip_entry(ip: Ipv4Addr) -> Vec<u8> {
-    format!("{TXT_KEY_IP}={ip}").into_bytes()
-}
-
-/// `session=<value>` TXT entry, byte-encoded for avahi `AddService`.
-pub(super) fn txt_session_entry(session_id: &str) -> Vec<u8> {
-    format!("{TXT_KEY_SESSION}={session_id}").into_bytes()
 }
 
 // ── IP detection ─────────────────────────────────────────────────────────────
@@ -266,26 +195,12 @@ impl PeerRegistry {
 
     /// Replace the full endpoint list for one peer.  Returns `true` if the
     /// list actually changed (callers use this to suppress duplicate log
-    /// lines when a backend re-fires events for already-known peers).
+    /// lines when the backend re-fires events for already-known peers).
     pub(super) fn set(&mut self, key: String, endpoints: Vec<String>) -> bool {
         if self.peers.get(&key).map(|v| v.as_slice()) == Some(endpoints.as_slice()) {
             return false;
         }
         self.peers.insert(key, endpoints);
-        let _ = self.tx.send(self.flatten());
-        true
-    }
-
-    /// Append one endpoint to a peer's set.  Used by the avahi backend,
-    /// which receives per-interface events and accumulates endpoints
-    /// incrementally.  Returns `true` if the endpoint was new.
-    pub(super) fn add_one(&mut self, key: String, endpoint: String) -> bool {
-        let entry = self.peers.entry(key).or_default();
-        if entry.contains(&endpoint) {
-            return false;
-        }
-        entry.push(endpoint);
-        entry.sort();
         let _ = self.tx.send(self.flatten());
         true
     }

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -74,6 +74,12 @@ pub(super) const TXT_KEY_CN: &str = "cn";
 /// Embedding the LAN IPv4 directly in TXT bypasses both.
 pub(super) const TXT_KEY_IP: &str = "ip";
 
+/// TXT key carrying the session identifier — the admin's CN for everyone
+/// participating in the session.  Browsers skip peers whose session value
+/// doesn't match their own, so two unrelated users on the same LAN don't
+/// auto-mesh their routers.
+pub(super) const TXT_KEY_SESSION: &str = "session";
+
 // ── Name builders ────────────────────────────────────────────────────────────
 
 /// Human-readable service instance name shown by DNS-SD browsers
@@ -123,6 +129,11 @@ pub(super) fn txt_cn_entry(cn: &str) -> Vec<u8> {
 /// `ip=<value>` TXT entry, byte-encoded for avahi `AddService`.
 pub(super) fn txt_ip_entry(ip: Ipv4Addr) -> Vec<u8> {
     format!("{TXT_KEY_IP}={ip}").into_bytes()
+}
+
+/// `session=<value>` TXT entry, byte-encoded for avahi `AddService`.
+pub(super) fn txt_session_entry(session_id: &str) -> Vec<u8> {
+    format!("{TXT_KEY_SESSION}={session_id}").into_bytes()
 }
 
 // ── IP detection ─────────────────────────────────────────────────────────────

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -1,0 +1,292 @@
+//! Shared constants, naming conventions, and helpers used by both the
+//! announcing and browsing sides of DNS-SD discovery.
+//!
+//! Everything that defines the on-the-wire identity of a DVerse router lives
+//! here: change [`instance_name`] and the label seen by every remote browser
+//! changes too, without hunting through the publish + browse code paths.
+
+use std::collections::{HashMap, HashSet};
+use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+use std::sync::{Arc, Mutex};
+
+use mdns_sd::{IfKind, ServiceDaemon};
+use tokio::sync::watch;
+
+use crate::state::AppState;
+
+// ── Service identity ─────────────────────────────────────────────────────────
+
+/// Bare DNS-SD service name (RFC 6763) — `_<service>._<proto>`.
+/// Has no domain suffix; pair with [`MDNS_DOMAIN`] when an API expects them
+/// split (avahi D-Bus does), or use [`SERVICE_TYPE`] for the full form.
+pub(super) const SERVICE_NAME: &str = "_dverse._tcp";
+
+/// mDNS link-local domain (RFC 6762).  Always `"local"` for multicast DNS,
+/// regardless of which library publishes or browses.
+pub(super) const MDNS_DOMAIN: &str = "local";
+
+/// Fully-qualified DNS-SD service type with trailing dot, ready to drop into
+/// PTR record names or mdns-sd's `browse()` API.  Equals
+/// `concat!(SERVICE_NAME, ".", MDNS_DOMAIN, ".")` — kept as its own constant
+/// because `concat!` can only take literals.
+pub(super) const SERVICE_TYPE: &str = "_dverse._tcp.local.";
+
+// ── Avahi protocol sentinels ─────────────────────────────────────────────────
+// These are arbitrary numeric values defined by avahi's protocol enums in
+// <avahi-common/address.h> and <avahi-common/defs.h>.  They're not mDNS
+// standards — they're what the avahi D-Bus interface expects on the wire.
+
+/// `AvahiIfIndex` sentinel meaning "any/all interfaces" (`AVAHI_IF_UNSPEC`).
+pub(super) const AVAHI_IF_UNSPEC: i32 = -1;
+
+/// `AvahiProtocol` sentinel meaning "any address family" (`AVAHI_PROTO_UNSPEC`).
+pub(super) const AVAHI_PROTO_UNSPEC: i32 = -1;
+
+/// `AvahiProtocol` value for IPv4 (`AVAHI_PROTO_INET`).  Passed to
+/// `AddAddress` when we register an A record specifically (not AAAA).
+pub(super) const AVAHI_PROTO_INET: i32 = 0;
+
+/// `AvahiPublishFlags` / `AvahiLookupFlags` "none" value — we never need the
+/// publish/lookup/use_wide_area bits avahi defines.
+pub(super) const AVAHI_NO_FLAGS: u32 = 0;
+
+// ── D-Bus subscription tuning ────────────────────────────────────────────────
+
+/// Queue depth for the avahi ServiceBrowser D-Bus subscription.  64 covers
+/// the initial `ItemNew` cache-replay burst on busy mDNS networks with room
+/// to spare — typical announcement bursts are under ten messages.
+pub(super) const DBUS_MATCH_QUEUE_DEPTH: usize = 64;
+
+// ── TXT record keys ──────────────────────────────────────────────────────────
+
+/// TXT key carrying the publisher's CN.  Peers use this to skip their own
+/// service (we receive our announcement back via multicast loopback) and to
+/// label discovered peers.
+pub(super) const TXT_KEY_CN: &str = "cn";
+
+/// TXT key carrying the publisher's routable LAN IPv4.
+///
+/// Workaround for two failure modes observed in testing:
+///   1. mdns-sd resolves via IPv6 first and reports only the link-local
+///      `fe80::` AAAA address — useless for cross-host TLS.
+///   2. avahi sometimes resolves SRV targets to loopback (`127.0.0.1`)
+///      when the local hostname has multiple A records.
+/// Embedding the LAN IPv4 directly in TXT bypasses both.
+pub(super) const TXT_KEY_IP: &str = "ip";
+
+// ── Name builders ────────────────────────────────────────────────────────────
+
+/// Human-readable service instance name shown by DNS-SD browsers
+/// (e.g. `dns-sd -B _dverse._tcp` displays `DVerse (alice)`).
+pub(super) fn instance_name(cn: &str) -> String {
+    format!("DVerse ({cn})")
+}
+
+/// SRV target hostname for our router instance.  Peers resolve this to
+/// our address records to find us at the network layer.  Per-CN (rather
+/// than the machine's default hostname) so multiple test routers on one
+/// host don't collide.
+pub(super) fn srv_host_name(cn: &str) -> String {
+    format!("zenoh-{cn}.local.")
+}
+
+/// Custom A-record hostname registered alongside the avahi service,
+/// pinned to the detected LAN IPv4.  Pinning a dedicated A record makes
+/// SRV resolution deterministic — avahi's default hostname can resolve
+/// to loopback, link-local, and LAN addresses all at once.
+pub(super) fn pinned_a_record_host(cn: &str) -> String {
+    format!("dverse-{cn}.local.")
+}
+
+/// Cache key for tracking a discovered peer's endpoints.  avahi's
+/// `ItemNew` signal gives `(name, svc_type, domain)` separately — this
+/// re-assembles them into the same fullname mdns-sd reports, so both
+/// backends share the same key shape.
+pub(super) fn peer_cache_key(name: &str, svc_type: &str) -> String {
+    format!("{name}.{svc_type}.")
+}
+
+/// Zenoh endpoint URI for the router's `connect/endpoints` config.
+/// Zenoh's URI form is `<protocol>/<host>:<port>`; dverse runs mTLS.
+pub(super) fn zenoh_tls_endpoint(ip: IpAddr, port: u16) -> String {
+    format!("tls/{ip}:{port}")
+}
+
+// ── TXT entry builders ───────────────────────────────────────────────────────
+
+/// `cn=<value>` TXT entry, byte-encoded for avahi `AddService`.
+/// (mdns-sd takes `(&str, &str)` tuples instead; see [`TXT_KEY_CN`].)
+pub(super) fn txt_cn_entry(cn: &str) -> Vec<u8> {
+    format!("{TXT_KEY_CN}={cn}").into_bytes()
+}
+
+/// `ip=<value>` TXT entry, byte-encoded for avahi `AddService`.
+pub(super) fn txt_ip_entry(ip: Ipv4Addr) -> Vec<u8> {
+    format!("{TXT_KEY_IP}={ip}").into_bytes()
+}
+
+// ── IP detection ─────────────────────────────────────────────────────────────
+
+/// Bind ephemerally for the LAN-detection trick — we never `send()`, so the
+/// OS doesn't actually claim any specific interface.
+const LAN_DETECT_BIND: &str = "0.0.0.0:0";
+
+/// Well-known public address used to coax the routing table into revealing
+/// which local IP would be used for outbound traffic.  No packet is sent —
+/// only `connect()` + `local_addr()`.  Any reachable public IP works;
+/// Cloudflare's public DNS is chosen for its long-term stability.
+const LAN_DETECT_REMOTE: &str = "1.1.1.1:53";
+
+/// Detect this machine's LAN IPv4 — the address the kernel would use to
+/// reach the public internet.  Uses a UDP routing trick: bind ephemerally,
+/// `connect()` to a public address (no packet leaves), then read back
+/// the local address the kernel selected.
+pub(super) fn detect_lan_ipv4() -> Option<Ipv4Addr> {
+    let sock = UdpSocket::bind(LAN_DETECT_BIND).ok()?;
+    sock.connect(LAN_DETECT_REMOTE).ok()?;
+    match sock.local_addr().ok()? {
+        std::net::SocketAddr::V4(a) if !a.ip().is_loopback() && !a.ip().is_link_local() => {
+            Some(*a.ip())
+        }
+        _ => None,
+    }
+}
+
+/// Whether an address is unsuitable to hand to Zenoh as a peer endpoint:
+/// loopback (only routes inside our own host) or link-local (no scope id,
+/// so cross-host TLS would fail).
+pub(super) fn is_unroutable(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_link_local(),
+        IpAddr::V6(v6) => v6.is_loopback() || (v6.segments()[0] & 0xffc0) == 0xfe80,
+    }
+}
+
+// ── mdns-sd daemon setup ─────────────────────────────────────────────────────
+
+/// Create a new mdns-sd daemon with interface filters applied.
+/// Returns `None` (and logs) if the daemon couldn't be initialised — typically
+/// because UDP 5353 is bound by another process in an incompatible way.
+pub(super) fn create_filtered_daemon(state: &Arc<Mutex<AppState>>) -> Option<ServiceDaemon> {
+    let daemon = match ServiceDaemon::new() {
+        Ok(d) => d,
+        Err(e) => {
+            state.lock().unwrap().push_log(format!(
+                "mDNS[mdns-sd]: daemon init failed ({e}); peer discovery disabled"
+            ));
+            return None;
+        }
+    };
+    state.lock().unwrap().push_log("mDNS[mdns-sd]: daemon started".to_string());
+    apply_interface_filters(&daemon, state);
+    Some(daemon)
+}
+
+/// Disable IPv6 and any virtual/link-local IPv4 adapter on the given daemon.
+///
+/// Why each filter exists:
+///   * IPv6 — Zenoh peer endpoints are `tls/<ipv4>:<port>`; `fe80::`
+///     addresses are not routable across subnets and would only generate
+///     dead endpoints.
+///   * Virtual adapters — Npcap Loopback (Wireshark), docker0 / br-* / veth*,
+///     vEthernet (Hyper-V), VMware, VirtualBox, WireGuard.  Valid locally
+///     but reach no remote peer; worse, on Windows a low-metric Npcap
+///     adapter silently swallows our PTR responses entirely.
+///   * Link-local IPv4 (169.254.0.0/16) — same story; no peer is there.
+fn apply_interface_filters(daemon: &ServiceDaemon, state: &Arc<Mutex<AppState>>) {
+    let _ = daemon.disable_interface(IfKind::IPv6);
+
+    let Ok(ifaces) = if_addrs::get_if_addrs() else { return };
+    let mut already_disabled: HashSet<String> = HashSet::new();
+
+    for iface in &ifaces {
+        if !is_virtual_or_link_local(iface) {
+            continue;
+        }
+        if !already_disabled.insert(iface.name.clone()) {
+            continue;
+        }
+        state.lock().unwrap().push_log(format!(
+            "mDNS[mdns-sd]: disabling virtual/link-local iface {} ({})",
+            iface.name,
+            iface.ip(),
+        ));
+        let _ = daemon.disable_interface(IfKind::Name(iface.name.clone()));
+    }
+}
+
+/// Pattern-match an interface name against known virtual-adapter prefixes,
+/// or check whether its IPv4 address is in the link-local range.
+fn is_virtual_or_link_local(iface: &if_addrs::Interface) -> bool {
+    let name = iface.name.to_lowercase();
+    let known_virtual = name.contains("npcap")
+        || name.contains("loopback")
+        || name.contains("vethernet")
+        || name.contains("hyper-v")
+        || name.contains("vmware")
+        || name.contains("virtualbox")
+        || name.contains("docker")
+        || name.starts_with("br-")
+        || name.starts_with("veth")
+        || name.starts_with("wg");
+    let link_local_v4 = matches!(
+        &iface.addr,
+        if_addrs::IfAddr::V4(v4) if v4.ip.is_link_local()
+    );
+    known_virtual || link_local_v4
+}
+
+// ── Peer registry ────────────────────────────────────────────────────────────
+
+/// Tracks discovered peers and pushes the flattened endpoint list onto a
+/// watch channel whenever it changes.  The flattened list is what the router
+/// passes to Zenoh's `connect/endpoints`; the change notification triggers
+/// a session reload to pick up new peers.
+pub(super) struct PeerRegistry {
+    peers: HashMap<String, Vec<String>>,
+    tx: watch::Sender<Vec<String>>,
+}
+
+impl PeerRegistry {
+    pub(super) fn new() -> (Self, watch::Receiver<Vec<String>>) {
+        let (tx, rx) = watch::channel(vec![]);
+        (Self { peers: HashMap::new(), tx }, rx)
+    }
+
+    /// Replace the full endpoint list for one peer.  Returns `true` if the
+    /// list actually changed (callers use this to suppress duplicate log
+    /// lines when a backend re-fires events for already-known peers).
+    pub(super) fn set(&mut self, key: String, endpoints: Vec<String>) -> bool {
+        if self.peers.get(&key).map(|v| v.as_slice()) == Some(endpoints.as_slice()) {
+            return false;
+        }
+        self.peers.insert(key, endpoints);
+        let _ = self.tx.send(self.flatten());
+        true
+    }
+
+    /// Append one endpoint to a peer's set.  Used by the avahi backend,
+    /// which receives per-interface events and accumulates endpoints
+    /// incrementally.  Returns `true` if the endpoint was new.
+    pub(super) fn add_one(&mut self, key: String, endpoint: String) -> bool {
+        let entry = self.peers.entry(key).or_default();
+        if entry.contains(&endpoint) {
+            return false;
+        }
+        entry.push(endpoint);
+        entry.sort();
+        let _ = self.tx.send(self.flatten());
+        true
+    }
+
+    /// Forget a peer entirely.  Returns the removed endpoints, for logging.
+    pub(super) fn remove(&mut self, key: &str) -> Option<Vec<String>> {
+        let removed = self.peers.remove(key)?;
+        let _ = self.tx.send(self.flatten());
+        Some(removed)
+    }
+
+    fn flatten(&self) -> Vec<String> {
+        self.peers.values().flatten().cloned().collect()
+    }
+}

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use eframe::egui;
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 
 use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, REGISTRATION_CLIENT_ID, REGISTRATION_CLIENT_SECRET, ROUTER_LISTEN, ROUTER_PORT};
 use crate::state::{AppState, RouterStatus};
@@ -20,11 +20,22 @@ pub struct LoginForm {
     pub username: String,
     pub password: String,
     pub error: Option<String>,
+    /// Radio: true = create a new session (this user becomes admin),
+    /// false = join an existing session whose admin's CN is `join_admin_cn`.
+    pub create_session: bool,
+    /// Admin CN to join when `create_session == false`.
+    pub join_admin_cn: String,
 }
 
 impl Default for LoginForm {
     fn default() -> Self {
-        Self { username: String::new(), password: String::new(), error: None }
+        Self {
+            username: String::new(),
+            password: String::new(),
+            error: None,
+            create_session: true,
+            join_admin_cn: String::new(),
+        }
     }
 }
 
@@ -147,6 +158,29 @@ fn show_login(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>, form: &mut 
                     }
                 });
 
+            ui.add_space(12.0);
+            ui.separator();
+            ui.add_space(8.0);
+
+            // Session role selector: create your own session, or join an
+            // existing one whose admin's CN you know.
+            ui.horizontal(|ui| {
+                ui.radio_value(&mut form.create_session, true, "Create new session");
+                ui.add_space(12.0);
+                ui.radio_value(&mut form.create_session, false, "Join session");
+            });
+            if !form.create_session {
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    ui.label("Admin username");
+                    ui.add(
+                        egui::TextEdit::singleline(&mut form.join_admin_cn)
+                            .hint_text("e.g. alice")
+                            .min_size(egui::vec2(220.0, 0.0)),
+                    );
+                });
+            }
+
             ui.add_space(16.0);
 
             if let Some(err) = &form.error {
@@ -192,6 +226,19 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         return;
     }
 
+    // Build session role from the radio + admin CN field.  When joining,
+    // the admin CN is required and must be non-empty.
+    let session_role = if form.create_session {
+        SessionRole::Admin
+    } else {
+        let admin_cn = form.join_admin_cn.trim().to_string();
+        if admin_cn.is_empty() {
+            form.error = Some("Admin username is required to join a session.".into());
+            return;
+        }
+        SessionRole::Client { admin_cn }
+    };
+
     let cert_dir = dirs::data_local_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join("dverse")
@@ -214,6 +261,7 @@ fn try_login(form: &mut LoginForm, state: &Arc<Mutex<AppState>>) {
         cert_dir,
         router_listen: ROUTER_LISTEN.into(),
         router_endpoint,
+        session_role,
     };
 
     if let Err(e) = cfg.save() {
@@ -444,6 +492,28 @@ fn show_loading(ctx: &egui::Context, state: &Arc<Mutex<AppState>>) {
 
 fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
     let st = state.lock().unwrap();
+
+    // Session badge — declared first so it renders above status_bar.  egui's
+    // top panels stack in declaration order.
+    egui::TopBottomPanel::top("session_bar").show(ctx, |ui| {
+        ui.horizontal(|ui| {
+            ui.label("Session:");
+            match &st.session_role {
+                SessionRole::Admin => {
+                    ui.colored_label(
+                        egui::Color32::LIGHT_BLUE,
+                        format!("Admin · {}", st.session_id),
+                    );
+                }
+                SessionRole::Client { admin_cn } => {
+                    ui.colored_label(
+                        egui::Color32::LIGHT_GREEN,
+                        format!("Joined · admin: {admin_cn}"),
+                    );
+                }
+            }
+        });
+    });
 
     egui::TopBottomPanel::top("status_bar").show(ctx, |ui| {
         ui.horizontal(|ui| {

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -47,7 +47,9 @@ fn run_demo() {
     let mut state = AppState::new(None);
     state.admitted = vec!["alice".into(), "mybot".into()];
     state.router_status = state::RouterStatus::Running;
+    state.session_id = "alice".into();
     state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
+    state.push_log("[demo] Session admin: alice");
     state.push_log("[demo] Auto-admitted: alice");
     state.push_log("[demo] Auto-admitted: mybot");
     launch_gui(Arc::new(Mutex::new(state)), Screen::Main);

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use bot_framework::cert;
 use bot_framework::config::DverseConfig;
+use tokio::sync::watch;
 use zenoh::Session;
 
 use crate::discovery::MdnsHandle;
@@ -18,6 +19,8 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut current_cfg: Option<DverseConfig> = None;
     // Kept alive for the entire router lifetime; dropped (→ mDNS record withdrawn) on exit.
     let mut _mdns: Option<MdnsHandle> = None;
+    // Carries the current set of discovered peer endpoints; starts empty.
+    let (_, mut peer_rx): (_, watch::Receiver<Vec<String>>) = watch::channel(vec![]);
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -35,9 +38,16 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
-            // Publish DNS-SD service record once, the first time we get a config.
+            // Publish DNS-SD service record and start peer browsing once, on first config.
             if _mdns.is_none() {
-                _mdns = MdnsHandle::publish(&cfg.operator_cn(), crate::constants::ROUTER_PORT, &state);
+                if let Some(handle) = MdnsHandle::publish(
+                    &cfg.operator_cn(),
+                    crate::constants::ROUTER_PORT,
+                    &state,
+                ) {
+                    peer_rx = handle.peer_rx.clone();
+                    _mdns = Some(handle);
+                }
             }
 
             cfg
@@ -87,9 +97,10 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             }
         };
 
-        // ── Phase 3: run session loop (restarts on ACL change) ───────────────
+        // ── Phase 3: run session loop (restarts on ACL or peer change) ──────
         let admitted = state.lock().unwrap().admitted.clone();
-        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted) {
+        let peers = peer_rx.borrow().clone();
+        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted, &peers) {
             Ok(c) => c,
             Err(e) => {
                 let mut s = state.lock().unwrap();
@@ -125,8 +136,8 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             s.push_log("Router running.");
         }
 
-        // session_loop returns when the admitted list changes.
-        if let Err(e) = session_loop(&session, Arc::clone(&state)).await {
+        // session_loop returns when the admitted list or peer set changes.
+        if let Err(e) = session_loop(&session, Arc::clone(&state), peer_rx.clone()).await {
             state.lock().unwrap().push_log(format!("Session error: {e}"));
         }
 
@@ -160,36 +171,49 @@ async fn acquire_or_reuse(
 }
 
 /// Subscribe to node announce messages; auto-admit any node with a valid cert.
-/// Returns when the admitted list changes (triggering an ACL session restart).
-async fn session_loop(session: &Session, state: Arc<Mutex<AppState>>) -> Result<()> {
+/// Returns when the admitted list or peer set changes (triggering a session restart).
+async fn session_loop(
+    session: &Session,
+    state: Arc<Mutex<AppState>>,
+    mut peer_rx: watch::Receiver<Vec<String>>,
+) -> Result<()> {
     let subscriber = session
         .declare_subscriber("dverse/nodes/announce/**")
         .await
         .map_err(|e| anyhow::anyhow!("declare_subscriber: {e}"))?;
 
+    // Mark current peer set as seen so the first .changed() fires only on a real change.
+    peer_rx.borrow_and_update();
+
     loop {
-        match subscriber.recv_async().await {
-            Ok(s) => {
-                let key = s.key_expr().as_str().to_string();
-                if key.starts_with("dverse/nodes/announce/") {
-                    // CN is sent as payload; fall back to key segment if empty.
-                    let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
-                    let cn = if payload_cn.trim().is_empty() {
-                        key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
-                    } else {
-                        payload_cn.trim().to_string()
-                    };
-                    if cn.is_empty() { continue; }
-                    let mut st = state.lock().unwrap();
-                    if !st.admitted.contains(&cn) {
-                        st.admitted.push(cn.clone());
-                        st.push_log(format!("Auto-admitted CN: {cn}"));
-                        // Signal the outer loop to restart the session with new ACL.
-                        return Ok(());
+        tokio::select! {
+            msg = subscriber.recv_async() => {
+                match msg {
+                    Ok(s) => {
+                        let key = s.key_expr().as_str().to_string();
+                        if key.starts_with("dverse/nodes/announce/") {
+                            let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
+                            let cn = if payload_cn.trim().is_empty() {
+                                key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
+                            } else {
+                                payload_cn.trim().to_string()
+                            };
+                            if cn.is_empty() { continue; }
+                            let mut st = state.lock().unwrap();
+                            if !st.admitted.contains(&cn) {
+                                st.admitted.push(cn.clone());
+                                st.push_log(format!("Auto-admitted CN: {cn}"));
+                                return Ok(());
+                            }
+                        }
                     }
+                    Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
                 }
             }
-            Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),
+            Ok(()) = peer_rx.changed() => {
+                state.lock().unwrap().push_log("Peer set changed, reloading router…");
+                return Ok(());
+            }
         }
     }
 }
@@ -200,6 +224,7 @@ fn build_zenoh_config(
     cert_path: &std::path::Path,
     key_path: &std::path::Path,
     admitted: &[String],
+    peers: &[String],
 ) -> Result<zenoh::Config> {
     let mut cfg = zenoh::Config::default();
 
@@ -211,6 +236,14 @@ fn build_zenoh_config(
     zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(&cert_path.to_string_lossy()))?;
     zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(&key_path.to_string_lossy()))?;
     zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
+
+    if !peers.is_empty() {
+        let endpoints_json = serde_json::to_string(peers).unwrap();
+        zinsert(&mut cfg, "connect/endpoints", &endpoints_json)?;
+        // Peer endpoints are IPs from DNS-SD; skip SNI hostname check.
+        // mTLS CA verification is still enforced on both sides.
+        zinsert(&mut cfg, "transport/link/tls/verify_name_on_connect", "false")?;
+    }
 
     Ok(cfg)
 }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use bot_framework::cert;
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 use tokio::sync::watch;
 use zenoh::Session;
 
@@ -38,10 +38,21 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                 tokio::time::sleep(Duration::from_millis(200)).await;
             };
 
+            // Copy session role + id into AppState before MdnsHandle::publish so
+            // the GUI shows the badge immediately and DNS-SD includes session=
+            // in its first announcement.
+            let session_id = cfg.session_id();
+            {
+                let mut s = state.lock().unwrap();
+                s.session_role = cfg.session_role.clone();
+                s.session_id = session_id.clone();
+            }
+
             // Publish DNS-SD service record and start peer browsing once, on first config.
             if _mdns.is_none() {
                 if let Some(handle) = MdnsHandle::publish(
                     &cfg.operator_cn(),
+                    &session_id,
                     crate::constants::ROUTER_PORT,
                     &state,
                 ) {
@@ -60,6 +71,16 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             if !st.admitted.contains(&operator_cn) {
                 st.admitted.push(operator_cn.clone());
                 st.push_log(format!("Pre-admitted operator CN: {operator_cn}"));
+            }
+            // When joining someone else's session, pre-admit the admin's CN too,
+            // so the admin's router (which carries that cert) can connect and
+            // form the mesh before we've heard a heartbeat from any of their
+            // agents.
+            if let SessionRole::Client { admin_cn } = &cfg.session_role {
+                if !admin_cn.is_empty() && !st.admitted.contains(admin_cn) {
+                    st.admitted.push(admin_cn.clone());
+                    st.push_log(format!("Pre-admitted session admin CN: {admin_cn}"));
+                }
             }
         }
 

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,4 +1,4 @@
-use bot_framework::config::DverseConfig;
+use bot_framework::config::{DverseConfig, SessionRole};
 
 pub struct AppState {
     pub router_status: RouterStatus,
@@ -8,6 +8,13 @@ pub struct AppState {
     pub log: Vec<String>,
     /// Config written by the GUI; background thread consumes it to start/restart.
     pub staged_config: Option<DverseConfig>,
+    /// Whether this router hosts the session (Admin) or joined one (Client).
+    /// Copied from the accepted config; the GUI reads it for the session badge.
+    pub session_role: SessionRole,
+    /// Cached `cfg.session_id()` — copied once at config-accept time so the
+    /// GUI and DNS-SD threads don't re-derive it.  Empty string until a config
+    /// has been accepted.
+    pub session_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -22,11 +29,17 @@ pub enum RouterStatus {
 
 impl AppState {
     pub fn new(initial_config: Option<DverseConfig>) -> Self {
+        let (session_role, session_id) = match &initial_config {
+            Some(cfg) => (cfg.session_role.clone(), cfg.session_id()),
+            None => (SessionRole::Admin, String::new()),
+        };
         Self {
             router_status: RouterStatus::Idle,
             admitted: Vec::new(),
             log: Vec::new(),
             staged_config: initial_config,
+            session_role,
+            session_id,
         }
     }
 


### PR DESCRIPTION
## Summary

The Linux-specific avahi path turned into a steady stream of platform bugs:

- **Chromium ships its own mDNS responder** and refuses to release UDP 5353 even after the browser window closes, causing avahi to flag every custom `AddAddress` as a local collision.
- **avahi 0.9-rc4** (current in Arch's `extra` repo) has a conflict-detection regression that rejects every custom A record on the host, with no config workaround.
- The **avahi D-Bus API expects names without trailing periods**, which disagrees with the fully-qualified form our shared helpers use.
- The hostname avahi auto-publishes for SRV resolution doesn't match the Step-CA cert SAN, and the per-CN hostname we want to register hits the bugs above before it has a chance to be useful.

`mdns-sd` is pure Rust, runs in-process, ships its own A record alongside the SRV target via `ServiceInfo::new`, and we've already proven it works on Linux even with `avahi-daemon` also bound to port 5353.

This drop:
- Removes the avahi publish + browse paths (~640 lines deleted).
- Removes the `zbus` dependency.
- Reduces `MdnsHandle::publish` to one line that calls `mdns_sd_start`.

No external API change. The on-the-wire DNS-SD output (PTR / SRV / TXT with `cn` / `ip` / `session`) is unchanged, so peers see no difference.

## Stacked on

- #91 — session role + DNS-SD session filter