### PR TITLE
feat(fabric): shared Zenoh fabric — all routers mesh, sessions as namespaces

### DIFF
--- a/src/bot_framework/src/node.rs
+++ b/src/bot_framework/src/node.rs
@@ -26,6 +26,11 @@ pub struct NodeConfig {
     /// Path to the node's private key PEM.
     /// Required for mTLS.
     pub tls_key: Option<PathBuf>,
+
+    /// Session namespace (the session id) applied to the Zenoh session, so this
+    /// node's key expressions match its router's namespace on the shared fabric.
+    /// `None` (or empty) means no namespace. Must equal the router's namespace.
+    pub namespace: Option<String>,
 }
 
 impl NodeConfig {
@@ -36,6 +41,7 @@ impl NodeConfig {
             tls_ca: None,
             tls_cert: None,
             tls_key: None,
+            namespace: None,
         }
     }
 
@@ -51,7 +57,16 @@ impl NodeConfig {
             tls_ca: Some(tls_ca.into()),
             tls_cert: Some(tls_cert.into()),
             tls_key: Some(tls_key.into()),
+            namespace: None,
         }
+    }
+
+    /// Set the session namespace (the session id) for this node. Empty values
+    /// are ignored. Must match the router's namespace to communicate.
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        let ns = namespace.into();
+        self.namespace = (!ns.is_empty()).then_some(ns);
+        self
     }
 
     /// Open a Zenoh session using this configuration.
@@ -68,6 +83,10 @@ impl NodeConfig {
         zinsert(&mut config, "mode", "\"client\"")?;
         zinsert(&mut config, "connect/endpoints", &format!("[\"{}\"]", self.router))?;
         zinsert(&mut config, "scouting/multicast/enabled", "false")?;
+
+        if let Some(ns) = self.namespace.as_deref().filter(|s| !s.is_empty()) {
+            zinsert(&mut config, "namespace", &format!("\"{ns}\""))?;
+        }
 
         if let Some(ca_path) = &self.tls_ca {
             zinsert(&mut config, "transport/link/tls/root_ca_certificate", &path_to_json_str(ca_path))?;

--- a/src/ping/src/main.rs
+++ b/src/ping/src/main.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<()> {
         &cert_path,
         &key_path,
     )
+    .with_namespace(cfg.session_id())
     .connect()
     .await?;
 

--- a/src/pong/src/main.rs
+++ b/src/pong/src/main.rs
@@ -36,6 +36,7 @@ async fn main() -> Result<()> {
         &cert_path,
         &key_path,
     )
+    .with_namespace(cfg.session_id())
     .connect()
     .await?;
 

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -25,6 +25,8 @@ use self::common::create_filtered_daemon;
 pub struct MdnsHandle {
     _inner: MdnsSdSession,
     pub peer_rx: watch::Receiver<Vec<String>>,
+    /// Admin CNs of sessions visible on the LAN (for the session chooser).
+    pub sessions_rx: watch::Receiver<Vec<String>>,
 }
 
 impl MdnsHandle {
@@ -51,9 +53,10 @@ impl Drop for MdnsSdSession {
 fn mdns_sd_start(cn: &str, session_id: &str, port: u16) -> Option<MdnsHandle> {
     let daemon = create_filtered_daemon()?;
     let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port)?;
-    let peer_rx = browsing::mdns_sd_start(&daemon, cn, session_id)?;
+    let (peer_rx, sessions_rx) = browsing::mdns_sd_start(&daemon, cn, session_id)?;
     Some(MdnsHandle {
         _inner: MdnsSdSession { daemon, fullname },
         peer_rx,
+        sessions_rx,
     })
 }

--- a/src/zenoh_router/src/discovery.rs
+++ b/src/zenoh_router/src/discovery.rs
@@ -53,7 +53,7 @@ impl Drop for MdnsSdSession {
 fn mdns_sd_start(cn: &str, session_id: &str, port: u16) -> Option<MdnsHandle> {
     let daemon = create_filtered_daemon()?;
     let fullname = announcing::mdns_sd_register(&daemon, cn, session_id, port)?;
-    let (peer_rx, sessions_rx) = browsing::mdns_sd_start(&daemon, cn, session_id)?;
+    let (peer_rx, sessions_rx) = browsing::mdns_sd_start(&daemon, cn)?;
     Some(MdnsHandle {
         _inner: MdnsSdSession { daemon, fullname },
         peer_rx,

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -6,18 +6,19 @@ use tokio::sync::watch;
 use tracing::{info, warn};
 
 use super::common::{
-    is_unroutable, zenoh_tls_endpoint, PeerRegistry, SERVICE_TYPE, TXT_KEY_CN, TXT_KEY_IP,
-    TXT_KEY_SESSION,
+    is_unroutable, zenoh_tls_endpoint, PeerRegistry, SessionRegistry, SERVICE_TYPE, TXT_KEY_CN,
+    TXT_KEY_IP, TXT_KEY_SESSION,
 };
 
-/// Start browsing for peers on the given mdns-sd daemon and return a watch
-/// receiver of the current endpoint list.  Spawns a background thread that
-/// drains the daemon's event channel.
+/// Start browsing for peers on the given mdns-sd daemon. Returns two watch
+/// receivers: the current peer endpoint list (for Zenoh `connect/endpoints`)
+/// and the list of session-host admin CNs visible on the LAN (for the chooser).
+/// Spawns a background thread that drains the daemon's event channel.
 pub(super) fn mdns_sd_start(
     daemon: &ServiceDaemon,
     my_cn: &str,
     my_session: &str,
-) -> Option<watch::Receiver<Vec<String>>> {
+) -> Option<(watch::Receiver<Vec<String>>, watch::Receiver<Vec<String>>)> {
     let browse_rx = match daemon.browse(SERVICE_TYPE) {
         Ok(rx) => rx,
         Err(e) => {
@@ -28,18 +29,20 @@ pub(super) fn mdns_sd_start(
     info!("mdns-sd browse started");
 
     let (registry, peer_rx) = PeerRegistry::new();
+    let (sessions, sessions_rx) = SessionRegistry::new();
     let my_cn = my_cn.to_string();
     let my_session = my_session.to_string();
 
     std::thread::spawn(move || {
         let mut registry = registry;
+        let mut sessions = sessions;
         while let Ok(event) = browse_rx.recv() {
-            handle_event(event, &my_cn, &my_session, &mut registry);
+            handle_event(event, &my_cn, &my_session, &mut registry, &mut sessions);
         }
         info!("mdns-sd browse loop exited");
     });
 
-    Some(peer_rx)
+    Some((peer_rx, sessions_rx))
 }
 
 fn handle_event(
@@ -47,13 +50,14 @@ fn handle_event(
     my_cn: &str,
     my_session: &str,
     registry: &mut PeerRegistry,
+    sessions: &mut SessionRegistry,
 ) {
     match event {
         ServiceEvent::ServiceFound(svc_type, fullname) => {
             info!(svc_type = %svc_type, fullname = %fullname, "mdns-sd service found");
         }
         ServiceEvent::ServiceResolved(info) => {
-            handle_resolved(info, my_cn, my_session, registry)
+            handle_resolved(info, my_cn, my_session, registry, sessions)
         }
         ServiceEvent::ServiceRemoved(_, fullname) => {
             info!(fullname = %fullname, "mdns-sd service removed");
@@ -75,6 +79,7 @@ fn handle_resolved(
     my_cn: &str,
     my_session: &str,
     registry: &mut PeerRegistry,
+    sessions: &mut SessionRegistry,
 ) {
     let remote_cn = info.get_property_val_str(TXT_KEY_CN).unwrap_or_default();
     let remote_session = info.get_property_val_str(TXT_KEY_SESSION).unwrap_or_default();
@@ -87,6 +92,14 @@ fn handle_resolved(
         port = info.get_port(),
         "mdns-sd resolved peer"
     );
+
+    // All-sessions registry (for the chooser): record every session *host* —
+    // a router whose own CN equals its session= TXT (i.e. the session admin).
+    // Done before the mesh filters so other sessions are still discoverable.
+    if !remote_cn.is_empty() && remote_cn == remote_session && sessions.add(remote_cn.to_string())
+    {
+        info!(admin_cn = %remote_cn, "discovered session on the LAN");
+    }
 
     if remote_cn.is_empty() || remote_cn == my_cn {
         info!(cn = %remote_cn, "mdns-sd skipping self or empty CN");

--- a/src/zenoh_router/src/discovery/browsing.rs
+++ b/src/zenoh_router/src/discovery/browsing.rs
@@ -17,7 +17,6 @@ use super::common::{
 pub(super) fn mdns_sd_start(
     daemon: &ServiceDaemon,
     my_cn: &str,
-    my_session: &str,
 ) -> Option<(watch::Receiver<Vec<String>>, watch::Receiver<Vec<String>>)> {
     let browse_rx = match daemon.browse(SERVICE_TYPE) {
         Ok(rx) => rx,
@@ -31,13 +30,12 @@ pub(super) fn mdns_sd_start(
     let (registry, peer_rx) = PeerRegistry::new();
     let (sessions, sessions_rx) = SessionRegistry::new();
     let my_cn = my_cn.to_string();
-    let my_session = my_session.to_string();
 
     std::thread::spawn(move || {
         let mut registry = registry;
         let mut sessions = sessions;
         while let Ok(event) = browse_rx.recv() {
-            handle_event(event, &my_cn, &my_session, &mut registry, &mut sessions);
+            handle_event(event, &my_cn, &mut registry, &mut sessions);
         }
         info!("mdns-sd browse loop exited");
     });
@@ -48,7 +46,6 @@ pub(super) fn mdns_sd_start(
 fn handle_event(
     event: ServiceEvent,
     my_cn: &str,
-    my_session: &str,
     registry: &mut PeerRegistry,
     sessions: &mut SessionRegistry,
 ) {
@@ -57,7 +54,7 @@ fn handle_event(
             info!(svc_type = %svc_type, fullname = %fullname, "mdns-sd service found");
         }
         ServiceEvent::ServiceResolved(info) => {
-            handle_resolved(info, my_cn, my_session, registry, sessions)
+            handle_resolved(info, my_cn, registry, sessions)
         }
         ServiceEvent::ServiceRemoved(_, fullname) => {
             info!(fullname = %fullname, "mdns-sd service removed");
@@ -77,7 +74,6 @@ fn handle_event(
 fn handle_resolved(
     info: ServiceInfo,
     my_cn: &str,
-    my_session: &str,
     registry: &mut PeerRegistry,
     sessions: &mut SessionRegistry,
 ) {
@@ -106,29 +102,11 @@ fn handle_resolved(
         return;
     }
 
-    // Session filter: skip peers that belong to a different session.  Without
-    // this, two unrelated users on the same LAN would auto-mesh their routers.
-    //
-    // Separate log line for "no session= TXT" because `unwrap_or_default()`
-    // collapses a missing TXT key and a literal empty string to the same ""
-    // value, and the failure mode (older binary, manual `dns-sd` test) is
-    // diagnostically different from "different session running on the LAN".
-    if remote_session.is_empty() {
-        info!(
-            cn = %remote_cn,
-            "mdns-sd skipping peer with no session= TXT key (likely older or non-DVerse announcement)"
-        );
-        return;
-    }
-    if remote_session != my_session {
-        info!(
-            cn = %remote_cn,
-            session = %remote_session,
-            ours = %my_session,
-            "mdns-sd skipping peer in different session"
-        );
-        return;
-    }
+    // Shared fabric: connect to *every* discovered router regardless of session.
+    // Cross-session traffic can't leak because each router + its agents run under
+    // a per-session Zenoh `namespace`, so a router only ever pub/subs its own
+    // session's keys; other sessions' traffic is merely relayed, never seen.
+    // (The earlier same-session peer filter is intentionally removed here.)
 
     let endpoints = endpoints_for(&info, remote_cn);
     if endpoints.is_empty() {

--- a/src/zenoh_router/src/discovery/common.rs
+++ b/src/zenoh_router/src/discovery/common.rs
@@ -208,3 +208,33 @@ impl PeerRegistry {
         self.peers.values().flatten().cloned().collect()
     }
 }
+
+/// Tracks the distinct sessions visible on the LAN — one entry per session
+/// *host* (a router whose own CN equals its `session=` TXT, i.e. the admin).
+/// Pushes the sorted admin-CN list on a watch channel for the session chooser.
+///
+/// Independent of Zenoh namespacing: this is built from raw mDNS `_dverse._tcp`
+/// records, which are visible regardless of which session the local node is in.
+pub(super) struct SessionRegistry {
+    admins: HashSet<String>,
+    tx: watch::Sender<Vec<String>>,
+}
+
+impl SessionRegistry {
+    pub(super) fn new() -> (Self, watch::Receiver<Vec<String>>) {
+        let (tx, rx) = watch::channel(vec![]);
+        (Self { admins: HashSet::new(), tx }, rx)
+    }
+
+    /// Record a session host (admin CN). Returns `true` if newly added.
+    pub(super) fn add(&mut self, admin_cn: String) -> bool {
+        if self.admins.insert(admin_cn) {
+            let mut v: Vec<String> = self.admins.iter().cloned().collect();
+            v.sort();
+            let _ = self.tx.send(v);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -158,7 +158,7 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
         if !peers.is_empty() {
             info!(?peers, "connecting to peer routers");
         }
-        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted, &peers) {
+        let config = match build_zenoh_config(&cfg.router_listen, &ca_p, &cert_p, &key_p, &admitted, &peers, &cfg.session_id()) {
             Ok(c) => c,
             Err(e) => {
                 state.lock().unwrap().router_status = RouterStatus::Error(e.to_string());
@@ -327,16 +327,24 @@ fn build_zenoh_config(
     key_path: &std::path::Path,
     admitted: &[String],
     peers: &[String],
+    namespace: &str,
 ) -> Result<zenoh::Config> {
     let mut cfg = zenoh::Config::default();
 
     zinsert(&mut cfg, "mode", "\"router\"")?;
     zinsert(&mut cfg, "listen/endpoints", &format!("[\"{listen_addr}\"]"))?;
     zinsert(&mut cfg, "scouting/multicast/enabled", "false")?;
+    // Session isolation on the shared fabric: every key this session pub/subs is
+    // transparently prefixed with the namespace, so routers + agents of one
+    // session never see another session's traffic even though all routers mesh.
+    // Agents must use the same namespace (see NodeConfig::with_namespace).
+    if !namespace.is_empty() {
+        zinsert(&mut cfg, "namespace", &json_str(namespace))?;
+    }
     zinsert(&mut cfg, "transport/link/tls/root_ca_certificate", &json_str(&ca_path.to_string_lossy()))?;
     zinsert(&mut cfg, "transport/link/tls/enable_mtls", "true")?;
     tls_identity(&mut cfg, cert_path, key_path)?;
-    zinsert(&mut cfg, "access_control", &build_acl_json(admitted))?;
+    zinsert(&mut cfg, "access_control", &build_acl_json(admitted, namespace))?;
 
     if !peers.is_empty() {
         let endpoints_json = serde_json::to_string(peers).unwrap();
@@ -349,9 +357,17 @@ fn build_zenoh_config(
     Ok(cfg)
 }
 
-fn build_acl_json(admitted: &[String]) -> String {
-    let announce_key = "dverse/nodes/announce/**";
-    let main_key = "dverse/**";
+fn build_acl_json(admitted: &[String], namespace: &str) -> String {
+    // Zenoh applies the session namespace at the face boundary and the ACL
+    // interceptor sees the *namespaced* key, so the rule key_exprs must carry
+    // the same prefix the namespace adds.
+    let prefix = if namespace.is_empty() {
+        String::new()
+    } else {
+        format!("{namespace}/")
+    };
+    let announce_key = format!("{prefix}dverse/nodes/announce/**");
+    let main_key = format!("{prefix}dverse/**");
     let announce_msgs = serde_json::json!(["put", "delete", "declare_subscriber"]);
     let main_msgs = serde_json::json!(["put", "delete", "declare_subscriber", "query", "reply", "declare_queryable"]);
 
@@ -440,4 +456,44 @@ fn tls_identity(
     zinsert(cfg, "transport/link/tls/connect_certificate", &cert)?;
     zinsert(cfg, "transport/link/tls/connect_private_key", &key)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    /// A mode=router session must open cleanly with a `namespace` set and do a
+    /// namespaced self pub/sub round-trip — i.e. namespacing the router doesn't
+    /// break its startup or local routing (the shared-fabric isolation, #108).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn router_opens_and_routes_with_namespace() {
+        use std::time::Duration;
+
+        let mut cfg = zenoh::Config::default();
+        cfg.insert_json5("mode", "\"router\"").unwrap();
+        // Ephemeral port so the test never collides with a running router.
+        cfg.insert_json5("listen/endpoints", "[\"tcp/127.0.0.1:0\"]").unwrap();
+        cfg.insert_json5("scouting/multicast/enabled", "false").unwrap();
+        cfg.insert_json5("namespace", "\"test-session\"").unwrap();
+
+        let session = zenoh::open(cfg).await.expect("router opens with namespace");
+
+        // Code uses un-namespaced keys; the namespace is applied transparently,
+        // so a self pub/sub on "dverse/agents/ping" must still match.
+        let sub = session
+            .declare_subscriber("dverse/agents/ping")
+            .await
+            .expect("declare subscriber");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        session
+            .put("dverse/agents/ping", "hello")
+            .await
+            .expect("put");
+
+        let sample = tokio::time::timeout(Duration::from_secs(2), sub.recv_async())
+            .await
+            .expect("recv did not time out")
+            .expect("got a sample");
+        assert_eq!(sample.payload().try_to_string().unwrap().as_ref(), "hello");
+
+        session.close().await.unwrap();
+    }
 }

--- a/src/zenoh_router/src/router.rs
+++ b/src/zenoh_router/src/router.rs
@@ -64,6 +64,21 @@ pub async fn run(state: Arc<Mutex<AppState>>) {
                     crate::constants::ROUTER_PORT,
                 ) {
                     peer_rx = handle.peer_rx.clone();
+                    // Mirror the visible-sessions list into AppState continuously
+                    // (independent of session restarts) so the chooser stays fresh.
+                    let vis_state = Arc::clone(&state);
+                    let mut vis_rx = handle.sessions_rx.clone();
+                    tokio::spawn(async move {
+                        loop {
+                            {
+                                let v = vis_rx.borrow_and_update().clone();
+                                vis_state.lock().unwrap().visible_sessions = v;
+                            }
+                            if vis_rx.changed().await.is_err() {
+                                break;
+                            }
+                        }
+                    });
                     _mdns = Some(handle);
                 }
             }

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -25,6 +25,9 @@ pub struct AppState {
     /// from `dverse/nodes/announce/<cn>/agents/<name>` heartbeats and pruned
     /// by the stale-eviction task.
     pub connected_nodes: HashMap<String, NodeInfo>,
+    /// Admin CNs of sessions visible on the LAN, mirrored from DNS-SD browsing.
+    /// Drives the session chooser; independent of which session we're in.
+    pub visible_sessions: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -102,6 +105,7 @@ impl AppState {
             session_role,
             session_id,
             connected_nodes: HashMap::new(),
+            visible_sessions: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

Turns the per-session isolated router meshes into **one shared fabric**: every router connects, and sessions stay separated by a Zenoh **namespace**. Plus an **all-sessions registry** so the (future) chooser can list every session on the LAN.

Stacked on `feature/tauri-clients` (after #106). Closes #108.

## What changed

**Shared fabric + namespace isolation**
- `discovery/browsing.rs`: dropped the same-session peer filter — the router now connects to *every* discovered router. Cross-session traffic can't leak because each router + its agents run under a per-session Zenoh `namespace` (other sessions' traffic is merely relayed, never subscribed/seen). Removed the now-unused `my_session` plumbing.
- `router.rs`: `build_zenoh_config` sets `namespace = session_id`; `build_acl_json` prefixes its key_exprs with `<namespace>/` (the ACL interceptor sees the namespaced key, verified against the zenoh source).
- `bot_framework::node::NodeConfig`: new `with_namespace(session_id)`; `ping`/`pong` pass `cfg.session_id()` so their keys match their router's namespace on the wire.

**All-sessions registry** (additive, prior commit)
- `SessionRegistry` (common.rs) tracks session *hosts* (routers where `cn == session=`) → `MdnsHandle.sessions_rx` → mirrored into `AppState.visible_sessions` by a small task (independent of session restarts). Built from raw mDNS, so it sees all sessions regardless of namespace.

## Verification

- [x] `cargo build` clean: `zenoh-router` (lib headless + egui bin), `bot-framework`, `dverse-ping`, `dverse-pong`.
- [x] **Unit test** `router_opens_and_routes_with_namespace`: a `mode=router` session opens with a `namespace` set and a self pub/sub on `dverse/agents/ping` round-trips — proving namespacing doesn't break router startup or local routing (code keeps un-namespaced keys; the prefix is applied transparently).
- [x] Two-machine gate (manual): two routers in different namespaces coexist on one mesh without cross-talk; a same-namespace pair still exchanges ping↔pong.

## Known follow-ups

- **Python chat-app bots** must also adopt the session namespace to talk to a namespaced router (they're launched via `start_bot`; not part of the ping/pong gate). Tracked as a follow-up.
- The all-sessions registry is surfaced on `AppState.visible_sessions` but not yet rendered — the chooser that consumes it is #110.
- Endpoint churn: connecting to all routers means more `connect/endpoints` changes → more session reopens (no runtime peer-add in Zenoh). Fine at LAN scale.

## Test plan
- [x] lib/bin/agents build; namespaced-router unit test passes
- [x] two-machine isolation + same-session ping↔pong (manual)
