### PR TITLE
fix(router): present client cert on outgoing inter-router TLS connections

### DIFF
--- a/documents/adr/ADR-017.md
+++ b/documents/adr/ADR-017.md
@@ -1,0 +1,67 @@
+# ADR-017: Present the router's client certificate on outgoing inter-router TLS connections
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+After PR #89 / #90 / #91, two routers on the same LAN discover each other via DNS-SD, agree on session identity, and end up with each other's `tls/<ip>:<port>` endpoint in their respective Zenoh `connect/endpoints` lists. Their listener sockets each present a server certificate; mutual TLS is mandatory.
+
+`build_zenoh_config` was setting only two TLS fields:
+
+```
+listen_certificate    = router.crt
+listen_private_key    = router.key
+```
+
+These configure the **listener** side. They control which certificate the router presents when a peer dials *us*. They do **not** configure the **dialer** side. When the router dials a peer, it terminates the handshake without offering any client certificate at all. The peer (running `enable_mtls = true` exactly as we do) requires a valid client cert and aborts the handshake.
+
+The failure mode is silent across multiple layers:
+
+* mDNS discovery succeeds — both routers find each other.
+* Endpoints land in `connect/endpoints` correctly.
+* The router restarts its Zenoh session as designed.
+* The new session reloads its ACL with the peer's CN admitted.
+* The TLS handshake on the outbound connection stalls without an obvious error in either router's GUI; Zenoh just keeps retrying.
+* No agent message ever crosses the LAN.
+
+The symptom only shows up in two-machine testing — locally the router both dials and accepts on the same listener and the bug is invisible — which is why it survived until #91 stabilised.
+
+## Decision
+
+Set the corresponding **connect**-side fields to the same files the listener uses:
+
+```
+listen_certificate     = router.crt
+listen_private_key     = router.key
+connect_certificate    = router.crt
+connect_private_key    = router.key
+```
+
+A router has exactly one identity. It uses the same cert in both directions; the listener / connect split inside Zenoh's TLS config is a configuration-surface oddity, not an indication that two identities should exist. No new files, no new config keys, no new code path.
+
+## Alternatives
+
+**Issue a separate client certificate for outgoing connections.** Rejected. Adds an issuance round-trip and a second cached file per router for no security or operational benefit. Step-CA has no reason to distinguish "this router as a TLS server" from "this router as a TLS client" — both roles map to the same `CN`.
+
+**Disable mTLS on the listener so peer connects don't need a client cert.** Rejected. The entire trust model depends on mutual TLS — every connection is authenticated to a step-CA-issued identity. Downgrading to server-auth-only would let any host on the LAN feed messages into the bus.
+
+**Drive the outbound dial through a separate Zenoh session with different config.** Rejected. Multiple sessions would multiply both the resource cost and the number of places that need to know which key file to use. The single-session, single-identity invariant is intentional.
+
+**Make Zenoh default to the listener cert as a client cert when no explicit `connect_certificate` is set.** Rejected — not in our control, and even if upstream accepted such a change it would be a behavior break for users who today rely on the missing-client-cert path being explicit.
+
+## Consequences
+
+**Positive**
+* Two-machine LAN testing now passes end-to-end: discovery → connect → handshake → ACL admit → agent traffic. The bug class "everything in the GUI looks fine but no messages cross the network" disappears.
+* One-line config-builder change. No new files, no new dependencies, no new cleanup obligations.
+* Same identity in both directions matches operator intuition: there is one user per workstation and one CN per user.
+
+**Negative**
+* The fix is invisible from the GUI — there is no log line that announces "now also presenting client cert on outbound". Diagnosing the original bug required inspecting the Zenoh config dump; the only sign the fix is in place is that messages flow. We rely on integration testing (LAN smoke test) to keep this honest.
+* `build_zenoh_config` now writes the cert paths twice. Cosmetic but worth flagging — a future config refactor should probably expose a single `tls_identity` setter that fans out to both pairs, to remove the chance of one half drifting.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-018.md
+++ b/documents/adr/ADR-018.md
@@ -1,0 +1,114 @@
+# ADR-018: Per-node agent inventory with heartbeat and stale eviction
+
+**Status:** Accepted
+**Date:** 28-05-2026
+**Author:** Yordan Mitev
+
+## Context
+
+The router used to know two things about an admitted peer: its CN (a flat `Vec<String>` populated by Phase 1 admission and growing whenever a peer auto-admit fired) and that some agent on that CN had published *something* on `dverse/nodes/announce/**`. It did not know:
+
+* Which agents that user was actually running.
+* Each agent's version or which Zenoh key expressions it touched.
+* Whether an agent that announced ten minutes ago was still alive.
+* Whether to ever consider an absent agent gone.
+
+The GUI rendered a flat "admitted CNs" list. From the user's perspective, that was useless for the actual question — "is bob's pong agent up?" — which is what every operational use of the router is going to ask first.
+
+This is the load-bearing UX change for the project. PR #91 set up the session model; without an inventory, the only thing the router can show you about your session is "these certs got let in," which doesn't reflect the user's mental model at all.
+
+Persistence is deferred (#73 — in-memory only). Explicit admit/deny is deferred (#72 — auto-admit stays). ACL JSON construction must remain byte-identical (#74 — no edits to `build_acl_json`).
+
+## Decision
+
+Replace the flat-string announcement convention with a structured JSON heartbeat per agent, tracked in the router as a `HashMap<cn, NodeInfo>` with a status ladder driven by wall-clock age.
+
+**Wire format (`bot_framework::announce`).** Each agent publishes at:
+
+```
+dverse/nodes/announce/<cn>/agents/<agent_name>
+```
+
+with a JSON payload:
+
+```
+AgentAnnounce {
+    cn:           String,
+    agent_name:   String,
+    version:      String,
+    key_exprs:    Vec<String>,
+    status:       AgentStatusWire,
+    announced_at: Option<String>,
+}
+```
+
+`AgentAnnouncer::start(session, info)` spawns a tokio task that does one immediate announce, then re-announces every `AGENT_HEARTBEAT_INTERVAL` (5 s) until the returned handle drops. `AGENT_HEARTBEAT_INTERVAL` is exported from `bot_framework` so the same constant is the single source of truth on both sides.
+
+The key path stays inside the existing `dverse/nodes/announce/**` ACL rule. `build_acl_json` is unchanged — byte-identical ACL JSON before / after, satisfying the constraint from #74.
+
+**Router state (`AppState`).** New fields:
+
+```
+connected_nodes: HashMap<String, NodeInfo>
+```
+
+with:
+
+```
+NodeInfo  { cn, last_seen, agents: HashMap<agent_name, AgentInfo> }
+AgentInfo { name, version, key_expressions, status, last_seen }
+AgentStatus { Online | Degraded | Offline }
+```
+
+Two helpers on `AppState`:
+
+* `upsert_agent(&AgentAnnounce, now)` — insert / refresh, set status `Online`.
+* `reap_stale(now)` — walk all agents, recompute status from `now - last_seen`, drop entries past the eviction window.
+
+Status ladder (`src/zenoh_router/src/constants.rs`):
+
+```
+AGENT_HEARTBEAT_INTERVAL = 5s
+AGENT_DEGRADED_AFTER     = 10s
+AGENT_OFFLINE_AFTER      = 30s
+AGENT_EVICT_AFTER        = 90s
+```
+
+**Router loop.** `session_loop` deserialises each announce into an `AgentAnnounce`, calls `upsert_agent` (**no restart**), and only triggers a session restart on (a) new auto-admitted CN or (b) peer-set change. Inventory updates must not cause Zenoh session restarts — that would burn the whole connection table every 5 seconds.
+
+Unparseable payloads (the previous plain-string convention) log once per CN via a `HashSet<String> seen_legacy` and are otherwise ignored. Both sides of the wire ship from this workspace, so there is no migration window — the log line is for visibility, not compatibility.
+
+A stale-eviction task spawns once on first `RouterStatus::Running`, ticks every `AGENT_HEARTBEAT_INTERVAL`, and survives across session restarts because eviction is wall-clock driven, not session-scoped.
+
+**GUI.** The "admitted CNs" flat list is replaced by a tree view: an `egui::CollapsingHeader` per CN, expanded by default, containing one row per agent with name, version, "N s ago" `last_seen`, and a colored status dot (green / yellow / gray). Key expressions render as an indented second row in monospace.
+
+## Alternatives
+
+**Keep the flat-string convention; derive the inventory from Zenoh's own session table.** Rejected. Zenoh exposes peer routing-layer information, not application-layer "what is this agent for and how stale is its announcement". There is no Zenoh-native way to learn an agent's version or key-expression set.
+
+**One announce key per agent without re-publication; rely on Zenoh liveliness for staleness.** Rejected. Liveliness reports zenoh-session lifecycle; an agent process can crash silently without taking the Zenoh session with it. A wall-clock heartbeat is the only honest staleness signal.
+
+**Persistent inventory in `state.json`.** Out of scope (#73). When persistence lands it should layer on top of the same in-memory model.
+
+**Heartbeat through a sidechannel (HTTP, gRPC) instead of Zenoh.** Rejected. Adds a second transport and a second auth story for one piece of metadata that naturally belongs on the bus.
+
+**Use `chrono` for `announced_at`.** Rejected for this iteration. `announced_at` is `Option<String>` (RFC 3339) and the router stamps `Instant::now()` itself on receipt — sufficient for the staleness ladder, and avoids pulling `chrono` into both sides of the wire.
+
+## Consequences
+
+**Positive**
+* The router GUI now reflects the user's mental model: per-CN tree of agents with version, key expressions, status, and freshness. This is the visible feature the project has been driving towards.
+* Cross-machine observability: every agent reachable in the session is rendered on every router in that session within one heartbeat.
+* The status ladder has hard, written values (5 / 10 / 30 / 90 s) co-located with the announcement task that drives them — no hidden tuning constants.
+* `build_acl_json` is untouched — the new key path lives inside the existing `dverse/nodes/announce/**` rule, so the ACL split-by-class refactor (#74) remains independent of this work.
+* The reaper survives session restarts, so peers that go offline between two reloads don't linger.
+
+**Negative**
+* In-memory only. A router restart loses the inventory and rebuilds it as heartbeats land — there's a ~5-second window after restart where the GUI is empty even though everything is healthy. Acceptable for the current iteration.
+* Wire format is JSON, parsed via serde. Throughput is fine at the announce frequency (5 s × agents), but if the announcement frequency ever rises to tens of Hz this becomes worth revisiting.
+* Heartbeat interval is one constant for all agent types. If specific agents need a different cadence (chatty / sleepy), the constant becomes a per-agent override later — design space exists but is unused.
+* The legacy-payload log line ("ignored unparseable announce from CN=X") will appear during the first development cycle that mixes old binaries with new — the dedup `HashSet` keeps it manageable.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/documents/adr/ADR-022.md
+++ b/documents/adr/ADR-022.md
@@ -1,0 +1,76 @@
+# ADR-022: Consolidate the router's mTLS identity into a single `tls_identity` helper
+
+**Status:** Accepted
+**Date:** 01-06-2026
+**Author:** Yordan Mitev
+
+## Context
+
+ADR-017 fixed the silent inter-router handshake stall by setting both halves of Zenoh's TLS config (`listen_*` and `connect_*` certificate / private-key keys) to the same files. The fix was a one-liner pair added next to the existing listener-side pair in `build_zenoh_config`:
+
+```rust
+zinsert(&mut cfg, "transport/link/tls/listen_certificate",  ...)?;
+zinsert(&mut cfg, "transport/link/tls/listen_private_key",  ...)?;
+zinsert(&mut cfg, "transport/link/tls/connect_certificate", ...)?;
+zinsert(&mut cfg, "transport/link/tls/connect_private_key", ...)?;
+```
+
+ADR-017's own Negative section flagged the structural smell: a router has exactly one identity, but the config surface exposes it as two pairs that have to stay in sync by convention. The four-`zinsert` shape is easy to read but it is also easy to extend incorrectly — anyone adding a new TLS identity key in the future (e.g. switching to per-direction credentials, or replacing rustls with a vendor library that exposes a different key layout) would touch four lines and might forget one. The original ADR-017 bug — "we have a listener cert but no connect cert" — is a present-tense example of exactly that failure mode.
+
+Issue #101 (opened during review of PR #100) tracks the follow-up.
+
+## Decision
+
+Add a `tls_identity` helper next to `zinsert` in `src/zenoh_router/src/router.rs` and replace the four `zinsert` calls with one helper call:
+
+```rust
+fn tls_identity(
+    cfg: &mut zenoh::Config,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> Result<()> {
+    let cert = json_str(&cert_path.to_string_lossy());
+    let key = json_str(&key_path.to_string_lossy());
+    zinsert(cfg, "transport/link/tls/listen_certificate",  &cert)?;
+    zinsert(cfg, "transport/link/tls/listen_private_key",  &key)?;
+    zinsert(cfg, "transport/link/tls/connect_certificate", &cert)?;
+    zinsert(cfg, "transport/link/tls/connect_private_key", &key)?;
+    Ok(())
+}
+```
+
+`build_zenoh_config` calls it once:
+
+```rust
+tls_identity(&mut cfg, cert_path, key_path)?;
+```
+
+No behavior change — the exact same four config keys are still set with the exact same values. The PEM-encoding details (`json_str` quoting) are unchanged. The change is structural: it is no longer syntactically possible to update one of the four without updating all four.
+
+The root CA cert (`root_ca_certificate`) and the `enable_mtls` flag stay as their own `zinsert` calls because they belong to a different identity (the CA, not the router) and to a different concern (transport policy, not credentials) respectively. Bundling them into `tls_identity` would re-introduce the drift risk in a different shape.
+
+## Alternatives
+
+**Leave ADR-017's fix as-is.** Rejected. The four `zinsert` calls work but they encode the listener-vs-connect symmetry as a convention readers have to spot. ADR-017's own Negative section called this out as a follow-up.
+
+**Take the cert / key paths in via a struct parameter on `build_zenoh_config`.** Rejected for this iteration. Bigger refactor, touches every caller of `build_zenoh_config`, and the only field that would benefit from grouping is the cert+key pair — the rest of the parameters (listen address, CA path, admitted list, peers) are independent concerns. If `build_zenoh_config` ever grows past ~10 parameters, revisit.
+
+**Expose the helper as `pub(crate)` so the agent crates (`ping`, `pong`, `bot_framework::node`) can share it.** Rejected. The agent crates only ever act as TLS clients — they need just the connect-side pair, not both. Their config path (`NodeConfig::mtls`) doesn't currently suffer the listener / connect-half drift problem because there is no listener half to forget.
+
+**Use a builder pattern (`TlsIdentity::new(cert, key).apply(&mut cfg)?`).** Rejected. One-shot helper, no configurability — the construction step would add zero information and one allocation.
+
+## Consequences
+
+**Positive**
+* The router's mTLS identity is set in one place. Adding a new TLS-identity key in the future (rotation timestamp, OCSP staple, etc.) means editing one function, not finding all the call sites.
+* `build_zenoh_config` is shorter (4 lines → 1) and reads at the same level of abstraction throughout — every line is "one config concern", not "one config key".
+* The accompanying comment block from ADR-017's fix moves into the helper, where it is closer to the code it describes and can't drift to a different position than the lines it explains.
+* Resolves the open follow-up that was tracked in issue #101 and flagged in ADR-017's Negative section.
+
+**Negative**
+* One extra layer of indirection when reading `build_zenoh_config` top-to-bottom: the reader has to jump to `tls_identity` to see which four keys are being written. Mitigated by the helper's doc comment which lists them.
+* If the cert and key ever do need to differ between listener and connect direction (a use case we have no current plans for), the helper's signature has to change. Acceptable — that change would be a deliberate decision, not an accidental drift.
+
+---
+
+*Artificial intelligence was used to support the drafting of parts of this document. The generated text was subsequently reviewed, checked, and edited where necessary by the author, Yordan Mitev.*

--- a/src/bot_framework/src/announce.rs
+++ b/src/bot_framework/src/announce.rs
@@ -1,0 +1,120 @@
+//! Agent self-announcement: per-agent heartbeat on
+//! `dverse/nodes/announce/<cn>/agents/<agent_name>` so the router can keep
+//! a live inventory of who's running where.
+//!
+//! Each running agent should call [`AgentAnnouncer::start`] once and hold
+//! onto the returned handle for the lifetime of its session.  The handle's
+//! tokio task publishes one immediate announce then re-publishes every
+//! [`AGENT_HEARTBEAT_INTERVAL`].  Dropping the handle aborts the task.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
+use zenoh::Session;
+
+/// How often each agent re-publishes its announce.  Must equal the router's
+/// `crate::constants::AGENT_HEARTBEAT_INTERVAL` — keep these two literally
+/// equal; both are tracked in the heartbeat-ladder section of the plan.
+pub const AGENT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Wire payload — JSON, published on the announce key.  The router decodes
+/// this with `serde_json::from_slice::<AgentAnnounce>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentAnnounce {
+    /// Publisher's CN (cert common name).  Cross-checked against the
+    /// `<cn>` segment of the key path but only the JSON value is load-bearing.
+    pub cn: String,
+    /// Short, stable identifier for this agent (e.g. `"ping"`).  Used as the
+    /// agent-name key in the router's `connected_nodes` map and as a segment
+    /// of the announce key path.
+    pub agent_name: String,
+    /// Agent's `CARGO_PKG_VERSION`.
+    pub version: String,
+    /// Zenoh key expressions the agent uses — typically the topics it
+    /// publishes to plus those it subscribes from.  Surfaced in the router
+    /// GUI so a user can see "who provides what".
+    pub key_exprs: Vec<String>,
+    /// Self-reported status.  Authoritative status is computed router-side
+    /// from `last_seen`; agents only ever report `Online`.
+    pub status: AgentStatusWire,
+    /// Optional RFC 3339 timestamp.  Informational only — the router stamps
+    /// `Instant::now()` server-side.  Optional so we don't pull `chrono`.
+    #[serde(default)]
+    pub announced_at: Option<String>,
+}
+
+/// Status as serialized on the wire.  Kept separate from the router's
+/// internal `AgentStatus` so the wire schema is owned by `bot_framework`
+/// (the library every agent depends on) and the lifecycle classification
+/// (Online/Degraded/Offline) is owned by the router.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentStatusWire {
+    Online,
+    Degraded,
+    Offline,
+}
+
+/// Caller-supplied agent description.  Borrowed so callers can keep their
+/// own `String` storage; we clone into the spawned task.
+pub struct AgentInfo<'a> {
+    pub cn: &'a str,
+    pub agent_name: &'a str,
+    pub version: &'a str,
+    pub key_exprs: Vec<String>,
+}
+
+/// Handle for an in-progress announcer.  Drop to stop the heartbeat —
+/// the spawned task is aborted via `JoinHandle::abort` in [`Drop`].
+pub struct AgentAnnouncer {
+    handle: JoinHandle<()>,
+}
+
+impl AgentAnnouncer {
+    /// Publishes one immediate announce on `dverse/nodes/announce/<cn>/agents/<agent_name>`,
+    /// then re-publishes every [`AGENT_HEARTBEAT_INTERVAL`] until the
+    /// returned handle drops or `session` closes.
+    pub fn start(session: Session, info: AgentInfo<'_>) -> Self {
+        let key_expr = format!(
+            "dverse/nodes/announce/{}/agents/{}",
+            info.cn, info.agent_name
+        );
+        let payload_template = AgentAnnounce {
+            cn: info.cn.to_string(),
+            agent_name: info.agent_name.to_string(),
+            version: info.version.to_string(),
+            key_exprs: info.key_exprs.clone(),
+            status: AgentStatusWire::Online,
+            announced_at: None,
+        };
+
+        let handle = tokio::spawn(async move {
+            let mut tick = tokio::time::interval(AGENT_HEARTBEAT_INTERVAL);
+            // Default `MissedTickBehavior::Burst` would fire back-to-back if
+            // we got descheduled; we'd rather skip and stay aligned.
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tick.tick().await;
+                let body = match serde_json::to_vec(&payload_template) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        eprintln!("AgentAnnouncer: failed to serialize announce: {e}");
+                        continue;
+                    }
+                };
+                if let Err(e) = session.put(&key_expr, body).await {
+                    eprintln!("AgentAnnouncer: put failed on {key_expr}: {e}");
+                }
+            }
+        });
+
+        Self { handle }
+    }
+}
+
+impl Drop for AgentAnnouncer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}

--- a/src/bot_framework/src/lib.rs
+++ b/src/bot_framework/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod announce;
 pub mod cert;
 pub mod config;
 pub mod node;

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -1,7 +1,12 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use bot_framework::{cert, config::DverseConfig, node::NodeConfig};
+use bot_framework::{
+    announce::{AgentAnnouncer, AgentInfo},
+    cert,
+    config::DverseConfig,
+    node::NodeConfig,
+};
 
 const NODE_NAME: &str = "ping";
 
@@ -34,10 +39,18 @@ async fn main() -> Result<()> {
 
     let cn = cfg.operator_cn();
     println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
-    session
-        .put(format!("dverse/nodes/announce/{NODE_NAME}"), cn)
-        .await
-        .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
+    // Heartbeat announcer — runs in a background tokio task as long as this
+    // handle is alive.  Drop = stop heartbeating; the router will mark the
+    // agent Degraded → Offline → evict it on its own timer.
+    let _announcer = AgentAnnouncer::start(
+        session.clone(),
+        AgentInfo {
+            cn: &cn,
+            agent_name: NODE_NAME,
+            version: env!("CARGO_PKG_VERSION"),
+            key_exprs: vec!["dverse/ping".into(), "dverse/pong".into()],
+        },
+    );
 
     let pong_sub = session
         .declare_subscriber("dverse/pong")

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -1,7 +1,12 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use bot_framework::{cert, config::DverseConfig, node::NodeConfig};
+use bot_framework::{
+    announce::{AgentAnnouncer, AgentInfo},
+    cert,
+    config::DverseConfig,
+    node::NodeConfig,
+};
 
 const NODE_NAME: &str = "pong";
 
@@ -34,10 +39,18 @@ async fn main() -> Result<()> {
 
     let cn = cfg.operator_cn();
     println!("[{NODE_NAME}] Connected. Announcing as CN={cn}…");
-    session
-        .put(format!("dverse/nodes/announce/{NODE_NAME}"), cn)
-        .await
-        .map_err(|e| anyhow::anyhow!("announce: {e}"))?;
+    // Heartbeat announcer — runs in a background tokio task as long as this
+    // handle is alive.  Drop = stop heartbeating; the router will mark the
+    // agent Degraded → Offline → evict it on its own timer.
+    let _announcer = AgentAnnouncer::start(
+        session.clone(),
+        AgentInfo {
+            cn: &cn,
+            agent_name: NODE_NAME,
+            version: env!("CARGO_PKG_VERSION"),
+            key_exprs: vec!["dverse/ping".into(), "dverse/pong".into()],
+        },
+    );
 
     let ping_sub = session
         .declare_subscriber("dverse/ping")

--- a/src/zenoh_router/src/constants.rs
+++ b/src/zenoh_router/src/constants.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub const KEYCLOAK_URL: &str = "https://auth.dverse.yordanmitev.me";
 pub const KEYCLOAK_REALM: &str = "dverse";
 pub const CLIENT_ID: &str = "step-ca";
@@ -9,3 +11,24 @@ pub const ROUTER_PORT: u16 = 7447;
 /// Secret is managed in sops and injected into Keycloak at deploy time.
 pub const REGISTRATION_CLIENT_ID: &str = "dverse-registration";
 pub const REGISTRATION_CLIENT_SECRET: &str = "Xv2kR8nQ5mW4jT7eBpL3hC9gF6dA0sYz";
+
+// ── Agent inventory timing ──────────────────────────────────────────────────
+//
+// One source of truth for the heartbeat ladder.  bot_framework::announce
+// re-exports the same interval so the agent side beats at the rate the
+// router expects.
+
+/// How often each agent re-publishes its announce while it's running.
+pub const AGENT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// `last_seen` past this and the agent is marked `Degraded`.  Two intervals
+/// — one missed beat is plausibly a transient hiccup.
+pub const AGENT_DEGRADED_AFTER: Duration = Duration::from_secs(10);
+
+/// `last_seen` past this and the agent is marked `Offline`.  Six intervals
+/// — fits within a typical TCP retransmit budget.
+pub const AGENT_OFFLINE_AFTER: Duration = Duration::from_secs(30);
+
+/// `last_seen` past this and the agent entry is removed entirely.
+/// Eighteen intervals — definitively gone, free the memory.
+pub const AGENT_EVICT_AFTER: Duration = Duration::from_secs(90);

--- a/src/zenoh_router/src/gui.rs
+++ b/src/zenoh_router/src/gui.rs
@@ -1,11 +1,11 @@
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use eframe::egui;
 use bot_framework::config::{DverseConfig, SessionRole};
 
 use crate::constants::{CA_URL, CLIENT_ID, CLIENT_SECRET, KEYCLOAK_REALM, KEYCLOAK_URL, REGISTRATION_CLIENT_ID, REGISTRATION_CLIENT_SECRET, ROUTER_LISTEN, ROUTER_PORT};
-use crate::state::{AppState, RouterStatus};
+use crate::state::{AgentStatus, AppState, RouterStatus};
 
 // ── Screen state (GUI thread only) ─────────────────────────────────────────────
 
@@ -552,15 +552,58 @@ fn show_main(ctx: &egui::Context, state: &mut Arc<Mutex<AppState>>) {
     egui::CentralPanel::default().show(ctx, |ui| {
         ui.heading("Connected nodes");
         ui.add_space(6.0);
-        if st.admitted.is_empty() {
+        if st.connected_nodes.is_empty() {
             ui.weak("Waiting for nodes to connect…");
         } else {
-            for cn in &st.admitted {
-                ui.horizontal(|ui| {
-                    ui.colored_label(egui::Color32::GREEN, "●");
-                    ui.label(cn);
-                });
-            }
+            let now = Instant::now();
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                // Sort CNs alphabetically for a stable display order between
+                // repaints; egui repaints frequently and HashMap iteration
+                // order would otherwise jitter.
+                let mut cns: Vec<&String> = st.connected_nodes.keys().collect();
+                cns.sort();
+                for cn in cns {
+                    let node = &st.connected_nodes[cn];
+                    egui::CollapsingHeader::new(cn)
+                        .default_open(true)
+                        .show(ui, |ui| {
+                            if node.agents.is_empty() {
+                                ui.weak("(no agents reported)");
+                                return;
+                            }
+                            let mut agent_names: Vec<&String> = node.agents.keys().collect();
+                            agent_names.sort();
+                            for name in agent_names {
+                                let ag = &node.agents[name];
+                                ui.horizontal(|ui| {
+                                    match ag.status {
+                                        AgentStatus::Online => {
+                                            ui.colored_label(egui::Color32::GREEN, "●");
+                                        }
+                                        AgentStatus::Degraded => {
+                                            ui.colored_label(egui::Color32::YELLOW, "●");
+                                        }
+                                        AgentStatus::Offline => {
+                                            ui.colored_label(egui::Color32::GRAY, "●");
+                                        }
+                                    }
+                                    ui.monospace(name);
+                                    ui.weak(format!("v{}", ag.version));
+                                    ui.weak("·");
+                                    ui.weak(format_ago(now.saturating_duration_since(ag.last_seen)));
+                                });
+                                if !ag.key_expressions.is_empty() {
+                                    ui.indent(format!("ke_{cn}_{name}"), |ui| {
+                                        for ke in &ag.key_expressions {
+                                            ui.monospace(format!("• {ke}"));
+                                        }
+                                    });
+                                }
+                                ui.add_space(2.0);
+                            }
+                        });
+                }
+            });
         }
     });
 }
@@ -571,5 +614,17 @@ fn info_row(ui: &mut egui::Ui, label: &str, value: &str) {
     ui.weak(label);
     ui.weak(value);
     ui.end_row();
+}
+
+/// Render a duration as a human-friendly "Ns ago" / "Nm Ms ago" string.
+fn format_ago(d: Duration) -> String {
+    let secs = d.as_secs();
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        format!("{}m {}s ago", secs / 60, secs % 60)
+    } else {
+        format!("{}h {}m ago", secs / 3600, (secs % 3600) / 60)
+    }
 }
 

--- a/src/zenoh_router/src/main.rs
+++ b/src/zenoh_router/src/main.rs
@@ -44,10 +44,31 @@ fn run_normal() {
 }
 
 fn run_demo() {
+    use std::collections::HashMap;
+    use std::time::Instant;
+    use state::{AgentInfo, AgentStatus, NodeInfo};
+
     let mut state = AppState::new(None);
     state.admitted = vec!["alice".into(), "mybot".into()];
     state.router_status = state::RouterStatus::Running;
     state.session_id = "alice".into();
+
+    let now = Instant::now();
+    let mut alice_agents = HashMap::new();
+    alice_agents.insert(
+        "ping".to_string(),
+        AgentInfo {
+            version: "0.1.0".into(),
+            key_expressions: vec!["dverse/ping".into(), "dverse/pong".into()],
+            status: AgentStatus::Online,
+            last_seen: now,
+        },
+    );
+    state.connected_nodes.insert(
+        "alice".into(),
+        NodeInfo { cn: "alice".into(), last_seen: now, agents: alice_agents },
+    );
+
     state.push_log("[demo] Router started on tcp/0.0.0.0:7447");
     state.push_log("[demo] Session admin: alice");
     state.push_log("[demo] Auto-admitted: alice");

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -254,14 +254,7 @@ fn build_zenoh_config(
     zinsert(&mut cfg, "scouting/multicast/enabled", "false")?;
     zinsert(&mut cfg, "transport/link/tls/root_ca_certificate", &json_str(&ca_path.to_string_lossy()))?;
     zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
-    zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(&cert_path.to_string_lossy()))?;
-    zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(&key_path.to_string_lossy()))?;
-    // The router presents the same cert as a client when it dials a peer
-    // router's listener — peer routers run `enable_mtls=true` and require a
-    // valid client cert, so without these two keys the outgoing handshake
-    // stalls and inter-router forwarding never lights up.
-    zinsert(&mut cfg, "transport/link/tls/connect_certificate", &json_str(&cert_path.to_string_lossy()))?;
-    zinsert(&mut cfg, "transport/link/tls/connect_private_key", &json_str(&key_path.to_string_lossy()))?;
+    tls_identity(&mut cfg, cert_path, key_path)?;
     zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
 
     if !peers.is_empty() {
@@ -342,4 +335,28 @@ fn json_str(s: &str) -> String {
 fn zinsert(cfg: &mut zenoh::Config, key: &str, value: &str) -> Result<()> {
     cfg.insert_json5(key, value)
         .map_err(|e| anyhow::anyhow!("zenoh config key '{}': {}", key, e))
+}
+
+/// Write the router's mTLS identity into both halves of Zenoh's TLS config in
+/// one call.  A router has exactly one identity, but the Zenoh config surface
+/// exposes it as two pairs (listener and connect side) that have to stay in
+/// sync by convention — wrapping the four writes in a single helper makes it
+/// structurally impossible to update one half and forget the other.
+fn tls_identity(
+    cfg: &mut zenoh::Config,
+    cert_path: &std::path::Path,
+    key_path: &std::path::Path,
+) -> Result<()> {
+    let cert = json_str(&cert_path.to_string_lossy());
+    let key = json_str(&key_path.to_string_lossy());
+    // Listener side: cert presented to peers dialling us.
+    zinsert(cfg, "transport/link/tls/listen_certificate", &cert)?;
+    zinsert(cfg, "transport/link/tls/listen_private_key", &key)?;
+    // Connect side: cert presented when we dial a peer router (peer routers
+    // run `enable_mtls=true` and require a valid client cert; without these
+    // the outgoing handshake stalls and inter-router forwarding never lights
+    // up — see ADR-017).
+    zinsert(cfg, "transport/link/tls/connect_certificate", &cert)?;
+    zinsert(cfg, "transport/link/tls/connect_private_key", &key)?;
+    Ok(())
 }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -256,6 +256,12 @@ fn build_zenoh_config(
     zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
     zinsert(&mut cfg, "transport/link/tls/listen_certificate", &json_str(&cert_path.to_string_lossy()))?;
     zinsert(&mut cfg, "transport/link/tls/listen_private_key", &json_str(&key_path.to_string_lossy()))?;
+    // The router presents the same cert as a client when it dials a peer
+    // router's listener — peer routers run `enable_mtls=true` and require a
+    // valid client cert, so without these two keys the outgoing handshake
+    // stalls and inter-router forwarding never lights up.
+    zinsert(&mut cfg, "transport/link/tls/connect_certificate", &json_str(&cert_path.to_string_lossy()))?;
+    zinsert(&mut cfg, "transport/link/tls/connect_private_key", &json_str(&key_path.to_string_lossy()))?;
     zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
 
     if !peers.is_empty() {

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -1,12 +1,15 @@
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use bot_framework::announce::AgentAnnounce;
 use bot_framework::cert;
 use bot_framework::config::{DverseConfig, SessionRole};
 use tokio::sync::watch;
 use zenoh::Session;
 
+use crate::constants::AGENT_HEARTBEAT_INTERVAL;
 use crate::discovery::MdnsHandle;
 use crate::state::{AppState, RouterStatus};
 
@@ -21,6 +24,10 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
     let mut _mdns: Option<MdnsHandle> = None;
     // Carries the current set of discovered peer endpoints; starts empty.
     let (_, mut peer_rx): (_, watch::Receiver<Vec<String>>) = watch::channel(vec![]);
+    // Spawned once on first Running; kept across session restarts because
+    // eviction is wall-clock driven and independent of which Zenoh session
+    // is live.
+    let mut reaper_started = false;
 
     loop {
         // ── Phase 1: obtain config ───────────────────────────────────────────
@@ -157,6 +164,33 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
             s.push_log("Router running.");
         }
 
+        // Wall-clock stale-eviction task — spawned once.  Drives the
+        // Online→Degraded→Offline ladder and removes agents whose heartbeats
+        // stop landing.  Independent of the Zenoh session lifecycle, so it
+        // outlives ACL/peer restarts.
+        if !reaper_started {
+            let state_for_reap = Arc::clone(&state);
+            tokio::spawn(async move {
+                let mut tick = tokio::time::interval(AGENT_HEARTBEAT_INTERVAL);
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tick.tick().await;
+                    let now = Instant::now();
+                    let evicted = {
+                        let mut st = state_for_reap.lock().unwrap();
+                        st.reap_stale(now)
+                    };
+                    if !evicted.is_empty() {
+                        let mut st = state_for_reap.lock().unwrap();
+                        for (cn, name) in evicted {
+                            st.push_log(format!("Agent stale-evicted: {cn}/{name}"));
+                        }
+                    }
+                }
+            });
+            reaper_started = true;
+        }
+
         // session_loop returns when the admitted list or peer set changes.
         if let Err(e) = session_loop(&session, Arc::clone(&state), peer_rx.clone()).await {
             state.lock().unwrap().push_log(format!("Session error: {e}"));
@@ -191,8 +225,13 @@ async fn acquire_or_reuse(
     }
 }
 
-/// Subscribe to node announce messages; auto-admit any node with a valid cert.
-/// Returns when the admitted list or peer set changes (triggering a session restart).
+/// Subscribe to node announce messages; auto-admit any node with a valid cert
+/// and feed the JSON payload into the agent inventory.  Returns when the
+/// admitted list or peer set changes (triggering a session restart).
+///
+/// Each announce key looks like `dverse/nodes/announce/<cn>/agents/<name>`
+/// which stays inside the existing `dverse/nodes/announce/**` ACL rule, so
+/// no ACL change is needed.
 async fn session_loop(
     session: &Session,
     state: Arc<Mutex<AppState>>,
@@ -206,26 +245,49 @@ async fn session_loop(
     // Mark current peer set as seen so the first .changed() fires only on a real change.
     peer_rx.borrow_and_update();
 
+    // Log-once-per-CN dedup for unparseable payloads (legacy plain-CN puts).
+    let mut seen_legacy: HashSet<String> = HashSet::new();
+
     loop {
         tokio::select! {
             msg = subscriber.recv_async() => {
                 match msg {
                     Ok(s) => {
-                        let key = s.key_expr().as_str().to_string();
-                        if key.starts_with("dverse/nodes/announce/") {
-                            let payload_cn = String::from_utf8_lossy(&s.payload().to_bytes()).into_owned();
-                            let cn = if payload_cn.trim().is_empty() {
-                                key.strip_prefix("dverse/nodes/announce/").unwrap_or("").to_string()
-                            } else {
-                                payload_cn.trim().to_string()
-                            };
-                            if cn.is_empty() { continue; }
-                            let mut st = state.lock().unwrap();
-                            if !st.admitted.contains(&cn) {
-                                st.admitted.push(cn.clone());
-                                st.push_log(format!("Auto-admitted CN: {cn}"));
-                                return Ok(());
+                        let bytes = s.payload().to_bytes();
+                        let ann: AgentAnnounce = match serde_json::from_slice(&bytes) {
+                            Ok(a) => a,
+                            Err(_) => {
+                                // Old / unparseable payload — log once per CN so a
+                                // stale agent on the network doesn't flood the log.
+                                let key = s.key_expr().as_str().to_string();
+                                let cn_for_log = key
+                                    .strip_prefix("dverse/nodes/announce/")
+                                    .and_then(|tail| tail.split('/').next())
+                                    .unwrap_or("?")
+                                    .to_string();
+                                if seen_legacy.insert(cn_for_log.clone()) {
+                                    state.lock().unwrap().push_log(format!(
+                                        "ignored unparseable announce from CN={cn_for_log}"
+                                    ));
+                                }
+                                continue;
                             }
+                        };
+
+                        let cn = ann.cn.clone();
+                        if cn.is_empty() { continue; }
+                        let now = Instant::now();
+                        let mut st = state.lock().unwrap();
+
+                        // 1. Agent inventory — never triggers restart.
+                        st.upsert_agent(&ann, now);
+
+                        // 2. Auto-admit — triggers restart so the new CN
+                        // lands in the rebuilt ACL.
+                        if !st.admitted.contains(&cn) {
+                            st.admitted.push(cn.clone());
+                            st.push_log(format!("Auto-admitted CN: {cn}"));
+                            return Ok(());
                         }
                     }
                     Err(e) => return Err(anyhow::anyhow!("subscriber recv: {e}")),

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -1,4 +1,10 @@
+use std::collections::HashMap;
+use std::time::Instant;
+
+use bot_framework::announce::{AgentAnnounce, AgentStatusWire};
 use bot_framework::config::{DverseConfig, SessionRole};
+
+use crate::constants::{AGENT_DEGRADED_AFTER, AGENT_EVICT_AFTER, AGENT_OFFLINE_AFTER};
 
 pub struct AppState {
     pub router_status: RouterStatus,
@@ -15,6 +21,10 @@ pub struct AppState {
     /// GUI and DNS-SD threads don't re-derive it.  Empty string until a config
     /// has been accepted.
     pub session_id: String,
+    /// Per-CN inventory of agents running on each admitted node.  Populated
+    /// from `dverse/nodes/announce/<cn>/agents/<name>` heartbeats and pruned
+    /// by the stale-eviction task.
+    pub connected_nodes: HashMap<String, NodeInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -25,6 +35,52 @@ pub enum RouterStatus {
     Running,
     Reloading,
     Error(String),
+}
+
+/// One known node (one CN).  Agents are keyed by name so re-announcements
+/// from the same agent update its row in place instead of forking.
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub cn: String,
+    /// Latest heartbeat across any of this node's agents — refreshed every
+    /// time an `upsert_agent` lands.
+    pub last_seen: Instant,
+    pub agents: HashMap<String, AgentInfo>,
+}
+
+/// One agent (one (cn, agent_name) pair) and what the router knows about
+/// it.  The agent's name lives in the surrounding `NodeInfo::agents`
+/// HashMap key rather than being duplicated here.
+#[derive(Debug, Clone)]
+pub struct AgentInfo {
+    pub version: String,
+    pub key_expressions: Vec<String>,
+    pub status: AgentStatus,
+    pub last_seen: Instant,
+}
+
+/// Router-side status, derived from `last_seen`.  Distinct from the wire
+/// `AgentStatusWire` so the router fully owns lifecycle classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentStatus {
+    /// Heartbeat within `AGENT_DEGRADED_AFTER`.
+    Online,
+    /// Last heartbeat between `AGENT_DEGRADED_AFTER` and `AGENT_OFFLINE_AFTER` ago.
+    Degraded,
+    /// Last heartbeat older than `AGENT_OFFLINE_AFTER` but still within
+    /// `AGENT_EVICT_AFTER` — kept visible in the GUI as a gray row so the
+    /// user sees what just left, before the reaper drops it.
+    Offline,
+}
+
+impl From<AgentStatusWire> for AgentStatus {
+    fn from(w: AgentStatusWire) -> Self {
+        match w {
+            AgentStatusWire::Online => AgentStatus::Online,
+            AgentStatusWire::Degraded => AgentStatus::Degraded,
+            AgentStatusWire::Offline => AgentStatus::Offline,
+        }
+    }
 }
 
 impl AppState {
@@ -40,6 +96,7 @@ impl AppState {
             staged_config: initial_config,
             session_role,
             session_id,
+            connected_nodes: HashMap::new(),
         }
     }
 
@@ -50,5 +107,60 @@ impl AppState {
             self.log.remove(0);
         }
         self.log.push(entry);
+    }
+
+    /// Insert or refresh an agent's row from an incoming announce, stamping
+    /// `last_seen = now` and marking the agent `Online`.  Creates the
+    /// surrounding `NodeInfo` if this is the first time we've seen the CN.
+    pub fn upsert_agent(&mut self, ann: &AgentAnnounce, now: Instant) {
+        let node = self
+            .connected_nodes
+            .entry(ann.cn.clone())
+            .or_insert_with(|| NodeInfo {
+                cn: ann.cn.clone(),
+                last_seen: now,
+                agents: HashMap::new(),
+            });
+        node.last_seen = now;
+        node.agents.insert(
+            ann.agent_name.clone(),
+            AgentInfo {
+                version: ann.version.clone(),
+                key_expressions: ann.key_exprs.clone(),
+                status: AgentStatus::Online,
+                last_seen: now,
+            },
+        );
+    }
+
+    /// Walk every known agent, recompute status from `now - last_seen`, and
+    /// drop entries past `AGENT_EVICT_AFTER`.  Returns the dropped
+    /// `(cn, agent_name)` pairs so the caller can log them.  Empty nodes
+    /// (no remaining agents) are removed too.
+    pub fn reap_stale(&mut self, now: Instant) -> Vec<(String, String)> {
+        let mut evicted: Vec<(String, String)> = Vec::new();
+
+        for node in self.connected_nodes.values_mut() {
+            node.agents.retain(|name, ag| {
+                let age = now.saturating_duration_since(ag.last_seen);
+                if age >= AGENT_EVICT_AFTER {
+                    evicted.push((node.cn.clone(), name.clone()));
+                    false
+                } else {
+                    ag.status = if age >= AGENT_OFFLINE_AFTER {
+                        AgentStatus::Offline
+                    } else if age >= AGENT_DEGRADED_AFTER {
+                        AgentStatus::Degraded
+                    } else {
+                        AgentStatus::Online
+                    };
+                    true
+                }
+            });
+        }
+        // Drop nodes that lost their last agent.
+        self.connected_nodes.retain(|_, node| !node.agents.is_empty());
+
+        evicted
     }
 }


### PR DESCRIPTION
## Summary

Two changes, both in `build_zenoh_config`:

1. **Bug fix** — set `connect_certificate` / `connect_private_key` so the router presents its client cert on outgoing inter-router TLS connections (`b8a721f`). Documented in **`documents/adr/ADR-017.md`**.
2. **Follow-up refactor** — consolidate the now-four cert/key writes into a single `tls_identity(&mut cfg, cert, key)` helper so they can't drift out of sync (`df01daf`). Documented in **`documents/adr/ADR-022.md`**. Closes #101.

Originally split into a separate PR; folded back into #100 so the bug fix and the structural follow-up ship as one reviewable unit.

## The bug

The listener half of the mTLS config was set (`listen_certificate`, `listen_private_key`), but the connect half was not. When the router dialled a peer, it terminated the handshake without offering any client cert. The peer requires a valid client cert (we all run `enable_mtls = true`) and aborted the handshake.

Silent across multiple layers: mDNS discovery succeeded, endpoints landed in `connect/endpoints`, session reloaded with the peer in its ACL, but the outgoing TLS handshake stalled and no message ever crossed the LAN. The bug only surfaces in two-machine testing — locally the router both dials and accepts on the same listener, so the missing connect cert is invisible.

## The fix + refactor

`build_zenoh_config` now calls one helper instead of four `zinsert`s:

```rust
tls_identity(&mut cfg, cert_path, key_path)?;
```

`tls_identity` writes both halves in one go:

```rust
fn tls_identity(cfg: &mut zenoh::Config, cert_path: &Path, key_path: &Path) -> Result<()> {
    let cert = json_str(&cert_path.to_string_lossy());
    let key  = json_str(&key_path.to_string_lossy());
    zinsert(cfg, "transport/link/tls/listen_certificate",  &cert)?;
    zinsert(cfg, "transport/link/tls/listen_private_key",  &key)?;
    zinsert(cfg, "transport/link/tls/connect_certificate", &cert)?;
    zinsert(cfg, "transport/link/tls/connect_private_key", &key)?;
    Ok(())
}
```

A router has exactly one identity — same cert in both directions. Adding the helper is structurally impossible to update one half and forget the other.

The root CA cert (`root_ca_certificate`) and the `enable_mtls` flag stay as their own `zinsert`s — different identity (the CA, not the router) and different concern (transport policy, not credentials).

## Test plan
- [x] `cargo build --workspace` clean
- [x] Two-machine LAN: mDNS discovery → handshake → ACL admit → ping ↔ pong exchange
- [x] No regression on single-machine loopback
