### PR TITLE
nix: OCI images for step-ca and keycloak (refs #136)

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -50,6 +50,94 @@ Inside the VM (root/root login):
     step ca health --ca-url https://localhost:9000 \
       --root /var/lib/step-ca/certs/root_ca.crt
 
+## Building OCI container images
+
+The flake also exposes two container images for operators who want to
+deploy step-ca or Keycloak outside of a full NixOS host (e.g. into an
+existing Kubernetes / Nomad / docker-compose setup). The images are
+reproducible Nix builds — they are tagged `nix` and **not** stamped with
+a git SHA. Re-tag on push if you want versioning.
+
+| Output                     | What it builds            | Approx size (gzipped) |
+| -------------------------- | ------------------------- | --------------------- |
+| `.#oci-step-ca` (default)  | `dverse/step-ca:nix`      | ~54 MiB               |
+| `.#oci-keycloak`           | `dverse/keycloak:nix`     | ~609 MiB              |
+
+Build:
+
+    cd nix
+    nix build .#oci-step-ca       # ./result is a gzipped docker-archive tar
+    nix build .#oci-keycloak
+
+Load into a local engine:
+
+    docker load < result
+    # or
+    podman load < result
+
+Push to a registry (no engine required) with skopeo:
+
+    skopeo copy docker-archive:./result \
+      docker://registry.example.com/dverse/step-ca:nix
+
+### step-ca image
+
+Mirrors the NixOS module's invocation
+(`step-ca --password-file <pw> <ca.json>`). Both images run as uid/gid
+`1000:1000` — chown your host mounts accordingly.
+
+Expected mounts:
+
+| Container path                  | Purpose                                    |
+| ------------------------------- | ------------------------------------------ |
+| `/etc/step-ca/ca.json`          | The `ca.json` produced by `step ca init`   |
+| `/run/secrets/step-ca-password` | File containing the intermediate-key password |
+| `/var/lib/step-ca`              | State volume (certs, db, secrets/)         |
+
+Exposed port: `9000/tcp` (HTTPS).
+
+Minimal run example:
+
+    docker run -d --name step-ca \
+      -p 9000:9000 \
+      -v /srv/step-ca/ca.json:/etc/step-ca/ca.json:ro \
+      -v /srv/step-ca/password:/run/secrets/step-ca-password:ro \
+      -v step-ca-data:/var/lib/step-ca \
+      dverse/step-ca:nix
+
+To override the entrypoint for ops (e.g. to run `step ca health`), pass
+`--entrypoint /bin/step`.
+
+### keycloak image
+
+Entrypoint is `kc.sh` with default `Cmd = ["start"]` (production mode).
+Override to `start-dev` for local testing. **Config is supplied via
+container env vars** — nothing is baked in.
+
+Minimum env vars for a production-mode start:
+
+| Variable                   | Example                                   |
+| -------------------------- | ----------------------------------------- |
+| `KC_DB`                    | `postgres`                                |
+| `KC_DB_URL`                | `jdbc:postgresql://db:5432/keycloak`      |
+| `KC_DB_USERNAME`           | `keycloak`                                |
+| `KC_DB_PASSWORD`           | `<secret>`                                |
+| `KC_HOSTNAME`              | `auth.example.com`                        |
+| `KEYCLOAK_ADMIN`           | `admin` (only honoured on first boot)     |
+| `KEYCLOAK_ADMIN_PASSWORD`  | `<secret>` (only honoured on first boot)  |
+
+Exposed ports: `8080/tcp`, `8443/tcp`.
+
+Postgres is **not** bundled — bring your own.
+
+Minimal local-testing run:
+
+    docker run -d --name keycloak \
+      -p 8080:8080 \
+      -e KEYCLOAK_ADMIN=admin \
+      -e KEYCLOAK_ADMIN_PASSWORD=admin \
+      dverse/keycloak:nix start-dev
+
 ## Deploying the real host
 
 1. **Replace the hardware module.** The shipped

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -20,6 +20,7 @@
     let
       system = "x86_64-linux";
       lib = nixpkgs.lib;
+      pkgs = import nixpkgs { inherit system; };
       specialArgs = { inherit system inputs; };
     in
     {
@@ -30,6 +31,81 @@
         step-ca = import ./modules/services/step-ca.nix;
         keycloak = import ./modules/services/keycloak.nix;
         dverse-ca = import ./hosts/dverse-ca/configuration.nix;
+      };
+
+      # ─── OCI container images ──────────────────────────────────────────
+      # Built with dockerTools.buildLayeredImage for better layer reuse.
+      # Output is a gzipped tarball loadable via `docker load` / `podman load`
+      # or pushable via `skopeo copy docker-archive:./result docker://...`.
+      # Tags are deterministic ("nix"); re-tag on push if you want versioning.
+      packages.${system} = {
+        # step-ca: entrypoint mirrors the NixOS module's ExecStart
+        # (step-ca --password-file <pw> <ca.json>). Operator mounts:
+        #   /etc/step-ca/ca.json       (read-only, the ca.json)
+        #   /run/secrets/step-ca-password  (read-only, password file)
+        #   /var/lib/step-ca           (read-write volume for state/certs)
+        # Runs as uid/gid 1000:1000 — chown mounts on the host accordingly.
+        oci-step-ca = pkgs.dockerTools.buildLayeredImage {
+          name = "dverse/step-ca";
+          tag = "nix";
+          contents = [
+            pkgs.step-ca
+            pkgs.step-cli
+            pkgs.cacert
+            pkgs.bashInteractive
+            pkgs.coreutils
+          ];
+          config = {
+            Entrypoint = [ "${pkgs.step-ca}/bin/step-ca" ];
+            Cmd = [
+              "--password-file"
+              "/run/secrets/step-ca-password"
+              "/etc/step-ca/ca.json"
+            ];
+            WorkingDir = "/var/lib/step-ca";
+            User = "1000:1000";
+            ExposedPorts = {
+              "9000/tcp" = { };
+            };
+            Env = [
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              "STEPPATH=/var/lib/step-ca"
+            ];
+            Volumes = {
+              "/var/lib/step-ca" = { };
+            };
+          };
+        };
+
+        # keycloak: kc.sh entrypoint with `start` (production mode) as the
+        # default Cmd. Override to `start-dev` for local testing. Config is
+        # supplied via container env vars — see nix/README.md.
+        oci-keycloak = pkgs.dockerTools.buildLayeredImage {
+          name = "dverse/keycloak";
+          tag = "nix";
+          contents = [
+            pkgs.keycloak
+            pkgs.cacert
+            pkgs.bashInteractive
+            pkgs.coreutils
+          ];
+          config = {
+            Entrypoint = [ "${pkgs.keycloak}/bin/kc.sh" ];
+            Cmd = [ "start" ];
+            User = "1000:1000";
+            ExposedPorts = {
+              "8080/tcp" = { };
+              "8443/tcp" = { };
+            };
+            Env = [
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+          };
+        };
+
+        # Convenience alias — step-ca is the primary thing this CA host
+        # exists for, so `nix build .#` defaults to that image.
+        default = self.packages.${system}.oci-step-ca;
       };
 
       # ─── Deployable host configurations ────────────────────────────────


### PR DESCRIPTION
## Summary

Stacked on top of #142 (review/merge that first). Adds two `dockerTools.buildLayeredImage` packages so the dverse-ca services can be deployed as containers in addition to the NixOS host config.

## New flake outputs

- `packages.x86_64-linux.oci-step-ca` → \`dverse/step-ca:nix\` (~54 MiB gz)
  - Entrypoint mirrors the NixOS module's ExecStart: \`step-ca --password-file /run/secrets/step-ca-password /etc/step-ca/ca.json\`.
  - Expected mounts: ca.json, password file, \`/var/lib/step-ca\` volume.
  - Exposes \`9000/tcp\`, runs as \`1000:1000\`.
- `packages.x86_64-linux.oci-keycloak` → \`dverse/keycloak:nix\` (~609 MiB gz)
  - Entrypoint \`kc.sh\` with default \`Cmd = [ \"start\" ]\` (production mode).
  - Config via container env vars (\`KC_DB\`, \`KC_DB_URL\`, \`KC_HOSTNAME\`, \`KEYCLOAK_ADMIN\`, …) — documented in README.
  - Exposes \`8080\` + \`8443\`.
- `packages.x86_64-linux.default` → alias of `oci-step-ca` (CA is the primary thing this host exists for).

Both contain \`step-cli\` / \`cacert\` / \`bashInteractive\` / \`coreutils\` for ops debugging without kitchen-sinking.

## README

`nix/README.md` gets a new section covering:
- `nix build .#oci-step-ca` → load via `docker load` / `podman load`,
- push via `skopeo copy docker-archive:./result docker://…`,
- minimal run examples per service with required mounts/env vars,
- re-tag-on-push note (tags are deterministic at \`nix\`, not git-SHA stamped).

## Caveats

- `User=\"1000:1000\"` is the simpler choice but uid 1000 has no \`/etc/passwd\` entry. Fine for step-ca's Go binary; Keycloak's JVM may want a writable HOME mount in some configurations — noted in README.
- No compose/k8s/CI publication wiring — out of scope per #136.

## Verification

Both built locally:
- `nix build .#oci-step-ca` → /nix/store/h8q09d6rsgic7rnbcy5ladm97k4ac9m7-step-ca.tar.gz
- `nix build .#oci-keycloak` → /nix/store/qpxahaygrs5yfw8vqwcw6alkkg3i1izc-keycloak.tar.gz

## Test plan

- [ ] `nix build .#oci-step-ca && docker load < result` registers `dverse/step-ca:nix`
- [ ] `nix build .#oci-keycloak && docker load < result` registers `dverse/keycloak:nix`
- [ ] step-ca container starts when given ca.json + password file + writable /var/lib/step-ca
- [ ] keycloak container starts with documented env vars against an external Postgres

Refs: #136