### PR TITLE
feat(crypto): session_crypto via vodozemac (Olm/Megolm) + identity binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +218,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -373,6 +386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +428,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "vodozemac",
  "x509-parser",
  "zenoh",
 ]
@@ -597,6 +620,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +689,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +734,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -962,6 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1009,6 +1067,34 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "darling"
@@ -1356,6 +1442,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "eframe"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1719,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -2333,6 +2451,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,6 +2802,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -3134,6 +3262,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrix-pickle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c34e6db65145740459f2ca56623b40cd4e6000ffae2a7d91515fa82aa935dbf"
+dependencies = [
+ "matrix-pickle-derive",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "matrix-pickle-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a962fc9981f823f6555416dcb2ae9ae67ca412d767ee21ecab5150113ee6285b"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3909,6 +4060,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,6 +4479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "pong"
 version = "0.1.0"
 dependencies = [
@@ -4429,6 +4597,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4442,6 +4631,29 @@ name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pxfm"
@@ -5210,6 +5422,16 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6845,6 +7067,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6979,6 +7211,36 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vodozemac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98bf83c0992966775b8012f194b07b44928996163e5a05b741b43891571ae5b"
+dependencies = [
+ "aes",
+ "arrayvec",
+ "base64 0.22.1",
+ "base64ct",
+ "cbc",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hkdf",
+ "hmac",
+ "matrix-pickle",
+ "prost",
+ "rand 0.8.6",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "vswhom"
@@ -8369,6 +8631,18 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "x509-parser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +426,7 @@ dependencies = [
  "clap",
  "dirs 5.0.1",
  "keyring",
+ "p256",
  "rcgen 0.13.2",
  "reqwest 0.12.28",
  "serde",
@@ -1013,6 +1020,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,6 +1451,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ecolor"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1615,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "emath"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1771,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2019,6 +2082,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2313,6 +2377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4128,6 +4203,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4541,6 +4628,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5023,6 +5119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5326,6 +5432,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -42,3 +42,4 @@ keyring = { version = "3", features = ["sync-secret-service", "apple-native", "w
 x509-parser = "0.18"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+vodozemac = "0.10.0"

--- a/src/bot_framework/Cargo.toml
+++ b/src/bot_framework/Cargo.toml
@@ -43,3 +43,4 @@ x509-parser = "0.18"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 vodozemac = "0.10.0"
+p256 = { version = "0.13.2", features = ["ecdsa", "pkcs8"] }

--- a/src/bot_framework/src/lib.rs
+++ b/src/bot_framework/src/lib.rs
@@ -3,3 +3,4 @@ pub mod cert;
 pub mod config;
 pub mod logging;
 pub mod node;
+pub mod session_crypto;

--- a/src/bot_framework/src/session_crypto.rs
+++ b/src/bot_framework/src/session_crypto.rs
@@ -322,4 +322,127 @@ mod tests {
         // against bob's real (public) cert it must be rejected.
         assert!(verify_enc_binding(&bob_cert, "bob", &forged).is_err());
     }
+
+    // ── Adversarial / property tests ──────────────────────────────────────
+
+    /// A single-bit flip in the serialized Megolm ciphertext (in the Ed25519
+    /// signature suffix) must cause decryption to fail — i.e. the message is
+    /// integrity-protected end to end.
+    #[test]
+    fn megolm_tampered_ciphertext_rejected() {
+        let mut sender = GroupSender::new();
+        let mut receiver = GroupReceiver::new(&sender.session_key());
+        let msg = sender.encrypt(b"top secret");
+        let mut bytes = msg.to_bytes();
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0x01;
+        // Re-parse and try to decrypt; either re-parse fails or decrypt fails.
+        match MegolmMessage::from_bytes(&bytes) {
+            Ok(tampered) => assert!(
+                receiver.decrypt(&tampered).is_err(),
+                "tampered megolm message must not decrypt"
+            ),
+            Err(_) => (),
+        }
+    }
+
+    /// The serialized ciphertext bytes must not contain the plaintext as a
+    /// substring — a basic "we are actually encrypting" sanity check.
+    #[test]
+    fn megolm_ciphertext_does_not_contain_plaintext() {
+        let mut sender = GroupSender::new();
+        let plaintext: &[u8] = b"DVERSE-PLAINTEXT-MARKER-unique-xyz-123";
+        let bytes = sender.encrypt(plaintext).to_bytes();
+        assert!(
+            !bytes.windows(plaintext.len()).any(|w| w == plaintext),
+            "plaintext leaked into ciphertext bytes"
+        );
+    }
+
+    /// Two Megolm encrypts of the same plaintext must yield different bytes
+    /// (the ratchet advances each message; per-message keys differ).
+    #[test]
+    fn megolm_consecutive_encrypts_are_non_deterministic() {
+        let mut sender = GroupSender::new();
+        let m1 = sender.encrypt(b"same plaintext").to_bytes();
+        let m2 = sender.encrypt(b"same plaintext").to_bytes();
+        assert_ne!(m1, m2, "consecutive megolm encrypts of the same plaintext must differ");
+    }
+
+    /// A `GroupReceiver` for session A must not decrypt a message from a
+    /// separate session B — cross-session isolation.
+    #[test]
+    fn cross_session_receiver_cannot_decrypt() {
+        let session_a = GroupSender::new();
+        let mut session_b = GroupSender::new();
+        let mut recv_a = GroupReceiver::new(&session_a.session_key());
+        let msg_b = session_b.encrypt(b"session B message");
+        assert!(recv_a.decrypt(&msg_b).is_err());
+    }
+
+    /// Olm one-time keys are consumed on first use: replaying the same OTK in
+    /// a second outbound→inbound exchange must fail.
+    #[test]
+    fn one_time_key_is_consumed_once() {
+        let alice = SessionIdentity::new();
+        let mut bob = SessionIdentity::new();
+        let otk = bob.generate_one_time_keys(1)[0];
+
+        let (_, msg1) = alice
+            .olm_encrypt_to(bob.curve25519_key(), otk, b"first")
+            .unwrap();
+        let (_, pt1) = bob.olm_decrypt_from(alice.curve25519_key(), &msg1).unwrap();
+        assert_eq!(pt1, b"first");
+
+        // Same OTK — bob has now consumed it. A second prekey message
+        // referencing it must be rejected on the inbound side.
+        let (_, msg2) = alice
+            .olm_encrypt_to(bob.curve25519_key(), otk, b"replay")
+            .unwrap();
+        assert!(bob.olm_decrypt_from(alice.curve25519_key(), &msg2).is_err());
+    }
+
+    /// Single-bit flips in either the binding signature or the bound key must
+    /// make `verify_enc_binding` reject (no malleability).
+    #[test]
+    fn enc_binding_rejects_bit_flips() {
+        let (cert, key_der) = mint_tls_identity("alice");
+        let id = SessionIdentity::new();
+        let honest = sign_enc_binding(&key_der, "alice", &id.curve25519_key()).unwrap();
+        assert!(verify_enc_binding(&cert, "alice", &honest).is_ok());
+
+        // Flip a bit in the signature.
+        let mut tampered_sig = honest.clone();
+        tampered_sig.signature[0] ^= 0x01;
+        assert!(verify_enc_binding(&cert, "alice", &tampered_sig).is_err());
+
+        // Flip a bit in the bound Curve25519 key.
+        let mut tampered_key = honest.clone();
+        tampered_key.curve25519_key[0] ^= 0x01;
+        assert!(verify_enc_binding(&cert, "alice", &tampered_key).is_err());
+    }
+
+    /// Even if a forger somehow bypassed the binding check, encrypt-to-pubkey
+    /// is self-defeating: a key wrapped to bob's Curve25519 key cannot be
+    /// unwrapped with mallory's account (she lacks bob's secret).
+    #[test]
+    fn forger_with_wrong_secret_cannot_unwrap() {
+        let alice = SessionIdentity::new();
+        let mut bob = SessionIdentity::new();
+        let bob_otk = bob.generate_one_time_keys(1)[0];
+
+        // alice wraps to bob's identity (legitimate target).
+        let key = b"secret-session-key-32-bytes!!!aa";
+        let (_, msg) = alice
+            .olm_encrypt_to(bob.curve25519_key(), bob_otk, key)
+            .unwrap();
+
+        // mallory tries to decrypt with her own account — she doesn't hold the
+        // OTK secret the prekey message references, so the inbound handshake
+        // can't derive the shared 3DH secret. Result: error, no plaintext.
+        let mut mallory = SessionIdentity::new();
+        assert!(mallory
+            .olm_decrypt_from(alice.curve25519_key(), &msg)
+            .is_err());
+    }
 }

--- a/src/bot_framework/src/session_crypto.rs
+++ b/src/bot_framework/src/session_crypto.rs
@@ -1,44 +1,117 @@
 //! Per-session group encryption via [vodozemac](https://github.com/matrix-org/vodozemac)
 //! (matrix.org's audited Olm/Megolm). Tracking issue: #109.
 //!
-//! Target model (see the plan + the #107 feasibility spike):
-//!   * Each node owns a vodozemac [`Account`] — its Curve25519 identity key is
-//!     the per-node *encryption* identity, distinct from the step-CA P-256 TLS
-//!     cert key.
-//!   * That Curve25519 key is **bound to the node's identity** by an ECDSA-P256
+//! Model (dverse session ≈ a Matrix room without a homeserver, over Zenoh):
+//!   * Each node owns a vodozemac [`Account`]. Its **Curve25519** identity key is
+//!     the per-node *encryption* identity — distinct from the step-CA P-256 TLS
+//!     cert key. It is **bound to the node's identity** by an ECDSA-P256
 //!     signature made with the TLS key over `(cn ‖ curve25519_key)`, verified
-//!     against the cert CN (Zenoh doesn't expose the publisher mTLS CN to the
-//!     app, so the binding must be explicit — ported from the #107 spike).
-//!   * A session is a **Megolm** group session; admission shares the Megolm key
-//!     over an **Olm** 1:1 channel; kick/ban rotates the Megolm session.
+//!     against the cert CN ([`sign_enc_binding`] / [`verify_enc_binding`]).
+//!     This binding is required because Zenoh doesn't expose the publisher mTLS
+//!     CN to the application layer (ported from the #107 spike; only the bound
+//!     key type changed from a P-256 enc key to the Curve25519 identity).
+//!   * A session is a **Megolm** group session ([`GroupSender`] /
+//!     [`GroupReceiver`]) — a ratcheting sender key with per-message forward
+//!     secrecy. Agents encrypt payloads with it.
+//!   * The Megolm session key is delivered to an admitted member over a 1:1
+//!     **Olm** session ([`SessionIdentity::olm_encrypt_to`] /
+//!     [`SessionIdentity::olm_decrypt_from`]).
+//!   * Kick/ban → mint a new [`GroupSender`] and re-deliver to the remaining
+//!     members; the removed node can't decrypt post-rotation traffic.
 //!
-//! WIP: this scaffold currently creates the account and exposes its identity
-//! keys. The binding (needs P-256 in this crate), Olm key delivery, Megolm
-//! payload encryption, and rotation land next under #109.
+//! Olm/Megolm here use `SessionConfig::version_1()` (libolm-compatible, no
+//! crate features required).
 
-use vodozemac::olm::Account;
+use anyhow::{anyhow, bail, Result};
+use p256::ecdsa::signature::{Signer, Verifier};
+use p256::ecdsa::{Signature, SigningKey, VerifyingKey};
+use p256::pkcs8::DecodePrivateKey;
+use vodozemac::megolm::{
+    GroupSession, InboundGroupSession, MegolmMessage, SessionConfig as MegolmConfig, SessionKey,
+};
+use vodozemac::olm::{Account, OlmMessage, Session, SessionConfig};
+use vodozemac::Curve25519PublicKey;
+use x509_parser::prelude::*;
 
-/// A node's vodozemac identity. The Curve25519 key is the encryption identity
-/// bound to the step-CA cert; the Ed25519 key is vodozemac's signing key.
+// ── Node identity (vodozemac Account) ─────────────────────────────────────────
+
+/// A node's vodozemac identity plus its one-time-key supply. The Curve25519
+/// identity key is the encryption identity bound to the step-CA cert.
 pub struct SessionIdentity {
     account: Account,
 }
 
 impl SessionIdentity {
-    /// Create a fresh vodozemac account (new identity + one-time keys on demand).
+    /// Create a fresh vodozemac account.
     pub fn new() -> Self {
         Self { account: Account::new() }
     }
 
-    /// Base64 Curve25519 identity key — the value bound to the cert and used
-    /// for Olm key agreement when delivering Megolm session keys.
-    pub fn curve25519_key(&self) -> String {
+    /// The Curve25519 identity (encryption) key — bound to the cert, and the
+    /// target of Olm sessions that deliver Megolm keys to this node.
+    pub fn curve25519_key(&self) -> Curve25519PublicKey {
+        self.account.curve25519_key()
+    }
+
+    /// Base64 Curve25519 identity key, for the wire / join-request.
+    pub fn curve25519_key_base64(&self) -> String {
         self.account.curve25519_key().to_base64()
     }
 
     /// Base64 Ed25519 fingerprint key.
-    pub fn ed25519_key(&self) -> String {
+    pub fn ed25519_key_base64(&self) -> String {
         self.account.ed25519_key().to_base64()
+    }
+
+    /// Generate `count` one-time keys (consumed by peers establishing an Olm
+    /// session to deliver this node a Megolm key). Returns the new public OTKs
+    /// to publish; call [`Self::mark_keys_as_published`] once published.
+    pub fn generate_one_time_keys(&mut self, count: usize) -> Vec<Curve25519PublicKey> {
+        self.account.generate_one_time_keys(count).created
+    }
+
+    pub fn mark_keys_as_published(&mut self) {
+        self.account.mark_keys_as_published();
+    }
+
+    /// Establish an outbound Olm session to a peer (by their identity key and
+    /// one of their one-time keys) and encrypt `plaintext` (e.g. a Megolm
+    /// [`SessionKey`]) for them. Returns the session and the pre-key message.
+    pub fn olm_encrypt_to(
+        &self,
+        peer_identity: Curve25519PublicKey,
+        peer_one_time_key: Curve25519PublicKey,
+        plaintext: &[u8],
+    ) -> Result<(Session, OlmMessage)> {
+        let mut session = self
+            .account
+            .create_outbound_session(SessionConfig::version_1(), peer_identity, peer_one_time_key)
+            .map_err(|e| anyhow!("olm outbound session: {e}"))?;
+        let msg = session
+            .encrypt(plaintext)
+            .map_err(|e| anyhow!("olm encrypt: {e}"))?;
+        Ok((session, msg))
+    }
+
+    /// Accept an inbound Olm pre-key message from a peer and decrypt it,
+    /// establishing the inbound session. Consumes a one-time key.
+    pub fn olm_decrypt_from(
+        &mut self,
+        peer_identity: Curve25519PublicKey,
+        message: &OlmMessage,
+    ) -> Result<(Session, Vec<u8>)> {
+        match message {
+            OlmMessage::PreKey(pre) => {
+                let res = self
+                    .account
+                    .create_inbound_session(SessionConfig::version_1(), peer_identity, pre)
+                    .map_err(|e| anyhow!("olm inbound session: {e}"))?;
+                Ok((res.session, res.plaintext))
+            }
+            OlmMessage::Normal(_) => {
+                bail!("expected an Olm pre-key message to establish the session")
+            }
+        }
     }
 }
 
@@ -48,17 +121,205 @@ impl Default for SessionIdentity {
     }
 }
 
+// ── Megolm group session (payload encryption) ─────────────────────────────────
+
+/// Outbound Megolm session: encrypts this node's session payloads. Its
+/// [`session_key`](Self::session_key) is shared (over Olm) with every member.
+pub struct GroupSender {
+    inner: GroupSession,
+}
+
+impl GroupSender {
+    pub fn new() -> Self {
+        Self { inner: GroupSession::new(MegolmConfig::version_1()) }
+    }
+
+    /// The key to deliver to members so they can decrypt this sender's messages.
+    pub fn session_key(&self) -> SessionKey {
+        self.inner.session_key()
+    }
+
+    pub fn session_id(&self) -> String {
+        self.inner.session_id()
+    }
+
+    pub fn encrypt(&mut self, plaintext: &[u8]) -> MegolmMessage {
+        self.inner.encrypt(plaintext)
+    }
+}
+
+impl Default for GroupSender {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Inbound Megolm session: decrypts one sender's messages, built from the
+/// [`SessionKey`] delivered over Olm.
+pub struct GroupReceiver {
+    inner: InboundGroupSession,
+}
+
+impl GroupReceiver {
+    pub fn new(key: &SessionKey) -> Self {
+        Self { inner: InboundGroupSession::new(key, MegolmConfig::version_1()) }
+    }
+
+    pub fn decrypt(&mut self, message: &MegolmMessage) -> Result<Vec<u8>> {
+        self.inner
+            .decrypt(message)
+            .map(|d| d.plaintext)
+            .map_err(|e| anyhow!("megolm decrypt: {e}"))
+    }
+}
+
+// ── Identity binding (Curve25519 enc key ⇄ step-CA P-256 cert) ─────────────────
+
+/// A node's claim that its Curve25519 encryption key belongs to its cert CN,
+/// signed with the node's TLS (P-256) key. Travels in the join-request.
+#[derive(Debug, Clone)]
+pub struct EncKeyBinding {
+    pub cn: String,
+    pub curve25519_key: [u8; 32],
+    /// ECDSA-P256 signature over `binding_message(cn, curve25519_key)`.
+    pub signature: Vec<u8>,
+}
+
+/// Domain-separated, length-prefixed message so `cn` and the key can't be
+/// ambiguously concatenated.
+fn binding_message(cn: &str, curve25519_key: &[u8]) -> Vec<u8> {
+    let mut m = Vec::new();
+    m.extend_from_slice(b"dverse/enc-key-binding/v1\0");
+    m.extend_from_slice(&(cn.len() as u32).to_be_bytes());
+    m.extend_from_slice(cn.as_bytes());
+    m.extend_from_slice(curve25519_key);
+    m
+}
+
+/// Sign the binding of `curve25519_key` to `cn` with the node's TLS P-256
+/// private key (PKCS#8 DER, as produced by rcgen / loaded from `<node>.key`).
+pub fn sign_enc_binding(
+    tls_key_pkcs8_der: &[u8],
+    cn: &str,
+    curve25519_key: &Curve25519PublicKey,
+) -> Result<EncKeyBinding> {
+    let sk = SigningKey::from_pkcs8_der(tls_key_pkcs8_der)
+        .map_err(|e| anyhow!("parse TLS key: {e}"))?;
+    let key_bytes = curve25519_key.to_bytes();
+    let sig: Signature = sk.sign(&binding_message(cn, &key_bytes));
+    Ok(EncKeyBinding { cn: cn.to_string(), curve25519_key: key_bytes, signature: sig.to_bytes().to_vec() })
+}
+
+/// Verify a binding against the requester's TLS cert (PEM). On success returns
+/// the now-trusted Curve25519 encryption key. Rejects on claimed-CN mismatch,
+/// cert-CN mismatch, or invalid signature.
+pub fn verify_enc_binding(
+    tls_cert_pem: &str,
+    expected_cn: &str,
+    b: &EncKeyBinding,
+) -> Result<Curve25519PublicKey> {
+    if b.cn != expected_cn {
+        bail!("claimed CN {:?} != expected {:?}", b.cn, expected_cn);
+    }
+    let (_, pem) = parse_x509_pem(tls_cert_pem.as_bytes()).map_err(|e| anyhow!("pem parse: {e}"))?;
+    let cert = pem.parse_x509().map_err(|e| anyhow!("x509 parse: {e}"))?;
+    let cert_cn = cert
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .ok_or_else(|| anyhow!("cert has no CN"))?;
+    if cert_cn != b.cn {
+        bail!("cert CN {:?} != claimed CN {:?}", cert_cn, b.cn);
+    }
+    let spki = cert.public_key().subject_public_key.data.as_ref();
+    let vk = VerifyingKey::from_sec1_bytes(spki).map_err(|e| anyhow!("cert SPKI: {e}"))?;
+    let sig = Signature::from_slice(&b.signature).map_err(|e| anyhow!("sig parse: {e}"))?;
+    vk.verify(&binding_message(&b.cn, &b.curve25519_key), &sig)
+        .map_err(|_| anyhow!("binding signature invalid"))?;
+    Curve25519PublicKey::from_slice(&b.curve25519_key).map_err(|e| anyhow!("curve25519 key: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Mint a P-256 self-signed cert (stand-in for a step-CA leaf): returns
+    /// (cert_pem, pkcs8_key_der).
+    fn mint_tls_identity(cn: &str) -> (String, Vec<u8>) {
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        let mut dn = rcgen::DistinguishedName::new();
+        dn.push(rcgen::DnType::CommonName, cn);
+        params.distinguished_name = dn;
+        let kp = rcgen::KeyPair::generate().unwrap();
+        let cert = params.self_signed(&kp).unwrap();
+        (cert.pem(), kp.serialize_der())
+    }
+
     #[test]
-    fn account_exposes_identity_keys() {
-        let id = SessionIdentity::new();
-        // Distinct, non-empty base64 keys (Curve25519 ≠ Ed25519).
-        let c = id.curve25519_key();
-        let e = id.ed25519_key();
-        assert!(!c.is_empty() && !e.is_empty());
-        assert_ne!(c, e);
+    fn megolm_round_trip_and_rotation() {
+        let mut sender_v1 = GroupSender::new();
+        let mut receiver = GroupReceiver::new(&sender_v1.session_key());
+        let msg = sender_v1.encrypt(b"hello session");
+        assert_eq!(receiver.decrypt(&msg).unwrap(), b"hello session");
+
+        // Rotation: a new sender; the old receiver cannot decrypt the new
+        // sender's messages (different Megolm session) — i.e. a kicked member
+        // holding only the old inbound session is locked out. The new key is
+        // shared at session start (before the first encrypt), as in real use.
+        let mut sender_v2 = GroupSender::new();
+        let mut receiver_v2 = GroupReceiver::new(&sender_v2.session_key());
+        let v2_msg = sender_v2.encrypt(b"post-rotation");
+        assert_ne!(sender_v1.session_id(), sender_v2.session_id());
+        assert!(receiver.decrypt(&v2_msg).is_err());
+        assert_eq!(receiver_v2.decrypt(&v2_msg).unwrap(), b"post-rotation");
+    }
+
+    #[test]
+    fn olm_delivers_megolm_key_end_to_end() {
+        // Admin (alice) has a Megolm sender; bob is admitted.
+        let alice = SessionIdentity::new();
+        let mut bob = SessionIdentity::new();
+        let bob_otks = bob.generate_one_time_keys(1);
+
+        let mut alice_sender = GroupSender::new();
+        let session_key_bytes = alice_sender.session_key().to_bytes();
+
+        // alice Olm-encrypts the Megolm session key to bob.
+        let (_alice_session, olm_msg) = alice
+            .olm_encrypt_to(bob.curve25519_key(), bob_otks[0], &session_key_bytes)
+            .unwrap();
+
+        // bob decrypts it, rebuilds the inbound Megolm session, and reads a
+        // payload alice encrypts under the group session.
+        let (_bob_session, recovered) = bob.olm_decrypt_from(alice.curve25519_key(), &olm_msg).unwrap();
+        let key = SessionKey::from_bytes(&recovered).unwrap();
+        let mut bob_receiver = GroupReceiver::new(&key);
+
+        let payload = alice_sender.encrypt(b"hello over the shared fabric");
+        assert_eq!(bob_receiver.decrypt(&payload).unwrap(), b"hello over the shared fabric");
+    }
+
+    #[test]
+    fn enc_key_binding_verifies_and_rejects_forgery() {
+        let (bob_cert, bob_key_der) = mint_tls_identity("bob");
+        let bob_enc = SessionIdentity::new();
+
+        // Honest binding: bob signs his Curve25519 key with his TLS key.
+        let binding = sign_enc_binding(&bob_key_der, "bob", &bob_enc.curve25519_key()).unwrap();
+        let trusted = verify_enc_binding(&bob_cert, "bob", &binding).unwrap();
+        assert_eq!(trusted.to_bytes(), bob_enc.curve25519_key().to_bytes());
+
+        // Wrong expected CN is rejected.
+        assert!(verify_enc_binding(&bob_cert, "alice", &binding).is_err());
+
+        // Forgery: mallory substitutes her own enc key under bob's cert/CN,
+        // signed with HER TLS key. Must fail (sig not valid under bob's cert).
+        let (_mallory_cert, mallory_key_der) = mint_tls_identity("mallory");
+        let mallory_enc = SessionIdentity::new();
+        let forged = sign_enc_binding(&mallory_key_der, "bob", &mallory_enc.curve25519_key()).unwrap();
+        // forged.cn == "bob" but it was signed with mallory's key; verified
+        // against bob's real (public) cert it must be rejected.
+        assert!(verify_enc_binding(&bob_cert, "bob", &forged).is_err());
     }
 }

--- a/src/bot_framework/src/session_crypto.rs
+++ b/src/bot_framework/src/session_crypto.rs
@@ -1,0 +1,64 @@
+//! Per-session group encryption via [vodozemac](https://github.com/matrix-org/vodozemac)
+//! (matrix.org's audited Olm/Megolm). Tracking issue: #109.
+//!
+//! Target model (see the plan + the #107 feasibility spike):
+//!   * Each node owns a vodozemac [`Account`] — its Curve25519 identity key is
+//!     the per-node *encryption* identity, distinct from the step-CA P-256 TLS
+//!     cert key.
+//!   * That Curve25519 key is **bound to the node's identity** by an ECDSA-P256
+//!     signature made with the TLS key over `(cn ‖ curve25519_key)`, verified
+//!     against the cert CN (Zenoh doesn't expose the publisher mTLS CN to the
+//!     app, so the binding must be explicit — ported from the #107 spike).
+//!   * A session is a **Megolm** group session; admission shares the Megolm key
+//!     over an **Olm** 1:1 channel; kick/ban rotates the Megolm session.
+//!
+//! WIP: this scaffold currently creates the account and exposes its identity
+//! keys. The binding (needs P-256 in this crate), Olm key delivery, Megolm
+//! payload encryption, and rotation land next under #109.
+
+use vodozemac::olm::Account;
+
+/// A node's vodozemac identity. The Curve25519 key is the encryption identity
+/// bound to the step-CA cert; the Ed25519 key is vodozemac's signing key.
+pub struct SessionIdentity {
+    account: Account,
+}
+
+impl SessionIdentity {
+    /// Create a fresh vodozemac account (new identity + one-time keys on demand).
+    pub fn new() -> Self {
+        Self { account: Account::new() }
+    }
+
+    /// Base64 Curve25519 identity key — the value bound to the cert and used
+    /// for Olm key agreement when delivering Megolm session keys.
+    pub fn curve25519_key(&self) -> String {
+        self.account.curve25519_key().to_base64()
+    }
+
+    /// Base64 Ed25519 fingerprint key.
+    pub fn ed25519_key(&self) -> String {
+        self.account.ed25519_key().to_base64()
+    }
+}
+
+impl Default for SessionIdentity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_exposes_identity_keys() {
+        let id = SessionIdentity::new();
+        // Distinct, non-empty base64 keys (Curve25519 ≠ Ed25519).
+        let c = id.curve25519_key();
+        let e = id.ed25519_key();
+        assert!(!c.is_empty() && !e.is_empty());
+        assert_ne!(c, e);
+    }
+}


### PR DESCRIPTION
## Summary

Builds `bot_framework::session_crypto` on **[vodozemac](https://github.com/matrix-org/vodozemac)** (matrix.org's audited Olm/Megolm), the production replacement for the #107 hand-rolled ECIES spike. This is the crypto toolkit; wiring it into agent payloads + the admission key-delivery / kick rotation lands with #110 / #111.

Stacked on #114 (#108 shared fabric). Closes #109.

## What's in it

- **`SessionIdentity`** (vodozemac `Account`): the node's **Curve25519** encryption identity, one-time-key generation, and Olm `encrypt_to` / `decrypt_from` helpers — used to deliver a Megolm session key to a member 1:1.
- **`GroupSender` / `GroupReceiver`** (Megolm): per-session group payload encryption with the Megolm ratchet (**per-message forward secrecy** — which the hand-rolled scheme lacked). Rotation = a fresh `GroupSender`; a receiver holding only the old session key is locked out.
- **Identity binding** (ported from the #107 spike; `p256` added to bot_framework): `sign_enc_binding` signs `(cn ‖ curve25519_key)` with the node's TLS **P-256** key; `verify_enc_binding` checks it against the step-CA cert (CN + signature) before trusting the encryption key — required because Zenoh doesn't expose the publisher mTLS CN to the app layer. Only the bound key type changed from the spike (Curve25519 instead of a P-256 enc key).

## Design notes

- **Olm for key delivery + Megolm for payloads** — the canonical Matrix pattern. Chosen over vodozemac's one-shot `PkEncryption` because the latter has a documented MAC quirk; Olm is the correct/audited channel.
- `SessionConfig::version_1()` for both Olm and Megolm (libolm-compatible; no crate features needed).
- vodozemac (MPL-2.0) + p256 added to **bot_framework only**; verified they resolve with no conflicts against the existing ring/rustls/zenoh crypto stack.

## Tests (`cargo test -p bot-framework`)

- [x] `megolm_round_trip_and_rotation` — encrypt/decrypt round-trip; after rotation a stale receiver cannot decrypt the new sender's messages.
- [x] `olm_delivers_megolm_key_end_to_end` — alice Olm-encrypts the Megolm session key to bob (via his one-time key); bob decrypts it, rebuilds the inbound session, and reads a Megolm payload.
- [x] `enc_key_binding_verifies_and_rejects_forgery` — honest binding verifies; wrong-CN and a forged binding (victim cert + attacker key/sig) are rejected.

## Not in this PR (follow-ups)

- Wiring agents (`ping`/`pong`) to Megolm-encrypt their payloads, and the router holding/distributing the session key — needs the admission flow (#110).
- Kick/ban → rotate the Megolm session and re-deliver to remaining members (#111).

## Test plan
- [x] `cargo test -p bot-framework` (3 session_crypto tests pass)
- [x] vodozemac + p256 resolve/build with the existing crypto stack
