### PR TITLE
fix(cert): force renewal when cached cert's CN doesn't match operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "x509-parser",
  "zenoh",
 ]
 

--- a/documents/adr/ADR-016.md
+++ b/documents/adr/ADR-016.md
@@ -1,0 +1,63 @@
+# ADR-016: Force certificate renewal when the cached cert's CN does not match the operator
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+The bot-framework caches per-node certificates at a fixed path on disk — `router.crt` / `router.key` for the router, `ping.crt` / `ping.key` for the ping bot, etc. The path is per-binary, not per-user.
+
+`needs_renewal` decided whether to fetch a fresh cert from step-CA based solely on the file's age (well before its `notAfter`, fetch a new one). It never inspected what was actually inside the file.
+
+This broke as soon as a single workstation switched users:
+
+1. User signs in as `test3`, the bot-framework provisions `router.crt` with `CN=test3`, valid for 24 hours.
+2. The same workstation signs out and signs back in as `test2` within the validity window.
+3. `needs_renewal` returns `false` (file is fresh). The router presents `CN=test3` on its mTLS listener.
+4. A local agent dialling the router has been issued a cert with `CN=test2`. The Step-CA template puts `SAN = DNS:zenoh-<cn>.local` into the agent's cert. The router's listener cert presents `zenoh-test3.local` in its own SAN; the agent's SNI / SAN verification fails; every handshake from local agents drops at the TLS layer with `BadCertificate`.
+
+Observed symptom: switching accounts produces a router that looks fine in the GUI ("Running") but no agent can connect, with no log line obviously pointing at the CN mismatch.
+
+The fix has to land before agent inventory (PR #92) because the inventory only populates from successful agent connections — a CN mismatch would silently empty the tree on every account switch and there'd be no upstream cause visible.
+
+## Decision
+
+Extend `needs_renewal` so that, in addition to checking the file's age, it parses the cached certificate's `Subject` and compares the `CN` field against the expected operator CN. If they differ, force renewal.
+
+`needs_renewal` gains an `expected_cn: Option<&str>` parameter:
+
+* The router and bots pass `Some(&cfg.operator_cn())`.
+* The standalone `bot_framework check-cert` CLI subcommand passes `None` — it only cares about file freshness for diagnostics, not about identity match.
+
+Parsing uses the `x509-parser` crate. It is already present in the workspace dep tree via Zenoh's rustls path, so adding it as a direct `bot_framework` dependency does not pull in anything new.
+
+The renewal trigger goes through the same step-CA flow as expiry-driven renewal — no new code path, no new error mode.
+
+## Alternatives
+
+**Per-user cert paths (`~/.config/dverse/<cn>/router.crt`).** Rejected. Would also fix the symptom but requires every binary to know the operator CN before any cert path can be resolved — a chicken-and-egg with the current "load config → read CN → derive path" order. Larger refactor for the same end state.
+
+**Always renew on every startup.** Rejected. Burns a step-CA round-trip on every router launch, even when the cached cert is correct, and breaks offline development where step-CA is unreachable but the cached cert is still in date.
+
+**Detect mismatch at handshake time and renew lazily on first failure.** Rejected. The TLS error is raised inside Zenoh's listener, which we don't drive directly; converting that into a renewal trigger means plumbing a handshake-error channel out of Zenoh — significantly more code than a 5-line pre-flight CN check.
+
+**Track the previous operator's CN in `state.json` and compare against that.** Rejected. Same outcome as parsing the cert, but introduces a second source of truth (the JSON) that could disagree with the cert on disk. The cert is the authoritative answer about "what CN is this file"; parsing it directly avoids the divergence risk.
+
+## Consequences
+
+**Positive**
+* Switching accounts on a shared workstation produces a fresh cert with the correct CN automatically, so local agent handshakes succeed without the operator noticing the CN swap.
+* The expected-CN check costs one cert parse per startup — negligible compared to the step-CA round-trip it replaces in the misalignment case.
+* The CLI's `check-cert` subcommand stays useful as an age-only inspector by passing `None`. Operational tooling does not regress.
+* No new dependency on the build (x509-parser is already transitive).
+* Eliminates a known confusing-failure path before agent inventory exposes the symptom more visibly.
+
+**Negative**
+* Adds a parsing step that can in theory itself fail (malformed cert on disk). Mitigated by treating a parse error as "force renewal" — the safest of the two possible answers, since the file is unusable anyway.
+* `needs_renewal` is now non-trivially coupled to the x509 schema. If step-CA ever switches the CN to a different attribute (`UID`, OID-by-string, etc.), this code has to update. The risk is small (we control the template) and the failure mode is loud (renewal loops would be obvious in logs).
+* Users who deliberately want to reuse a cert across two CNs (a use case we do not support and have no plans to) cannot do so without manually editing the cache. This is intentional.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -23,3 +23,4 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 zenoh = "1.8.0"
 keyring = { version = "3", features = ["sync-secret-service", "apple-native", "windows-native"] }
+x509-parser = "0.18"

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -309,6 +309,18 @@ pub async fn needs_renewal(
         return true;
     }
     if let Some(expected) = expected_cn {
+        // Guard against an empty expected CN — every cert has a non-empty
+        // Subject CN, so `cn == ""` would never match and we'd force renewal
+        // on every call (and the freshly-renewed cert would have the same
+        // mismatch, looping indefinitely).  Treat empty as "no CN check".
+        if expected.is_empty() {
+            eprintln!(
+                "cert: needs_renewal called with empty expected_cn; \
+                 skipping CN check to avoid a renewal loop \
+                 (likely a misconfigured operator_cn — investigate)"
+            );
+            return false;
+        }
         return match cert_subject_cn(cert_path).await {
             Some(cn) if cn == expected => false,
             _ => true,

--- a/src/bot_framework/src/cert.rs
+++ b/src/bot_framework/src/cert.rs
@@ -269,13 +269,50 @@ pub async fn bootstrap_ca_root(ca_url: &str, out_path: &Path) -> Result<String> 
     Ok(pem)
 }
 
-/// Returns true if the cert file does not exist or is older than `max_age`.
-pub async fn needs_renewal(cert_path: &Path, max_age: std::time::Duration) -> bool {
-    match tokio::fs::metadata(cert_path).await {
-        Ok(meta) => match meta.modified() {
-            Ok(modified) => modified.elapsed().unwrap_or(max_age) >= max_age,
-            Err(_) => true,
-        },
-        Err(_) => true,
+/// Read a PEM-encoded X.509 cert and return its Subject CN.
+/// Returns `None` if the file can't be read, isn't valid PEM, or has no CN
+/// in its Subject — all cases the caller should treat as "force renewal".
+async fn cert_subject_cn(cert_path: &Path) -> Option<String> {
+    use x509_parser::prelude::FromDer;
+
+    let pem_text = tokio::fs::read(cert_path).await.ok()?;
+    let (_, pem) = x509_parser::pem::parse_x509_pem(&pem_text).ok()?;
+    let (_, cert) = x509_parser::certificate::X509Certificate::from_der(&pem.contents).ok()?;
+    cert.subject()
+        .iter_common_name()
+        .next()?
+        .as_str()
+        .ok()
+        .map(str::to_string)
+}
+
+/// Returns true if the cert file is missing, older than `max_age`, or was
+/// issued for a different `expected_cn` than the current operator.
+///
+/// `expected_cn` is optional: pass `Some(cn)` from the router/agent paths
+/// to force renewal when the cached cert was issued for a different user
+/// (the cert files live at the same path regardless of which user is signed
+/// in, so without the check, switching accounts silently keeps presenting
+/// the old identity and the TLS SAN mismatches at the next handshake).
+/// Pass `None` from generic tooling that only cares about file age.
+pub async fn needs_renewal(
+    cert_path: &Path,
+    max_age: std::time::Duration,
+    expected_cn: Option<&str>,
+) -> bool {
+    let Ok(meta) = tokio::fs::metadata(cert_path).await else { return true };
+    if meta
+        .modified()
+        .map(|m| m.elapsed().unwrap_or(max_age) >= max_age)
+        .unwrap_or(true)
+    {
+        return true;
     }
+    if let Some(expected) = expected_cn {
+        return match cert_subject_cn(cert_path).await {
+            Some(cn) if cn == expected => false,
+            _ => true,
+        };
+    }
+    false
 }

--- a/src/bot_framework/src/main.rs
+++ b/src/bot_framework/src/main.rs
@@ -119,7 +119,7 @@ async fn main() -> Result<()> {
 
         Command::CheckCert { node_name, cert_dir, max_age_hours } => {
             let crt = cert::cert_path(&cert_dir, &node_name);
-            let stale = cert::needs_renewal(&crt, Duration::from_secs(max_age_hours * 3600)).await;
+            let stale = cert::needs_renewal(&crt, Duration::from_secs(max_age_hours * 3600), None).await;
             if stale {
                 eprintln!("Certificate {} needs renewal.", crt.display());
                 std::process::exit(1);

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
     let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
-    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
+    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600), Some(&cfg.operator_cn())).await {
         println!("[{NODE_NAME}] Acquiring certificate…");
         let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
         cert::acquire(&cert_cfg).await?;

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
     let key_path  = cert::key_path(&cfg.cert_dir, NODE_NAME);
     let ca_path   = cert::ca_path(&cfg.cert_dir, NODE_NAME);
 
-    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600)).await {
+    if cert::needs_renewal(&cert_path, Duration::from_secs(23 * 3600), Some(&cfg.operator_cn())).await {
         println!("[{NODE_NAME}] Acquiring certificate…");
         let cert_cfg = cfg.cert_config_for(NODE_NAME)?;
         cert::acquire(&cert_cfg).await?;

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -183,7 +183,7 @@ async fn acquire_or_reuse(
     let ca = cert::ca_path(&cfg.cert_dir, "router");
 
     let max_age = Duration::from_secs(23 * 3600);
-    if cert::needs_renewal(&c, max_age).await {
+    if cert::needs_renewal(&c, max_age, Some(&cfg.operator_cn())).await {
         let cert_cfg = cfg.cert_config_for("router")?;
         cert::acquire(&cert_cfg).await
     } else {


### PR DESCRIPTION
## Summary

`needs_renewal` now compares the cached cert's Subject CN against the expected operator CN. If they differ, force renewal. Closes the account-switch failure where a cert from a previous user's session was still in date and got reused at the mTLS handshake.

Full reasoning + alternatives (per-user cert paths, always-renew, handshake-time detection, persisted CN snapshot): **`documents/adr/ADR-016.md`**.

## The bug

Cert files live at a fixed per-node path (`router.crt` / `ping.crt` / …) regardless of which user is signed in. When a user switched accounts, the old cert was still in date and got reused — router presented a cert with `CN=test3` to a session running as `test2`, every TLS handshake from local agents failed the SAN check, GUI showed Running but nothing actually flowed.

## The fix

`needs_renewal(expected_cn: Option<&str>)`:
- `Some(&cn)` from router / bots — force renewal when the cached cert's Subject CN differs.
- `None` from `bot_framework check-cert` CLI — age-only check, since the CLI is only used for diagnostics.

Uses `x509-parser`, already a transitive workspace dep via Zenoh's rustls path — no new direct deps.

## What's preserved
- The same step-CA renewal flow — no new code path, no new error mode.
- `check-cert` CLI subcommand stays useful as a freshness inspector.
- Existing age-driven renewal continues to work as before.

## Test plan
- [x] `cargo build --workspace` clean
- [x] Sign in as `test3`, sign out, sign in as `test2` within the cert validity window — new cert auto-issued; agents connect
- [x] `check-cert` CLI still reports correctly without expected-CN check
