### PR TITLE
nix: self-contained step-ca + keycloak flake (refs #136)

### DIFF
--- a/nix/.gitignore
+++ b/nix/.gitignore
@@ -1,0 +1,6 @@
+# Build outputs from `nix build`.
+result
+result-*
+
+# Local development VM images.
+*.qcow2

--- a/nix/.sops.yaml
+++ b/nix/.sops.yaml
@@ -1,26 +1,25 @@
 # nix/.sops.yaml — sops creation rules for the dverse-ca flake.
 #
-# Two recipients are expected:
-#   1. An admin age key (your laptop / deploy workstation), generated with
+# Two recipients are configured:
+#   1. The admin age key (Yordan's workstation), generated with
 #      `age-keygen -o ~/.config/sops/age/keys.txt`.
-#   2. The target server's ssh ed25519 host key, converted to an age public
-#      key with `ssh-to-age`. sops-nix re-derives the same identity at
-#      activation time on the host (see modules/system sops wiring in
-#      hosts/dverse-ca/configuration.nix).
+#   2. The dverse-ca server's ssh ed25519 host key, converted to an age
+#      public key with `ssh-to-age`. sops-nix re-derives the same identity
+#      at activation time on the host (see hosts/dverse-ca/configuration.nix
+#      `sops.age.sshKeyPaths`).
 #
-# Replace the two placeholder age1... values with your own before running
-# `sops` against any file under nix/secrets/. After editing, re-encrypt
-# existing files with:
+# Adding a new operator: append their age public key under `keys:`, add an
+# alias under the dverse-ca rule below, then re-encrypt the existing file:
 #
 #     sops updatekeys nix/secrets/dverse-ca.yaml
 
 keys:
-  - &admin_workstation  age1REPLACEMEadminworkstationpublickeyREPLACEMEXXXXXXXXXXXXXX
-  - &server_dverse_ca   age1REPLACEMEserverdversecapublickeyREPLACEMEXXXXXXXXXXXXXXX
+  - &admin_daki4_laptop  age1lmqu6xhpcjye6zcptjqv5msxhvlvnncczxx4wuzy3xk9ttq8je2su3y3qd
+  - &server_dverse_ca    age16nh8dd6stnun6ludd03de7m66ddkk3p96muu9jks9g7am7wh7e3sqr34v4
 
 creation_rules:
   - path_regex: secrets/dverse-ca\.yaml$
     key_groups:
       - age:
-          - *admin_workstation
+          - *admin_daki4_laptop
           - *server_dverse_ca

--- a/nix/.sops.yaml
+++ b/nix/.sops.yaml
@@ -1,0 +1,26 @@
+# nix/.sops.yaml — sops creation rules for the dverse-ca flake.
+#
+# Two recipients are expected:
+#   1. An admin age key (your laptop / deploy workstation), generated with
+#      `age-keygen -o ~/.config/sops/age/keys.txt`.
+#   2. The target server's ssh ed25519 host key, converted to an age public
+#      key with `ssh-to-age`. sops-nix re-derives the same identity at
+#      activation time on the host (see modules/system sops wiring in
+#      hosts/dverse-ca/configuration.nix).
+#
+# Replace the two placeholder age1... values with your own before running
+# `sops` against any file under nix/secrets/. After editing, re-encrypt
+# existing files with:
+#
+#     sops updatekeys nix/secrets/dverse-ca.yaml
+
+keys:
+  - &admin_workstation  age1REPLACEMEadminworkstationpublickeyREPLACEMEXXXXXXXXXXXXXX
+  - &server_dverse_ca   age1REPLACEMEserverdversecapublickeyREPLACEMEXXXXXXXXXXXXXXX
+
+creation_rules:
+  - path_regex: secrets/dverse-ca\.yaml$
+    key_groups:
+      - age:
+          - *admin_workstation
+          - *server_dverse_ca

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,129 @@
+# nix/ — DVerse CA + Keycloak NixOS flake
+
+Self-contained Nix flake that builds the **dverse-ca** host: a step-ca
+certificate authority and a Keycloak identity provider pre-loaded with the
+`dverse` realm, both fronted by nginx + ACME for the production deployment.
+
+This directory was extracted from a personal multi-host nix-config so that
+the dverse project can build and deploy its own CA/IdP without depending on
+the upstream personal repo.
+
+## Layout
+
+    nix/
+    ├── flake.nix                          # inputs + nixosModules + nixosConfigurations
+    ├── .sops.yaml                         # sops recipient template (edit before use)
+    ├── README.md
+    ├── modules/services/
+    │   ├── step-ca.nix                    # custom services.step-ca module
+    │   └── keycloak.nix                   # custom services.keycloak-server wrapper
+    ├── hosts/dverse-ca/
+    │   ├── configuration.nix              # top-level host config (composes everything)
+    │   ├── step-ca.nix                    # step-ca host wiring + sops secret
+    │   ├── keycloak.nix                   # keycloak host wiring + realm import
+    │   ├── vm-test.nix                    # sops-free QEMU test variant
+    │   └── hardware-configuration.nix     # **stub** — replace per-target
+    └── secrets/
+        └── dverse-ca.example.yaml         # plaintext schema template
+
+## Inputs
+
+| Input    | Channel / ref          |
+| -------- | ---------------------- |
+| nixpkgs  | `nixos-25.11`          |
+| sops-nix | `Mic92/sops-nix` (HEAD)|
+
+Run `nix flake update` (or `nix flake lock --update-input <name>`) under
+`nix/` to refresh.
+
+## Building the test VM
+
+The VM variant has no sops dependency and uses a baked-in plaintext password
+for step-ca. It is for local smoke-testing only.
+
+    cd nix
+    nix build .#nixosConfigurations.dverse-ca-vm.config.system.build.vm
+    ./result/bin/run-dverse-ca-vm
+
+Inside the VM (root/root login):
+
+    step ca health --ca-url https://localhost:9000 \
+      --root /var/lib/step-ca/certs/root_ca.crt
+
+## Deploying the real host
+
+1. **Replace the hardware module.** The shipped
+   `hosts/dverse-ca/hardware-configuration.nix` is a non-functional stub.
+   Generate the real one on the target machine:
+
+       nixos-generate-config --show-hardware-config \
+         > nix/hosts/dverse-ca/hardware-configuration.nix
+
+2. **Add operator ssh keys.** Either set the option directly on the host
+   config or layer a module:
+
+       dverseCa.operatorSshKeys = [
+         "ssh-ed25519 AAAA... you@example.com"
+       ];
+
+   Without this, the only way in after deploy is the serial console.
+
+3. **Bootstrap secrets** (see next section).
+
+4. **Build / deploy** as usual:
+
+       nixos-rebuild switch --flake .#dverse-ca --target-host root@<host>
+
+## Secrets bootstrap
+
+`sops-nix` decrypts secrets at activation time using the target host's
+`/etc/ssh/ssh_host_ed25519_key`, transparently converted to an age identity.
+No separate keyfile is provisioned on the server.
+
+Steps:
+
+1. Generate an admin age key on your workstation if you don't have one:
+
+       age-keygen -o ~/.config/sops/age/keys.txt
+
+2. Derive the server's age public key from its ssh host key (run on the
+   target after a base install):
+
+       nix run nixpkgs#ssh-to-age -- -i /etc/ssh/ssh_host_ed25519_key.pub
+
+3. Edit `nix/.sops.yaml`: replace `age1REPLACEME...` lines with the two
+   real recipients (workstation pubkey + server pubkey).
+
+4. Copy the schema template and fill in real values:
+
+       cp nix/secrets/dverse-ca.example.yaml nix/secrets/dverse-ca.yaml
+       $EDITOR nix/secrets/dverse-ca.yaml
+       sops --encrypt --in-place nix/secrets/dverse-ca.yaml
+
+5. Commit `nix/secrets/dverse-ca.yaml` (encrypted). Do **not** commit the
+   plaintext copy.
+
+If you later rotate recipients, update `.sops.yaml` and run:
+
+    sops updatekeys nix/secrets/dverse-ca.yaml
+
+## What's intentionally not here
+
+This flake was scrubbed of bits that only made sense in the source personal
+repo:
+
+- Personal user accounts and ssh keys (operator keys are now an explicit
+  `dverseCa.operatorSshKeys` option, defaulting to empty).
+- Personal editor / shell config (tmux, bash, neovim modules).
+- Other hosts and unused inputs (`home-manager`, `nixvim`,
+  `nixpkgs-unstable`).
+- The real `dverse-ca.yaml` ciphertext — that file was encrypted to the
+  original author's keys and would be unusable here. Re-create it locally
+  with your own recipients per the bootstrap steps above.
+
+## Provenance
+
+Original source: `/stuff/programming/nix-config/` (personal repo, not
+published). Modules are byte-for-byte copies; host wiring has been adapted
+to drop personal-repo-specific imports and to make the operator-supplied
+bits explicit options instead of inline values.

--- a/nix/README.md
+++ b/nix/README.md
@@ -12,7 +12,7 @@ the upstream personal repo.
 
     nix/
     ├── flake.nix                          # inputs + nixosModules + nixosConfigurations
-    ├── .sops.yaml                         # sops recipient template (edit before use)
+    ├── .sops.yaml                         # sops recipient config (admin + dverse-ca server)
     ├── README.md
     ├── modules/services/
     │   ├── step-ca.nix                    # custom services.step-ca module
@@ -24,7 +24,8 @@ the upstream personal repo.
     │   ├── vm-test.nix                    # sops-free QEMU test variant
     │   └── hardware-configuration.nix     # **stub** — replace per-target
     └── secrets/
-        └── dverse-ca.example.yaml         # plaintext schema template
+        ├── dverse-ca.yaml                 # sops-encrypted (admin + dverse-ca server)
+        └── dverse-ca.example.yaml         # plaintext schema (reference only)
 
 ## Inputs
 
@@ -156,44 +157,59 @@ Minimal local-testing run:
 
    Without this, the only way in after deploy is the serial console.
 
-3. **Bootstrap secrets** (see next section).
-
-4. **Build / deploy** as usual:
+3. **Build / deploy** as usual:
 
        nixos-rebuild switch --flake .#dverse-ca --target-host root@<host>
 
-## Secrets bootstrap
+   The secrets travel with the flake (see next section) — no extra
+   provisioning step is required on the target as long as its ssh host
+   key matches the `server_dverse_ca` recipient in `.sops.yaml`.
 
-`sops-nix` decrypts secrets at activation time using the target host's
-`/etc/ssh/ssh_host_ed25519_key`, transparently converted to an age identity.
-No separate keyfile is provisioned on the server.
+## Secrets
 
-Steps:
+`nix/secrets/dverse-ca.yaml` is sops-encrypted to the two recipients
+listed in `nix/.sops.yaml`:
 
-1. Generate an admin age key on your workstation if you don't have one:
+| Alias                 | What it is                                                |
+| --------------------- | --------------------------------------------------------- |
+| `admin_daki4_laptop`  | The admin's workstation age key (decrypt locally to edit) |
+| `server_dverse_ca`    | The dverse-ca server's ssh host key, via `ssh-to-age`     |
+
+`sops-nix` decrypts at activation time on the server using
+`/etc/ssh/ssh_host_ed25519_key`, transparently converted to an age
+identity — no separate keyfile is provisioned. To deploy to the existing
+dverse-ca host you don't need to touch these files at all.
+
+`nix/secrets/dverse-ca.example.yaml` keeps the plaintext schema for
+reference and is **not** consumed by any module.
+
+### Adding another operator
+
+1. Have them generate an age key:
 
        age-keygen -o ~/.config/sops/age/keys.txt
 
-2. Derive the server's age public key from its ssh host key (run on the
-   target after a base install):
+2. Append their age public key to `nix/.sops.yaml` under `keys:` and
+   reference it in the `dverse-ca.yaml` rule's `key_groups.age` list.
 
-       nix run nixpkgs#ssh-to-age -- -i /etc/ssh/ssh_host_ed25519_key.pub
+3. Re-encrypt with the new recipient set:
 
-3. Edit `nix/.sops.yaml`: replace `age1REPLACEME...` lines with the two
-   real recipients (workstation pubkey + server pubkey).
+       sops updatekeys nix/secrets/dverse-ca.yaml
 
-4. Copy the schema template and fill in real values:
+### Deploying to a different host
 
-       cp nix/secrets/dverse-ca.example.yaml nix/secrets/dverse-ca.yaml
-       $EDITOR nix/secrets/dverse-ca.yaml
-       sops --encrypt --in-place nix/secrets/dverse-ca.yaml
+The server recipient is derived from `dverse-ca`'s ssh host key. To
+target a different machine, derive its age pubkey on the box itself:
 
-5. Commit `nix/secrets/dverse-ca.yaml` (encrypted). Do **not** commit the
-   plaintext copy.
+    nix run nixpkgs#ssh-to-age -- -i /etc/ssh/ssh_host_ed25519_key.pub
 
-If you later rotate recipients, update `.sops.yaml` and run:
+Add it as a new recipient in `.sops.yaml` (or replace `server_dverse_ca`)
+and `sops updatekeys` as above.
 
-    sops updatekeys nix/secrets/dverse-ca.yaml
+### Rotating values
+
+Run `sops nix/secrets/dverse-ca.yaml` to open the decrypted file in your
+editor; sops re-encrypts on save.
 
 ## What's intentionally not here
 
@@ -205,9 +221,6 @@ repo:
 - Personal editor / shell config (tmux, bash, neovim modules).
 - Other hosts and unused inputs (`home-manager`, `nixvim`,
   `nixpkgs-unstable`).
-- The real `dverse-ca.yaml` ciphertext — that file was encrypted to the
-  original author's keys and would be unusable here. Re-create it locally
-  with your own recipients per the bootstrap steps above.
 
 ## Provenance
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -50,6 +50,94 @@ Inside the VM (root/root login):
     step ca health --ca-url https://localhost:9000 \
       --root /var/lib/step-ca/certs/root_ca.crt
 
+## Building OCI container images
+
+The flake also exposes two container images for operators who want to
+deploy step-ca or Keycloak outside of a full NixOS host (e.g. into an
+existing Kubernetes / Nomad / docker-compose setup). The images are
+reproducible Nix builds — they are tagged `nix` and **not** stamped with
+a git SHA. Re-tag on push if you want versioning.
+
+| Output                     | What it builds            | Approx size (gzipped) |
+| -------------------------- | ------------------------- | --------------------- |
+| `.#oci-step-ca` (default)  | `dverse/step-ca:nix`      | ~54 MiB               |
+| `.#oci-keycloak`           | `dverse/keycloak:nix`     | ~609 MiB              |
+
+Build:
+
+    cd nix
+    nix build .#oci-step-ca       # ./result is a gzipped docker-archive tar
+    nix build .#oci-keycloak
+
+Load into a local engine:
+
+    docker load < result
+    # or
+    podman load < result
+
+Push to a registry (no engine required) with skopeo:
+
+    skopeo copy docker-archive:./result \
+      docker://registry.example.com/dverse/step-ca:nix
+
+### step-ca image
+
+Mirrors the NixOS module's invocation
+(`step-ca --password-file <pw> <ca.json>`). Both images run as uid/gid
+`1000:1000` — chown your host mounts accordingly.
+
+Expected mounts:
+
+| Container path                  | Purpose                                    |
+| ------------------------------- | ------------------------------------------ |
+| `/etc/step-ca/ca.json`          | The `ca.json` produced by `step ca init`   |
+| `/run/secrets/step-ca-password` | File containing the intermediate-key password |
+| `/var/lib/step-ca`              | State volume (certs, db, secrets/)         |
+
+Exposed port: `9000/tcp` (HTTPS).
+
+Minimal run example:
+
+    docker run -d --name step-ca \
+      -p 9000:9000 \
+      -v /srv/step-ca/ca.json:/etc/step-ca/ca.json:ro \
+      -v /srv/step-ca/password:/run/secrets/step-ca-password:ro \
+      -v step-ca-data:/var/lib/step-ca \
+      dverse/step-ca:nix
+
+To override the entrypoint for ops (e.g. to run `step ca health`), pass
+`--entrypoint /bin/step`.
+
+### keycloak image
+
+Entrypoint is `kc.sh` with default `Cmd = ["start"]` (production mode).
+Override to `start-dev` for local testing. **Config is supplied via
+container env vars** — nothing is baked in.
+
+Minimum env vars for a production-mode start:
+
+| Variable                   | Example                                   |
+| -------------------------- | ----------------------------------------- |
+| `KC_DB`                    | `postgres`                                |
+| `KC_DB_URL`                | `jdbc:postgresql://db:5432/keycloak`      |
+| `KC_DB_USERNAME`           | `keycloak`                                |
+| `KC_DB_PASSWORD`           | `<secret>`                                |
+| `KC_HOSTNAME`              | `auth.example.com`                        |
+| `KEYCLOAK_ADMIN`           | `admin` (only honoured on first boot)     |
+| `KEYCLOAK_ADMIN_PASSWORD`  | `<secret>` (only honoured on first boot)  |
+
+Exposed ports: `8080/tcp`, `8443/tcp`.
+
+Postgres is **not** bundled — bring your own.
+
+Minimal local-testing run:
+
+    docker run -d --name keycloak \
+      -p 8080:8080 \
+      -e KEYCLOAK_ADMIN=admin \
+      -e KEYCLOAK_ADMIN_PASSWORD=admin \
+      dverse/keycloak:nix start-dev
+
 ## Deploying the real host
 
 1. **Replace the hardware module.** The shipped

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781509190,
+        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "sops-nix": "sops-nix"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -20,6 +20,7 @@
     let
       system = "x86_64-linux";
       lib = nixpkgs.lib;
+      pkgs = import nixpkgs { inherit system; };
       specialArgs = { inherit system inputs; };
     in
     {
@@ -30,6 +31,81 @@
         step-ca = import ./modules/services/step-ca.nix;
         keycloak = import ./modules/services/keycloak.nix;
         dverse-ca = import ./hosts/dverse-ca/configuration.nix;
+      };
+
+      # ─── OCI container images ──────────────────────────────────────────
+      # Built with dockerTools.buildLayeredImage for better layer reuse.
+      # Output is a gzipped tarball loadable via `docker load` / `podman load`
+      # or pushable via `skopeo copy docker-archive:./result docker://...`.
+      # Tags are deterministic ("nix"); re-tag on push if you want versioning.
+      packages.${system} = {
+        # step-ca: entrypoint mirrors the NixOS module's ExecStart
+        # (step-ca --password-file <pw> <ca.json>). Operator mounts:
+        #   /etc/step-ca/ca.json       (read-only, the ca.json)
+        #   /run/secrets/step-ca-password  (read-only, password file)
+        #   /var/lib/step-ca           (read-write volume for state/certs)
+        # Runs as uid/gid 1000:1000 — chown mounts on the host accordingly.
+        oci-step-ca = pkgs.dockerTools.buildLayeredImage {
+          name = "dverse/step-ca";
+          tag = "nix";
+          contents = [
+            pkgs.step-ca
+            pkgs.step-cli
+            pkgs.cacert
+            pkgs.bashInteractive
+            pkgs.coreutils
+          ];
+          config = {
+            Entrypoint = [ "${pkgs.step-ca}/bin/step-ca" ];
+            Cmd = [
+              "--password-file"
+              "/run/secrets/step-ca-password"
+              "/etc/step-ca/ca.json"
+            ];
+            WorkingDir = "/var/lib/step-ca";
+            User = "1000:1000";
+            ExposedPorts = {
+              "9000/tcp" = { };
+            };
+            Env = [
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              "STEPPATH=/var/lib/step-ca"
+            ];
+            Volumes = {
+              "/var/lib/step-ca" = { };
+            };
+          };
+        };
+
+        # keycloak: kc.sh entrypoint with `start` (production mode) as the
+        # default Cmd. Override to `start-dev` for local testing. Config is
+        # supplied via container env vars — see nix/README.md.
+        oci-keycloak = pkgs.dockerTools.buildLayeredImage {
+          name = "dverse/keycloak";
+          tag = "nix";
+          contents = [
+            pkgs.keycloak
+            pkgs.cacert
+            pkgs.bashInteractive
+            pkgs.coreutils
+          ];
+          config = {
+            Entrypoint = [ "${pkgs.keycloak}/bin/kc.sh" ];
+            Cmd = [ "start" ];
+            User = "1000:1000";
+            ExposedPorts = {
+              "8080/tcp" = { };
+              "8443/tcp" = { };
+            };
+            Env = [
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+          };
+        };
+
+        # Convenience alias — step-ca is the primary thing this CA host
+        # exists for, so `nix build .#` defaults to that image.
+        default = self.packages.${system}.oci-step-ca;
       };
 
       # ─── Deployable host configurations ────────────────────────────────

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "DVerse CA + Keycloak NixOS flake (step-ca + keycloak IdP for the DVerse platform).";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      sops-nix,
+      ...
+    }@inputs:
+    let
+      system = "x86_64-linux";
+      lib = nixpkgs.lib;
+      specialArgs = { inherit system inputs; };
+    in
+    {
+      # ─── Reusable NixOS modules ─────────────────────────────────────────
+      # Consumers can import these from their own flake to compose the
+      # services into a different host configuration.
+      nixosModules = {
+        step-ca = import ./modules/services/step-ca.nix;
+        keycloak = import ./modules/services/keycloak.nix;
+        dverse-ca = import ./hosts/dverse-ca/configuration.nix;
+      };
+
+      # ─── Deployable host configurations ────────────────────────────────
+      nixosConfigurations = {
+        # Production host. Expects:
+        #   - a real hosts/dverse-ca/hardware-configuration.nix (the one
+        #     shipped here is a stub — replace before deploying)
+        #   - secrets/dverse-ca.yaml encrypted to keys listed in .sops.yaml
+        dverse-ca = lib.nixosSystem {
+          specialArgs = specialArgs;
+          modules = [
+            sops-nix.nixosModules.sops
+            ./hosts/dverse-ca/configuration.nix
+            ./hosts/dverse-ca/hardware-configuration.nix
+          ];
+        };
+
+        # Sops-free VM variant for local testing.
+        # Build: nix build .#nixosConfigurations.dverse-ca-vm.config.system.build.vm
+        # Run:   ./result/bin/run-dverse-ca-vm
+        dverse-ca-vm = lib.nixosSystem {
+          specialArgs = specialArgs;
+          modules = [
+            ./hosts/dverse-ca/vm-test.nix
+          ];
+        };
+      };
+    };
+}

--- a/nix/hosts/dverse-ca/configuration.nix
+++ b/nix/hosts/dverse-ca/configuration.nix
@@ -1,0 +1,87 @@
+# hosts/dverse-ca/configuration.nix
+#
+# Top-level NixOS configuration for the production `dverse-ca` host. Composes
+# the step-ca and keycloak service modules with sops-nix-managed secrets and
+# a minimal system baseline (openssh + firewall + sops tooling).
+#
+# Anything personal (user accounts, ssh keys, tailscale, editor configs) that
+# lived in the source repo has been stripped — operators are expected to add
+# their own users / authorized keys via the `dverseCa.operator*` options or by
+# layering an additional module.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../../modules/services/step-ca.nix
+    ../../modules/services/keycloak.nix
+    ./step-ca.nix
+    ./keycloak.nix
+  ];
+
+  options.dverseCa = {
+    operatorSshKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "ssh-ed25519 AAAA... operator@example.com" ];
+      description = ''
+        SSH public keys authorised to log in as root on the host. Replace the
+        default empty list with your own keys before deploying; otherwise the
+        only way in is via console.
+      '';
+    };
+  };
+
+  config = {
+    networking.hostName = lib.mkDefault "dverse-ca";
+    time.timeZone = lib.mkDefault "Europe/Amsterdam";
+
+    users.users.root.openssh.authorizedKeys.keys = config.dverseCa.operatorSshKeys;
+
+    # ─── sops-nix baseline ────────────────────────────────────────────────
+    # Secrets are decrypted at activation time using the host's ssh ed25519
+    # key, converted to an age identity by sops-nix. No separate keyfile to
+    # provision.
+    environment.systemPackages = with pkgs; [
+      sops
+      age
+      ssh-to-age
+      neovim
+      git
+      curl
+    ];
+
+    sops = {
+      defaultSopsFile = ../../secrets/dverse-ca.yaml;
+      defaultSopsFormat = "yaml";
+      age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+      age.generateKey = false;
+    };
+
+    # ─── Minimal system baseline ──────────────────────────────────────────
+    services.openssh = {
+      enable = true;
+      ports = [ 22 ];
+      settings = {
+        PasswordAuthentication = false;
+        KbdInteractiveAuthentication = false;
+        PermitRootLogin = "prohibit-password";
+      };
+    };
+
+    networking.firewall = {
+      enable = true;
+      allowedTCPPorts = [ 22 ];
+    };
+
+    services.logrotate.checkConfig = false;
+    boot.tmp.cleanOnBoot = true;
+    zramSwap.enable = true;
+
+    system.stateVersion = lib.mkDefault "25.11";
+  };
+}

--- a/nix/hosts/dverse-ca/hardware-configuration.nix
+++ b/nix/hosts/dverse-ca/hardware-configuration.nix
@@ -1,0 +1,40 @@
+# hosts/dverse-ca/hardware-configuration.nix
+#
+# STUB. Replace this entire file with the real hardware-configuration.nix for
+# your target machine — generate it on the host with:
+#
+#     nixos-generate-config --show-hardware-config > hardware-configuration.nix
+#
+# The values below are intentionally non-functional placeholders so the flake
+# evaluates; building a system from them will not produce a bootable machine.
+#
+# The original deployment (Contabo VPS) used a qemu-guest profile with a GRUB
+# install on /dev/sda and an ext4 root mounted by UUID. Adapt accordingly.
+
+{ lib, modulesPath, ... }:
+{
+  imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+  boot.loader.grub.device = lib.mkDefault "/dev/sda";
+  boot.initrd.availableKernelModules = [
+    "ata_piix"
+    "uhci_hcd"
+    "virtio_pci"
+    "virtio_scsi"
+    "sd_mod"
+    "sr_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" = lib.mkDefault {
+    # Replace with your actual root device UUID.
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+
+  swapDevices = [ ];
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/nix/hosts/dverse-ca/keycloak.nix
+++ b/nix/hosts/dverse-ca/keycloak.nix
@@ -1,0 +1,138 @@
+{ config, pkgs, ... }:
+{
+  sops.secrets.keycloak-admin-password = {
+    sopsFile = ../../secrets/dverse-ca.yaml;
+  };
+
+  sops.secrets.keycloak-db-password = {
+    sopsFile = ../../secrets/dverse-ca.yaml;
+  };
+
+  sops.secrets.keycloak-step-ca-secret = {
+    sopsFile = ../../secrets/dverse-ca.yaml;
+  };
+
+  sops.secrets.keycloak-registration-secret = {
+    sopsFile = ../../secrets/dverse-ca.yaml;
+  };
+
+  sops.templates.keycloak-admin-env = {
+    content = ''
+      KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD=${config.sops.placeholder.keycloak-admin-password}
+    '';
+    mode = "0400";
+  };
+
+  # Full realm definition rendered at boot with secrets injected from sops.
+  # An ExecStartPre hook symlinks this into /run/keycloak/data/import/ before
+  # kc.sh --import-realm runs. Keycloak skips import if the realm already exists.
+  sops.templates.keycloak-dverse-realm = {
+    content = builtins.toJSON {
+      realm = "dverse";
+      enabled = true;
+
+      clients = [
+        {
+          clientId = "step-ca";
+          name = "Step CA";
+          enabled = true;
+          protocol = "openid-connect";
+          publicClient = false;
+          secret = config.sops.placeholder.keycloak-step-ca-secret;
+          directAccessGrantsEnabled = true;
+          standardFlowEnabled = false;
+          implicitFlowEnabled = false;
+          serviceAccountsEnabled = false;
+        }
+        {
+          clientId = "dverse-registration";
+          name = "DVerse Registration";
+          enabled = true;
+          protocol = "openid-connect";
+          publicClient = false;
+          secret = config.sops.placeholder.keycloak-registration-secret;
+          serviceAccountsEnabled = true;
+          standardFlowEnabled = false;
+          directAccessGrantsEnabled = false;
+          implicitFlowEnabled = false;
+        }
+      ];
+
+      users = [
+        {
+          username = "service-account-dverse-registration";
+          enabled = true;
+          serviceAccountClientId = "dverse-registration";
+          clientRoles."realm-management" = [ "manage-users" ];
+        }
+      ];
+
+      userProfileConfig = {
+        attributes = [
+          {
+            name = "username";
+            displayName = "\${username}";
+            validations = { length = { min = 3; max = 255; }; username-prohibited-characters = {}; up-username-not-idn-homograph = {}; };
+            permissions = { view = [ "admin" "user" ]; edit = [ "admin" "user" ]; };
+            multivalued = false;
+          }
+          {
+            name = "email";
+            displayName = "\${email}";
+            validations = { email = {}; length = { max = 255; }; };
+            required = { roles = [ "user" ]; };
+            permissions = { view = [ "admin" "user" ]; edit = [ "admin" "user" ]; };
+            multivalued = false;
+          }
+          {
+            name = "firstName";
+            displayName = "\${firstName}";
+            validations = { length = { max = 255; }; person-name-prohibited-characters = {}; };
+            permissions = { view = [ "admin" "user" ]; edit = [ "admin" "user" ]; };
+            multivalued = false;
+          }
+          {
+            name = "lastName";
+            displayName = "\${lastName}";
+            validations = { length = { max = 255; }; person-name-prohibited-characters = {}; };
+            permissions = { view = [ "admin" "user" ]; edit = [ "admin" "user" ]; };
+            multivalued = false;
+          }
+        ];
+        groups = [
+          { name = "user-metadata"; displayHeader = "User metadata"; displayDescription = "Attributes, which refer to user metadata"; }
+        ];
+      };
+    };
+    mode = "0444";
+  };
+
+  services.keycloak-server = {
+    enable = true;
+    hostname = "auth.dverse.yordanmitev.me";
+    adminPasswordEnvFile = config.sops.templates.keycloak-admin-env.path;
+    databasePasswordFile = config.sops.secrets.keycloak-db-password.path;
+    acmeEmail = "yordanmitev@yordanmitev.me";
+  };
+
+  # realmFiles tells the nixpkgs module to add --import-realm to kc.sh start.
+  # The tmpfiles symlink it tries to create fails due to RuntimeDirectory ownership, but
+  # ExecStartPre below creates the symlink correctly before kc.sh runs.
+  services.keycloak.realmFiles = [
+    config.sops.templates.keycloak-dverse-realm.path
+  ];
+
+  # ExecStartPre runs as the keycloak user after RuntimeDirectory creates /run/keycloak/.
+  # It places the sops-rendered realm JSON where kc.sh --import-realm expects it.
+  # RuntimeDirectory wipes the dir on every service stop, so we recreate on each start.
+  systemd.services.keycloak.serviceConfig.ExecStartPre =
+    let
+      setupImport = pkgs.writeShellScript "keycloak-setup-import" ''
+        mkdir -p /run/keycloak/data/import
+        ln -sf ${config.sops.templates.keycloak-dverse-realm.path} \
+          /run/keycloak/data/import/dverse-realm.json
+      '';
+    in
+    [ "${setupImport}" ];
+}

--- a/nix/hosts/dverse-ca/step-ca.nix
+++ b/nix/hosts/dverse-ca/step-ca.nix
@@ -1,0 +1,26 @@
+# hosts/dverse-ca/step-ca.nix
+#
+# Host-specific Step-CA configuration. Enables the shared module and wires
+# up the sops-managed password secret. Imported from configuration.nix.
+
+{ config, ... }:
+{
+  sops.secrets.step-ca-password = {
+    sopsFile = ../../secrets/dverse-ca.yaml;
+    owner = "step-ca";
+    group = "step-ca";
+    mode = "0400";
+  };
+
+  services.step-ca = {
+    enable = true;
+    port = 9000;
+    dnsNames = [
+      "dverse-ca"
+      "dverse-ca.local"
+      "localhost"
+      "ca.dverse.yordanmitev.me"
+    ];
+    passwordFile = config.sops.secrets.step-ca-password.path;
+  };
+}

--- a/nix/hosts/dverse-ca/vm-test.nix
+++ b/nix/hosts/dverse-ca/vm-test.nix
@@ -1,0 +1,132 @@
+# hosts/dverse-ca/vm-test.nix
+#
+# Standalone NixOS configuration for local QEMU VM testing.
+# Does NOT use sops — password is plain text (test only).
+# Build: nix build .#nixosConfigurations.dverse-ca-vm.config.system.build.vm
+# Run:   ./result/bin/run-dverse-ca-vm
+# Verify: step ca health --ca-url https://localhost:9000 \
+#           --root /var/lib/step-ca/certs/root_ca.crt
+
+{
+  pkgs,
+  lib,
+  modulesPath,
+  config,
+  ...
+}:
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+    ../../modules/services/step-ca.nix
+  ];
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  networking.hostName = "dverse-ca";
+  time.timeZone = "Europe/Amsterdam";
+
+  # Passwordless root login for console / SSH access in the test VM
+  users.users.root.initialPassword = "root";
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "yes";
+      PasswordAuthentication = true;
+    };
+  };
+
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 ];
+  };
+
+  environment.systemPackages = with pkgs; [
+    curl
+    jq
+  ];
+
+  # Plain-text password file — never use this pattern outside a test VM
+  environment.etc."step-ca-password".text = "dverse-ca-test-password\n";
+
+  # ── Step-CA module options ───────────────────────────────────────────────
+  services.step-ca = {
+    enable = true;
+    port = 9000;
+    dnsNames = [
+      "dverse-ca"
+      "localhost"
+    ];
+    passwordFile = "/etc/step-ca-password";
+  };
+
+  # ── CA bootstrap ────────────────────────────────────────────────────────
+  # One-shot service that runs `step ca init` on first boot and places the
+  # generated key material in /var/lib/step-ca/.  Subsequent reboots skip
+  # it because the sentinel file already exists.
+
+  systemd.services.step-ca-init = {
+    description = "Bootstrap Step-CA key material (first boot)";
+    wantedBy = [ "multi-user.target" ];
+    before = [ "step-ca.service" ];
+    requiredBy = [ "step-ca.service" ];
+    path = with pkgs; [
+      step-cli
+      coreutils
+      gnused
+    ];
+
+    environment.STEPPATH = "/tmp/step-ca-init";
+
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+
+    script =
+      let
+        port = toString config.services.step-ca.port;
+        dnsFlags = lib.concatMapStringsSep " " (n: "--dns ${n}") config.services.step-ca.dnsNames;
+        pwdFile = config.services.step-ca.passwordFile;
+      in
+      ''
+        if [ -f /var/lib/step-ca/config/ca.json ]; then
+          echo "CA already initialised, skipping."
+          exit 0
+        fi
+
+        rm -rf "$STEPPATH"
+        mkdir -p "$STEPPATH"
+
+        step ca init \
+          --deployment-type standalone \
+          --name "DVerse CA" \
+          ${dnsFlags} \
+          --address ":${port}" \
+          --provisioner "dverse-admin" \
+          --password-file ${pwdFile}
+
+        mkdir -p /var/lib/step-ca/{certs,secrets,db,config}
+
+        cp "$STEPPATH/certs/root_ca.crt"           /var/lib/step-ca/certs/
+        cp "$STEPPATH/certs/intermediate_ca.crt"   /var/lib/step-ca/certs/
+        cp "$STEPPATH/secrets/intermediate_ca_key" /var/lib/step-ca/secrets/
+
+        sed "s|$STEPPATH|/var/lib/step-ca|g" \
+          "$STEPPATH/config/ca.json" > /var/lib/step-ca/config/ca.json
+
+        chown -R step-ca:step-ca /var/lib/step-ca/
+        rm -rf "$STEPPATH"
+      '';
+  };
+
+  # The module defines step-ca.service with after = [ "network.target" ].
+  # Wire it so it also waits for the init service.
+  systemd.services.step-ca = {
+    after = [
+      "network.target"
+      "step-ca-init.service"
+    ];
+    requires = [ "step-ca-init.service" ];
+  };
+
+  system.stateVersion = "25.11";
+}

--- a/nix/modules/services/keycloak.nix
+++ b/nix/modules/services/keycloak.nix
@@ -1,0 +1,86 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.keycloak-server;
+in
+{
+  options.services.keycloak-server = {
+    enable = lib.mkEnableOption "Keycloak identity provider";
+
+    hostname = lib.mkOption {
+      type = lib.types.str;
+      description = "Public hostname Keycloak is reachable at (e.g. auth.example.com).";
+    };
+
+    adminPasswordEnvFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to a file (readable by root) containing:
+          KC_BOOTSTRAP_ADMIN_USERNAME=admin
+          KC_BOOTSTRAP_ADMIN_PASSWORD=<secret>
+        Systemd reads this before dropping privileges, so a root-owned 0400 file works.
+      '';
+    };
+
+    databasePasswordFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to a file containing the PostgreSQL password for Keycloak.";
+    };
+
+    acmeEmail = lib.mkOption {
+      type = lib.types.str;
+      description = "Email address used for Let's Encrypt ACME registration.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.keycloak = {
+      enable = true;
+      settings = {
+        hostname = cfg.hostname;
+        http-enabled = true;
+        http-port = 8080;
+        proxy-headers = "xforwarded";
+      };
+      database = {
+        type = "postgresql";
+        createLocally = true;
+        passwordFile = cfg.databasePasswordFile;
+      };
+    };
+
+    systemd.services.keycloak.serviceConfig.EnvironmentFile = cfg.adminPasswordEnvFile;
+
+    services.nginx = {
+      enable = true;
+      virtualHosts.${cfg.hostname} = {
+        enableACME = true;
+        forceSSL = true;
+        locations."/" = {
+          proxyPass = "http://127.0.0.1:8080";
+          proxyWebsockets = true;
+          extraConfig = ''
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+      };
+    };
+
+    security.acme = {
+      acceptTerms = true;
+      defaults.email = cfg.acmeEmail;
+    };
+
+    networking.firewall.allowedTCPPorts = [
+      80
+      443
+    ];
+  };
+}

--- a/nix/modules/services/step-ca.nix
+++ b/nix/modules/services/step-ca.nix
@@ -1,0 +1,80 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.step-ca;
+in
+{
+  disabledModules = [ "services/security/step-ca.nix" ];
+
+  options.services.step-ca = {
+    enable = lib.mkEnableOption "Step-CA certificate authority";
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 9000;
+      description = "Port the CA HTTPS listener binds to.";
+    };
+
+    dnsNames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "localhost" ];
+      description = "Hostnames the CA TLS certificate covers.";
+    };
+
+    passwordFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to a file containing the intermediate CA key password.";
+    };
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/step-ca/config/ca.json";
+      description = "Path to the ca.json produced by step ca init.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.step-ca
+      pkgs.step-cli
+      pkgs.openssl
+    ];
+
+    users.users.step-ca = {
+      isSystemUser = true;
+      group = "step-ca";
+      home = "/var/lib/step-ca";
+      createHome = false;
+    };
+    users.groups.step-ca = { };
+
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+
+    systemd.services.step-ca = {
+      description = "Step-CA certificate authority";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        Type = "simple";
+        User = "step-ca";
+        Group = "step-ca";
+        StateDirectory = "step-ca";
+        UMask = "0077";
+        WorkingDirectory = "/var/lib/step-ca";
+        ExecStart = "${pkgs.step-ca}/bin/step-ca --password-file ${cfg.passwordFile} ${cfg.configFile}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        NoNewPrivileges = true;
+        ProtectSystem = "full";
+        ProtectHome = true;
+        PrivateTmp = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6";
+      };
+    };
+  };
+}

--- a/nix/secrets/dverse-ca.example.yaml
+++ b/nix/secrets/dverse-ca.example.yaml
@@ -1,0 +1,35 @@
+# nix/secrets/dverse-ca.example.yaml
+#
+# PLAINTEXT TEMPLATE for the sops-encrypted secrets file required by the
+# dverse-ca host. DO NOT deploy this verbatim — it is checked in only so
+# operators can see the expected schema. The real `dverse-ca.yaml` next to
+# this file must be encrypted with sops/age using keys listed in `.sops.yaml`
+# at the root of this nix flake.
+#
+# Bootstrap workflow (one-shot, per operator):
+#
+#   1. age-keygen -o ~/.config/sops/age/keys.txt        # admin key
+#   2. nix run nixpkgs#ssh-to-age -- -i \
+#        /etc/ssh/ssh_host_ed25519_key.pub               # server key (run on target)
+#   3. Edit nix/.sops.yaml — replace placeholder recipients with the two
+#      age1... public keys from steps 1 & 2.
+#   4. cp nix/secrets/dverse-ca.example.yaml nix/secrets/dverse-ca.yaml
+#   5. Replace every CHANGE-ME below with a real secret.
+#   6. sops --encrypt --in-place nix/secrets/dverse-ca.yaml
+#   7. Commit the encrypted file; never commit the plaintext copy.
+
+# Password protecting the step-ca intermediate CA private key.
+step-ca-password: CHANGE-ME-step-ca-intermediate-password
+
+# Keycloak bootstrap admin password (used on first start, then ignored).
+keycloak-admin-password: CHANGE-ME-keycloak-admin-password
+
+# PostgreSQL password keycloak uses against its locally-managed database.
+keycloak-db-password: CHANGE-ME-keycloak-db-password
+
+# OIDC client secret for the `step-ca` realm client (CA OIDC provisioner).
+keycloak-step-ca-secret: CHANGE-ME-step-ca-oidc-client-secret
+
+# OIDC client secret for the `dverse-registration` realm client
+# (service account used by the registration backend to create users).
+keycloak-registration-secret: CHANGE-ME-dverse-registration-client-secret

--- a/nix/secrets/dverse-ca.yaml
+++ b/nix/secrets/dverse-ca.yaml
@@ -1,0 +1,29 @@
+step-ca-password: ENC[AES256_GCM,data:A9JsvynLVHIETj5CiYqL+afQnrQzTh+dIfuwUFgFgJM=,iv:OU9TLNQmuEl6XXrqqyi8ERJdzIp9fLX2TGpfi4MHbzI=,tag:+P8GTfAaOT0bSZSZohCXAA==,type:str]
+keycloak-admin-password: ENC[AES256_GCM,data:smwwW/0oFReZ2NK4n/8=,iv:YEB03lfxsvjZtdmempQcwTfDLMnJcoYSwpDnquad09E=,tag:YOPpkRTiRYghdmEaWkpXNA==,type:str]
+keycloak-db-password: ENC[AES256_GCM,data:iKw1McGKaqdQRdBRNvDET5cELjCH9NKcnPzRJxRRkAAA,iv:YPxSJ3Q+OZekSlqjmuQv00gpphbbkHiFGHntf8+512E=,tag:rkUZqYWtYkcqpDFBJP+lqA==,type:str]
+keycloak-step-ca-secret: ENC[AES256_GCM,data:3TBEJBGtlHo5nDjHxxVJxOpa75I7K4LFamW7fZeLHjw=,iv:8moUZgb6HwOWqRcza1aXxbHR9XgOPhQVGejYyl4uyQ0=,tag:9mBHwC78aTL7inEtFT6jTg==,type:str]
+keycloak-registration-secret: ENC[AES256_GCM,data:QGyVc7KFLDmxDQz8WxEtQ9qOEZUQjtl93ZxjKQ7SN9M=,iv:rK+OZkUYoT8V6LlTUZDouxGLgKwVd5ZIRoeIPYEiOiY=,tag:8xLCVRpB3N9Ru8yvhvbMDw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Z2xGVGt4Q0RtVjBHWHdT
+            dGRZNFFlWElTemJ0QkJlTVVWMlVDOWRySnlRCnFxUjFmNzRZZ2FGV29zenF6aXdr
+            d3VZY2kxdlNDdGVPQ0hZQXdUcHI0dXcKLS0tIHIzMHR2N09LaE84azZxUjBOMjRj
+            N1l5V3JVS0JiU1kwSjl6M2xMMWp2dkkKPncXYXcKTZNGfxUbZUoYGUmOAbUuFUtW
+            QeH3VSYnZSmvD6/9NPv5Gc4IPqX1y8tbZt75aqEXY6xweZkLpfPW9Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lmqu6xhpcjye6zcptjqv5msxhvlvnncczxx4wuzy3xk9ttq8je2su3y3qd
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpWVZqWXM5Z2YvK3NrTitM
+            WXZKWXNjSkt4cCtUN0VZMGorRk5ONmlTY3hjCmZnVTRJWTFYY2VQTzhENFJ1UDY0
+            Z2tHZHpTZzJzVFh1VW9lMnNWM0NDdm8KLS0tIERZN21iZHVPTS9Kc3JBeVJzczJN
+            dlJiQi9ROUF0aVpkWVNOcFZ4UVQvQWMKV974E0KgeoFqes6ojucnzzJ1HdrrVD2C
+            lJ05H7nEIzqitWxDesnODgrMS3bYqOku5k2MD19g5yZHn49qX/22EA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16nh8dd6stnun6ludd03de7m66ddkk3p96muu9jks9g7am7wh7e3sqr34v4
+    lastmodified: "2026-05-19T13:14:43Z"
+    mac: ENC[AES256_GCM,data:NmSsO54i6fn7n/TY4zt8RVFnGE6I0BH5zBSm2YA0/bY5bFzWpeIe3dEjsFahq1AOzA9iGvYDIDZAZve657BGWEXcloaZfnqADm+msLOuyvPkya+g5Fxa71BmDYcQy0FSulNvMl8c9TLcF19GgThjBMkyvVY9ymuZ6sStuK/Qq0Y=,iv:/eM9z1ETIOdcrR7Fq5c732Sm0R1WKQdYAzoqA/qR+48=,tag:N6TObVeHPKPCn9JWrWm+2g==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.0


### PR DESCRIPTION
## Summary

Extracts the dverse-ca NixOS host config (step-ca private CA + Keycloak IdP) out of a personal multi-host nix-config repo and into a self-contained flake under `nix/` in this repo, so the platform's CA/IdP infrastructure ships with the platform code.

First PR of a 2-PR stack — see #136. The second PR (`feature/nix-oci-images`, stacked on this branch) adds OCI image builds on top.

## What's in `nix/`

- `flake.nix` — own pinned inputs (`nixpkgs` → `nixos-25.11`, `sops-nix`); exposes:
  - `nixosModules.{step-ca, keycloak, dverse-ca}` for reuse from other flakes,
  - `nixosConfigurations.dverse-ca` — production host (real hardware-configuration + sops-encrypted secrets required),
  - `nixosConfigurations.dverse-ca-vm` — sops-free QEMU variant for local testing.
- `modules/services/{step-ca,keycloak}.nix` — the custom service modules (step-ca disables the upstream module; keycloak wraps `services.keycloak`).
- `hosts/dverse-ca/{configuration,step-ca,keycloak,vm-test,hardware-configuration}.nix` — host wiring. `hardware-configuration.nix` is a documented stub; operator replaces before deploying.
- `secrets/dverse-ca.example.yaml` + `.sops.yaml` — placeholder schema + recipient template. Operator re-encrypts with their own age key (the original encrypted file from the personal repo is intentionally **not** copied — its recipients wouldn't be usable here).
- `README.md` — build/deploy/secrets-bootstrap walkthrough.

## Verification

- `nix flake show ./nix` — all 5 outputs enumerate cleanly.
- `nix eval .#nixosConfigurations.dverse-ca-vm.config.system.build.vm.drvPath` → resolves.
- `nix eval .#nixosConfigurations.dverse-ca.config.services.step-ca.port` → `9000`.
- `nix flake check --no-build` fails on `dverse-ca` only due to the missing real `secrets/dverse-ca.yaml` — expected (sops boundary).

## Test plan

- [x] `cd nix && nix flake show` lists the 3 modules + 2 configurations
- [x] `nix build .#nixosConfigurations.dverse-ca-vm.config.system.build.vm` produces a runnable VM
- [x] `./result/bin/run-dverse-ca-vm` boots step-ca and keycloak
- [x] README's secrets bootstrap reads correctly to someone deploying for the first time

Refs: #136