### PR TITLE
feat(session): sign KickNotice with admin Ed25519 to close forgery gap

### DIFF
--- a/src/bot_framework/src/admission.rs
+++ b/src/bot_framework/src/admission.rs
@@ -64,8 +64,8 @@ pub enum AdmissionDecision {
         /// (e.g. `KickNotice`, #145) against it. Trust bootstrap: TOFU at
         /// the same level as `admin_identity_key` (the implicit binding is
         /// "the Olm decrypt of this Allow succeeded under that Curve25519
-        /// key" — extending that bond to the sibling Ed25519 inherits the
-        /// same model without re-keying the wire envelope).
+        /// key", and extending that bond to the sibling Ed25519 inherits
+        /// the same model without re-keying the wire envelope).
         admin_ed25519_key: String,
         /// RFC3339 timestamp.
         admitted_at: String,

--- a/src/bot_framework/src/admission.rs
+++ b/src/bot_framework/src/admission.rs
@@ -59,6 +59,14 @@ pub enum AdmissionDecision {
         /// The admin's Curve25519 identity key (base64) — the requester needs
         /// it to instantiate the inbound Olm session.
         admin_identity_key: String,
+        /// The admin's Ed25519 signing key (base64). The member pins this at
+        /// admission time and verifies subsequent control-plane signatures
+        /// (e.g. `KickNotice`, #145) against it. Trust bootstrap: TOFU at
+        /// the same level as `admin_identity_key` (the implicit binding is
+        /// "the Olm decrypt of this Allow succeeded under that Curve25519
+        /// key" — extending that bond to the sibling Ed25519 inherits the
+        /// same model without re-keying the wire envelope).
+        admin_ed25519_key: String,
         /// RFC3339 timestamp.
         admitted_at: String,
     },

--- a/src/bot_framework/src/control.rs
+++ b/src/bot_framework/src/control.rs
@@ -5,18 +5,18 @@
 //! `zenoh_router::router::build_acl_json`) carries them without an ACL change.
 //!
 //! * `dverse/session/control/kick/<kicked_cn>` — `KickNotice`,
-//!   admin → kicked member. JSON, plaintext.
+//!   admin → kicked member. JSON, plaintext, Ed25519-signed.
 //!
-//!   Authentication note (unmitigated): the session-rule allows ANY cert
-//!   holder to publish on `dverse/session/**`, so an admitted member could
-//!   forge a `KickNotice` targeted at a peer and the receiver would currently
-//!   tear down on the first match — `kick_handler::handle_kick` does NOT
-//!   cross-check against a rotation having actually happened, nor does it
-//!   verify a sender signature. The issue's acceptance criteria don't require
-//!   unforgeable kicks, but this is a known soft-spot to address in a follow
-//!   up (signing the notice with the admin's Ed25519 fingerprint is the
-//!   intended hardening; the wire type already carries `kicked_cn` and
-//!   `reason` so a future signature field can be added additively).
+//!   Authentication (#145): the notice carries an Ed25519 signature over a
+//!   domain-separated, length-prefixed byte form of `(kicked_cn, kicked_at,
+//!   banned)` (see [`kick_signing_bytes`]), signed with the admin's vodozemac
+//!   `Account` Ed25519 key. Receivers verify against the admin's Ed25519
+//!   identity learned during admission (`AdmissionDecision::Allow.admin_ed25519_key`,
+//!   pinned into `SessionCryptoState.session_admin_ed25519_b64`). Forged
+//!   notices (wrong signer, mutated identifying fields, missing signature)
+//!   are silently dropped. The session-rule still allows any admitted cert
+//!   holder to publish on this topic, but only the admin can produce a
+//!   notice that verifies.
 //!
 //! * `dverse/session/control/rotation/<member_cn>` — `SessionKeyRotation`,
 //!   admin → one remaining member. Carries an Olm `Normal` message whose
@@ -49,6 +49,46 @@ pub struct KickNotice {
     /// member able to decrypt traffic anyway, so its kick screen would be
     /// trivially detectable as a forgery.
     pub kicked_at: String,
+    /// Ed25519 signature, base64, over [`kick_signing_bytes`] of
+    /// `(kicked_cn, kicked_at, banned)`. Produced with the admin's vodozemac
+    /// `Account::sign`. Receivers verify against the admin's Ed25519 key
+    /// they learned at admission time (the stored trust anchor); the notice
+    /// is silently dropped on signature mismatch or absence (#145).
+    pub admin_ed25519_sig_b64: String,
+    /// The admin's Ed25519 public key, base64. Informational and useful in
+    /// tracing; verification is performed against the STORED admin Ed25519
+    /// from admission, not this field. A mismatch between the stored anchor
+    /// and the notice-carried key is itself a signal to drop.
+    pub admin_ed25519_key_b64: String,
+}
+
+/// Canonical, domain-separated byte form signed by the admin and re-built by
+/// the receiver. Both admin and receiver call this exact function so the byte
+/// layout is impossible to drift between sides.
+///
+/// Layout (little is structural, all delimiters explicit):
+/// ```text
+///   b"dverse.kick.v1\0"
+///   ‖ u32_be(len(kicked_cn)) ‖ kicked_cn
+///   ‖ u32_be(len(kicked_at)) ‖ kicked_at
+///   ‖ u8(banned as 0|1)
+/// ```
+///
+/// `reason` is intentionally NOT signed: it is display copy only, and the
+/// design choice lets admins fix a typo in the kick reason without
+/// re-signing. The unit test
+/// `kick_with_mutated_reason_still_verifies` pins that choice.
+pub fn kick_signing_bytes(kicked_cn: &str, kicked_at: &str, banned: bool) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(
+        15 + 4 + kicked_cn.len() + 4 + kicked_at.len() + 1,
+    );
+    buf.extend_from_slice(b"dverse.kick.v1\0");
+    buf.extend_from_slice(&(kicked_cn.len() as u32).to_be_bytes());
+    buf.extend_from_slice(kicked_cn.as_bytes());
+    buf.extend_from_slice(&(kicked_at.len() as u32).to_be_bytes());
+    buf.extend_from_slice(kicked_at.as_bytes());
+    buf.push(if banned { 1 } else { 0 });
+    buf
 }
 
 /// Admin → one remaining member. Carries a freshly-minted Megolm `SessionKey`
@@ -107,12 +147,51 @@ mod tests {
             reason: Some("spammed the channel".into()),
             banned: true,
             kicked_at: "1750000000".into(),
+            admin_ed25519_sig_b64: "sig".into(),
+            admin_ed25519_key_b64: "key".into(),
         };
         let json = serde_json::to_string(&n).unwrap();
         let parsed: KickNotice = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.kicked_cn, "bob");
         assert_eq!(parsed.reason.as_deref(), Some("spammed the channel"));
         assert!(parsed.banned);
+        assert_eq!(parsed.admin_ed25519_sig_b64, "sig");
+        assert_eq!(parsed.admin_ed25519_key_b64, "key");
+    }
+
+    /// Canonical signing bytes: stable across runs (no system inputs, no map
+    /// ordering), and the layout is exactly what the doc comment claims.
+    /// Pinned with an expected byte form so a future "tidy this up" refactor
+    /// can't silently break wire compatibility with already-deployed admins.
+    #[test]
+    fn kick_signing_bytes_layout_is_pinned() {
+        let bytes = kick_signing_bytes("bob", "1750000000", true);
+        let mut expected: Vec<u8> = Vec::new();
+        expected.extend_from_slice(b"dverse.kick.v1\0");
+        expected.extend_from_slice(&3u32.to_be_bytes());
+        expected.extend_from_slice(b"bob");
+        expected.extend_from_slice(&10u32.to_be_bytes());
+        expected.extend_from_slice(b"1750000000");
+        expected.push(1u8);
+        assert_eq!(bytes, expected);
+
+        // banned flag flips ONE byte at the tail.
+        let unbanned = kick_signing_bytes("bob", "1750000000", false);
+        assert_eq!(unbanned.last(), Some(&0u8));
+        assert_eq!(bytes.last(), Some(&1u8));
+        assert_eq!(&bytes[..bytes.len() - 1], &unbanned[..unbanned.len() - 1]);
+    }
+
+    /// Length-prefix isolation: two distinct field decompositions that would
+    /// concatenate to the same naive `cn || kicked_at` string must NOT collide
+    /// in the signing bytes. Catches the classic "ambiguous concatenation"
+    /// attack where an attacker pushes a `/` or digit boundary across fields.
+    #[test]
+    fn kick_signing_bytes_disambiguates_field_boundaries() {
+        // Naive: "bob1750" + "000000" == "bob17" + "50000000".
+        let a = kick_signing_bytes("bob1750", "000000", false);
+        let b = kick_signing_bytes("bob17", "50000000", false);
+        assert_ne!(a, b);
     }
 
     /// SessionKeyRotation wire format: all four required fields survive a

--- a/src/bot_framework/src/session_crypto.rs
+++ b/src/bot_framework/src/session_crypto.rs
@@ -39,7 +39,7 @@ use vodozemac::olm::{Account, Session, SessionConfig};
 // without re-consuming a one-time key.
 pub use vodozemac::megolm::{MegolmMessage, SessionKey};
 pub use vodozemac::olm::{OlmMessage, Session as OlmSession};
-pub use vodozemac::Curve25519PublicKey;
+pub use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature};
 use x509_parser::prelude::*;
 
 // ── Node identity (vodozemac Account) ─────────────────────────────────────────
@@ -70,6 +70,22 @@ impl SessionIdentity {
     /// Base64 Ed25519 fingerprint key.
     pub fn ed25519_key_base64(&self) -> String {
         self.account.ed25519_key().to_base64()
+    }
+
+    /// The Ed25519 signing/fingerprint public key. Admins use the matching
+    /// private key (held inside `account`) to sign control-plane messages
+    /// like `KickNotice` (#145); receivers verify against this public key,
+    /// which they learn at admission time.
+    pub fn ed25519_key(&self) -> Ed25519PublicKey {
+        self.account.ed25519_key()
+    }
+
+    /// Sign `message` with this account's Ed25519 signing key. Used by the
+    /// admin side of the kick path to produce the signature over
+    /// `control::kick_signing_bytes(...)`; receivers re-derive the same
+    /// bytes and call `Ed25519PublicKey::verify`.
+    pub fn sign(&self, message: &[u8]) -> Ed25519Signature {
+        self.account.sign(message)
     }
 
     /// Generate `count` one-time keys (consumed by peers establishing an Olm

--- a/src/zenoh_router/src/admission_handler.rs
+++ b/src/zenoh_router/src/admission_handler.rs
@@ -215,7 +215,13 @@ fn handle_decision(state: &Mutex<AppState>, payload: &[u8]) -> Result<()> {
         .map_err(|e| anyhow!("parse AdmissionDecision: {e}"))?;
 
     match dec {
-        AdmissionDecision::Allow { olm_message_type, olm_ciphertext_b64, admin_identity_key, .. } => {
+        AdmissionDecision::Allow {
+            olm_message_type,
+            olm_ciphertext_b64,
+            admin_identity_key,
+            admin_ed25519_key,
+            ..
+        } => {
             let ct = B64.decode(&olm_ciphertext_b64)
                 .map_err(|e| anyhow!("base64 decode olm ct: {e}"))?;
             let msg = OlmMessage::from_parts(olm_message_type, &ct)
@@ -245,6 +251,13 @@ fn handle_decision(state: &Mutex<AppState>, payload: &[u8]) -> Result<()> {
             // rotation message (a Normal Olm message on the same session)
             // can be decrypted without a fresh pre-key handshake (#111).
             crypto.member_olm_session = Some(session);
+            // Pin the admin's Ed25519 fingerprint so the kick path (#145) can
+            // verify `KickNotice` signatures against a stored trust anchor
+            // rather than the notice itself. Sanity-check the wire string
+            // parses as an Ed25519 key before storing.
+            bot_framework::session_crypto::Ed25519PublicKey::from_base64(&admin_ed25519_key)
+                .map_err(|e| anyhow!("parse admin Ed25519: {e}"))?;
+            crypto.session_admin_ed25519_b64 = Some(admin_ed25519_key);
             st.join_flow = Some(JoinFlowStatus::Allowed);
             info!("admission Allow accepted, group receiver installed");
         }
@@ -269,7 +282,7 @@ pub async fn admit(
     state: &Mutex<AppState>,
     requester_cn: &str,
 ) -> Result<()> {
-    let (olm_type, olm_ct_b64, admin_id_b64, decision_key) = {
+    let (olm_type, olm_ct_b64, admin_id_b64, admin_ed25519_b64, decision_key) = {
         let mut st = state.lock().unwrap();
         let pending = st
             .pending_requests
@@ -284,6 +297,7 @@ pub async fn admit(
             .ok_or_else(|| anyhow!("admin has no group sender (not in Admin role)"))?;
         let session_key_bytes = group_sender.session_key().to_bytes();
         let admin_id_b64 = crypto.identity.curve25519_key_base64();
+        let admin_ed25519_b64 = crypto.identity.ed25519_key_base64();
 
         let peer_id = Curve25519PublicKey::from_base64(&req.identity_key)
             .map_err(|e| anyhow!("parse peer identity: {e}"))?;
@@ -311,13 +325,14 @@ pub async fn admit(
         );
 
         let decision_key = format!("dverse/session/admission/{}", req.requester_cn);
-        (msg_type, B64.encode(&ct), admin_id_b64, decision_key)
+        (msg_type, B64.encode(&ct), admin_id_b64, admin_ed25519_b64, decision_key)
     };
 
     let decision = AdmissionDecision::Allow {
         olm_message_type: olm_type,
         olm_ciphertext_b64: olm_ct_b64,
         admin_identity_key: admin_id_b64,
+        admin_ed25519_key: admin_ed25519_b64,
         admitted_at: unix_epoch_secs(),
     };
     let payload = serde_json::to_vec(&decision)

--- a/src/zenoh_router/src/kick_handler.rs
+++ b/src/zenoh_router/src/kick_handler.rs
@@ -24,14 +24,14 @@ use anyhow::{anyhow, Result};
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
 use bot_framework::control::{
-    kick_notice_topic, session_key_rotation_topic, KickNotice, SessionKeyRotation,
-    KICK_NOTICE_SUB, SESSION_KEY_ROTATION_SUB,
+    kick_notice_topic, kick_signing_bytes, session_key_rotation_topic, KickNotice,
+    SessionKeyRotation, KICK_NOTICE_SUB, SESSION_KEY_ROTATION_SUB,
 };
 use bot_framework::session_crypto::{
-    olm_decrypt_on_session, olm_encrypt_on_session, Curve25519PublicKey, GroupReceiver,
-    GroupSender, OlmMessage, SessionKey,
+    olm_decrypt_on_session, olm_encrypt_on_session, Curve25519PublicKey, Ed25519PublicKey,
+    Ed25519Signature, GroupReceiver, GroupSender, OlmMessage, SessionKey,
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use zenoh::Session;
 
 use crate::state::{AppState, KickedState};
@@ -164,11 +164,23 @@ pub fn prepare_rotation(
         payloads.push((session_key_rotation_topic(cn), bytes));
     }
 
+    // Sign the canonical (kicked_cn, kicked_at, banned) bytes with the
+    // admin's vodozemac Ed25519 key. `reason` is intentionally not signed
+    // (see `kick_signing_bytes`). The wire field `admin_ed25519_key_b64`
+    // is informational — receivers verify against the Ed25519 they pinned
+    // at admission time (#145).
+    let kicked_at = unix_epoch_secs();
+    let crypto = st.crypto.as_ref().unwrap();
+    let signing_bytes = kick_signing_bytes(kicked_cn, &kicked_at, ban);
+    let sig = crypto.identity.sign(&signing_bytes);
+    let admin_ed25519_b64 = crypto.identity.ed25519_key_base64();
     let notice = KickNotice {
         kicked_cn: kicked_cn.to_string(),
         reason,
         banned: ban,
-        kicked_at: unix_epoch_secs(),
+        kicked_at,
+        admin_ed25519_sig_b64: sig.to_base64(),
+        admin_ed25519_key_b64: admin_ed25519_b64,
     };
     let notice_bytes =
         serde_json::to_vec(&notice).map_err(|e| anyhow!("serialize KickNotice: {e}"))?;
@@ -257,7 +269,52 @@ fn handle_kick(state: &Mutex<AppState>, my_cn: &str, payload: &[u8]) -> Result<(
         .map_err(|e| anyhow!("parse KickNotice: {e}"))?;
     if notice.kicked_cn != my_cn {
         // Broadcast topic — we subscribe broadly but only act on our own CN.
+        // Verifying notices targeted at other CNs is pointless work; we'd
+        // still ignore them. This short-circuit is purely a perf carve-out.
         return Ok(());
+    }
+    // Authenticity gate (#145): the notice MUST be signed by the admin we
+    // pinned at admission time. On failure we return Ok with a leakage-safe
+    // tracing line (do NOT log `kicked_cn`) and leave AppState untouched,
+    // which by construction keeps the member in the session.
+    //
+    // Anchor lookup is read-only under the same lock the teardown then
+    // re-acquires. We deliberately verify against the STORED admin
+    // Ed25519, not the notice-carried one. The notice's
+    // `admin_ed25519_key_b64` is informational; a mismatch with the
+    // stored anchor is itself a drop signal.
+    {
+        let st = state.lock().unwrap();
+        let Some(crypto) = st.crypto.as_ref() else {
+            debug!("kick verification skipped: no crypto state");
+            return Ok(());
+        };
+        let Some(anchor_b64) = crypto.session_admin_ed25519_b64.as_deref() else {
+            // No pinned admin identity — admission either hasn't completed
+            // or this node is the admin (admins don't kick themselves).
+            debug!("kick verification skipped: no pinned admin Ed25519 anchor");
+            return Ok(());
+        };
+        if anchor_b64 != notice.admin_ed25519_key_b64 {
+            warn!("dropping KickNotice: stored admin Ed25519 anchor differs from notice");
+            return Ok(());
+        }
+        let Ok(admin_pub) = Ed25519PublicKey::from_base64(anchor_b64) else {
+            warn!("dropping KickNotice: stored admin Ed25519 anchor unparseable");
+            return Ok(());
+        };
+        let Ok(sig) = Ed25519Signature::from_base64(&notice.admin_ed25519_sig_b64) else {
+            // Empty / malformed / wrong-length signature.
+            warn!("dropping KickNotice: signature unparseable or missing");
+            return Ok(());
+        };
+        let signing_bytes =
+            bot_framework::control::kick_signing_bytes(&notice.kicked_cn, &notice.kicked_at, notice.banned);
+        if admin_pub.verify(&signing_bytes, &sig).is_err() {
+            // Fields were mutated after signing, or signed by a non-admin.
+            warn!("dropping KickNotice: Ed25519 signature did not verify");
+            return Ok(());
+        }
     }
     // Tear down crypto + admission state and stage the Kicked screen. The
     // Tauri snapshot reads kicked_screen and routes the GUI; the embedded
@@ -572,48 +629,200 @@ mod tests {
         assert_eq!(pubs.kick_topic, "dverse/session/control/kick/bob");
     }
 
-    /// `handle_kick` for ourselves sets `kicked_screen` and clears the
-    /// inbound Megolm state; messages targeted at OTHER CNs leave state
-    /// untouched.
-    #[test]
-    fn handle_kick_routes_only_on_self_match() {
+    /// Test helper: build a member-side AppState with a single-slot pinned
+    /// admin Ed25519 anchor matching `admin`. Mirrors what the production
+    /// admission_handler::handle_decision path does on a successful Allow.
+    fn member_state_pinned_to(admin: &SessionIdentity) -> Mutex<AppState> {
         let mut s = AppState::new(None);
         s.crypto = Some(SessionCryptoState::new(false));
-        let state = Mutex::new(s);
+        s.crypto.as_mut().unwrap().session_admin_ed25519_b64 =
+            Some(admin.ed25519_key_base64());
+        Mutex::new(s)
+    }
 
-        // Notice for someone else — no-op.
-        let other = KickNotice {
-            kicked_cn: "alice".into(),
-            reason: None,
-            banned: false,
-            kicked_at: "0".into(),
-        };
-        super::handle_kick(
-            &state,
-            "bob",
-            &serde_json::to_vec(&other).unwrap(),
-        )
-        .unwrap();
+    /// Test helper: construct a signed KickNotice. Calls the SAME
+    /// canonical-bytes helper the production admin path uses — this is the
+    /// test-side mirror of the production single-source-of-truth, and is
+    /// what makes the "mutated after signing" tests faithful (no re-sign,
+    /// mutation happens on the constructed struct).
+    fn signed_kick_notice(
+        admin: &SessionIdentity,
+        kicked_cn: &str,
+        reason: Option<String>,
+        banned: bool,
+        kicked_at: &str,
+    ) -> KickNotice {
+        let bytes = bot_framework::control::kick_signing_bytes(kicked_cn, kicked_at, banned);
+        let sig = admin.sign(&bytes);
+        KickNotice {
+            kicked_cn: kicked_cn.into(),
+            reason,
+            banned,
+            kicked_at: kicked_at.into(),
+            admin_ed25519_sig_b64: sig.to_base64(),
+            admin_ed25519_key_b64: admin.ed25519_key_base64(),
+        }
+    }
+
+    /// Updated from the PR #144 baseline to know about the signing admin
+    /// and the pinned anchor (#145). Same contract: `handle_kick` for
+    /// ourselves sets `kicked_screen` and clears the inbound Megolm
+    /// state; messages targeted at OTHER CNs leave state untouched.
+    #[test]
+    fn handle_kick_routes_only_on_self_match() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+
+        // Notice for someone else — no-op (we never even verify; the
+        // self-match short-circuit returns before the auth gate).
+        let other = signed_kick_notice(&admin, "alice", None, false, "0");
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&other).unwrap()).unwrap();
         assert!(state.lock().unwrap().kicked_screen.is_none());
 
         // Notice for us — Kicked screen, crypto torn down.
-        let mine = KickNotice {
-            kicked_cn: "bob".into(),
-            reason: Some("nope".into()),
-            banned: true,
-            kicked_at: "0".into(),
-        };
-        super::handle_kick(
-            &state,
-            "bob",
-            &serde_json::to_vec(&mine).unwrap(),
-        )
-        .unwrap();
+        let mine = signed_kick_notice(&admin, "bob", Some("nope".into()), true, "0");
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&mine).unwrap()).unwrap();
         let s = state.lock().unwrap();
         let kicked = s.kicked_screen.as_ref().unwrap();
         assert_eq!(kicked.reason.as_deref(), Some("nope"));
         assert!(kicked.banned);
         assert!(s.crypto.as_ref().unwrap().group_receivers.is_empty());
         assert!(s.crypto.as_ref().unwrap().member_olm_session.is_none());
+    }
+
+    // ── Authenticity gate (#145) ──────────────────────────────────────────
+
+    /// Acceptance criterion: a valid kick verifies and the receiver tears
+    /// down.
+    #[test]
+    fn kick_verifies_with_admin_key() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let notice = signed_kick_notice(&admin, "bob", Some("ok".into()), false, "1750000000");
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_some());
+    }
+
+    /// Acceptance criterion: mutating `kicked_cn` after signing must fail
+    /// verification. The receiver MUST stay in the session.
+    #[test]
+    fn kick_with_mutated_kicked_cn_fails_verify() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let mut notice =
+            signed_kick_notice(&admin, "bob", None, false, "1750000000");
+        // Mutate AFTER signing. Use a CN we then match self against so the
+        // self-match short-circuit doesn't hide the verify failure.
+        notice.kicked_cn = "carol".into();
+        super::handle_kick(&state, "carol", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        let s = state.lock().unwrap();
+        assert!(s.kicked_screen.is_none(), "mutated kicked_cn must not tear down");
+        // Member is still in the session: crypto state retained.
+        assert!(s.crypto.is_some());
+    }
+
+    /// Acceptance criterion: mutating `kicked_at` after signing must fail
+    /// verification.
+    #[test]
+    fn kick_with_mutated_kicked_at_fails_verify() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let mut notice =
+            signed_kick_notice(&admin, "bob", None, false, "1750000000");
+        notice.kicked_at = "9999999999".into();
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
+    }
+
+    /// Acceptance criterion: mutating the `banned` flag after signing must
+    /// fail verification.
+    #[test]
+    fn kick_with_mutated_banned_flag_fails_verify() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let mut notice =
+            signed_kick_notice(&admin, "bob", None, false, "1750000000");
+        notice.banned = true;
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
+    }
+
+    /// Acceptance criterion: a notice signed by a different admitted
+    /// member (not the admin) must fail verification. We populate the
+    /// notice's carried key with the impostor's Ed25519 too — the stored
+    /// anchor mismatch is itself a drop signal.
+    #[test]
+    fn kick_signed_by_non_admin_member_fails_verify() {
+        let admin = SessionIdentity::new();
+        let impostor = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        // Impostor builds a complete, internally-consistent notice (their
+        // sig over the canonical bytes, their carried Ed25519 key) — but
+        // the stored anchor is the admin's, so the carried-key check trips
+        // first.
+        let notice =
+            signed_kick_notice(&impostor, "bob", Some("zap".into()), true, "1750000000");
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
+    }
+
+    /// Acceptance criterion: a notice with a missing (empty-string)
+    /// signature must fail verification.
+    #[test]
+    fn kick_with_missing_signature_fails_verify() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let mut notice =
+            signed_kick_notice(&admin, "bob", None, true, "1750000000");
+        notice.admin_ed25519_sig_b64 = String::new();
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
+
+        // Same contract with the all-zeros sig form.
+        let mut notice2 =
+            signed_kick_notice(&admin, "bob", None, true, "1750000000");
+        notice2.admin_ed25519_sig_b64 = base64::Engine::encode(&B64, [0u8; 64]);
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice2).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
+    }
+
+    /// Design-pinning test: `reason` is intentionally NOT part of the
+    /// canonical signing bytes (it's display copy only — see the
+    /// `kick_signing_bytes` doc). Mutating it after signing therefore
+    /// MUST still verify and tear down. Pair-test for
+    /// `kick_with_mutated_*_fails_verify`: if the design ever flips to
+    /// include `reason` in the canonical form, this test catches that
+    /// change at compile-test time and forces the doc note to be updated.
+    #[test]
+    fn kick_with_mutated_reason_still_verifies() {
+        let admin = SessionIdentity::new();
+        let state = member_state_pinned_to(&admin);
+        let mut notice = signed_kick_notice(
+            &admin,
+            "bob",
+            Some("original copy".into()),
+            true,
+            "1750000000",
+        );
+        notice.reason = Some("admin fixed a typo".into());
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        let kicked = state.lock().unwrap().kicked_screen.clone().unwrap();
+        assert_eq!(kicked.reason.as_deref(), Some("admin fixed a typo"));
+    }
+
+    /// Anchor-mismatch belt-and-suspenders: even if the notice carries a
+    /// valid sig from key X, and the stored anchor is key Y ≠ X, the
+    /// carried-key vs anchor mismatch short-circuits before the verify
+    /// call. This pins the "verify against STORED anchor, not the notice
+    /// field" semantics so a future refactor can't accidentally swap them.
+    #[test]
+    fn kick_with_carried_key_mismatching_anchor_fails_verify() {
+        let admin = SessionIdentity::new();
+        let other = SessionIdentity::new();
+        // Anchor pinned to `admin`; impostor signs as `other`.
+        let state = member_state_pinned_to(&admin);
+        let notice = signed_kick_notice(&other, "bob", None, false, "0");
+        super::handle_kick(&state, "bob", &serde_json::to_vec(&notice).unwrap()).unwrap();
+        assert!(state.lock().unwrap().kicked_screen.is_none());
     }
 }

--- a/src/zenoh_router/src/kick_handler.rs
+++ b/src/zenoh_router/src/kick_handler.rs
@@ -167,7 +167,7 @@ pub fn prepare_rotation(
     // Sign the canonical (kicked_cn, kicked_at, banned) bytes with the
     // admin's vodozemac Ed25519 key. `reason` is intentionally not signed
     // (see `kick_signing_bytes`). The wire field `admin_ed25519_key_b64`
-    // is informational — receivers verify against the Ed25519 they pinned
+    // is informational; receivers verify against the Ed25519 they pinned
     // at admission time (#145).
     let kicked_at = unix_epoch_secs();
     let crypto = st.crypto.as_ref().unwrap();
@@ -290,7 +290,7 @@ fn handle_kick(state: &Mutex<AppState>, my_cn: &str, payload: &[u8]) -> Result<(
             return Ok(());
         };
         let Some(anchor_b64) = crypto.session_admin_ed25519_b64.as_deref() else {
-            // No pinned admin identity — admission either hasn't completed
+            // No pinned admin identity: admission either hasn't completed
             // or this node is the admin (admins don't kick themselves).
             debug!("kick verification skipped: no pinned admin Ed25519 anchor");
             return Ok(());
@@ -641,10 +641,10 @@ mod tests {
     }
 
     /// Test helper: construct a signed KickNotice. Calls the SAME
-    /// canonical-bytes helper the production admin path uses — this is the
-    /// test-side mirror of the production single-source-of-truth, and is
-    /// what makes the "mutated after signing" tests faithful (no re-sign,
-    /// mutation happens on the constructed struct).
+    /// canonical-bytes helper the production admin path uses, which is
+    /// the test-side mirror of the production single-source-of-truth, and
+    /// is what makes the "mutated after signing" tests faithful (no
+    /// re-sign, mutation happens on the constructed struct).
     fn signed_kick_notice(
         admin: &SessionIdentity,
         kicked_cn: &str,
@@ -673,7 +673,7 @@ mod tests {
         let admin = SessionIdentity::new();
         let state = member_state_pinned_to(&admin);
 
-        // Notice for someone else — no-op (we never even verify; the
+        // Notice for someone else: no-op (we never even verify; the
         // self-match short-circuit returns before the auth gate).
         let other = signed_kick_notice(&admin, "alice", None, false, "0");
         super::handle_kick(&state, "bob", &serde_json::to_vec(&other).unwrap()).unwrap();
@@ -749,7 +749,7 @@ mod tests {
 
     /// Acceptance criterion: a notice signed by a different admitted
     /// member (not the admin) must fail verification. We populate the
-    /// notice's carried key with the impostor's Ed25519 too — the stored
+    /// notice's carried key with the impostor's Ed25519 too, so the stored
     /// anchor mismatch is itself a drop signal.
     #[test]
     fn kick_signed_by_non_admin_member_fails_verify() {
@@ -757,7 +757,7 @@ mod tests {
         let impostor = SessionIdentity::new();
         let state = member_state_pinned_to(&admin);
         // Impostor builds a complete, internally-consistent notice (their
-        // sig over the canonical bytes, their carried Ed25519 key) — but
+        // sig over the canonical bytes, their carried Ed25519 key), but
         // the stored anchor is the admin's, so the carried-key check trips
         // first.
         let notice =
@@ -787,7 +787,7 @@ mod tests {
     }
 
     /// Design-pinning test: `reason` is intentionally NOT part of the
-    /// canonical signing bytes (it's display copy only — see the
+    /// canonical signing bytes (it's display copy only, see the
     /// `kick_signing_bytes` doc). Mutating it after signing therefore
     /// MUST still verify and tear down. Pair-test for
     /// `kick_with_mutated_*_fails_verify`: if the design ever flips to

--- a/src/zenoh_router/src/state.rs
+++ b/src/zenoh_router/src/state.rs
@@ -116,6 +116,14 @@ pub struct SessionCryptoState {
     /// member can decrypt a rotation message that lands later in the session.
     /// `None` on the admin side and until the member's Olm-Allow lands.
     pub member_olm_session: Option<OlmSession>,
+    /// Member-side: the admin's Ed25519 signing key, base64, pinned at
+    /// admission time from `AdmissionDecision::Allow.admin_ed25519_key`.
+    /// `KickNotice` signature verification (#145) anchors against THIS
+    /// stored value, not the key the notice carries (the notice's
+    /// `admin_ed25519_key_b64` is informational; a stored-vs-notice
+    /// mismatch is itself a drop signal). `None` on the admin side and
+    /// until the member's Allow lands.
+    pub session_admin_ed25519_b64: Option<String>,
 }
 
 /// Per-admitted-CN identity record kept by the admin. Captured at admit time
@@ -147,6 +155,7 @@ impl SessionCryptoState {
             admin_olm_sessions: HashMap::new(),
             admitted_identities: HashMap::new(),
             member_olm_session: None,
+            session_admin_ed25519_b64: None,
         }
     }
 }


### PR DESCRIPTION
Closes #145.

Stacked on top of #144 (`feature/kick-ban-rotation`); review after #144 lands. GitHub will auto-retarget to `develop` once #144 merges.

## Summary

PR #144 shipped `KickNotice` on a control topic that any admitted member can publish to. A malicious admitted node could forge a self-targeted `KickNotice` for any peer and the receiver would tear down on first self-match without any verification. The data plane was unaffected (no real rotation means a forged kick just bounces the peer's UI back to the chooser), but it was a session-level DoS.

This PR closes the gap by signing `KickNotice` with the admin's vodozemac Ed25519 key and verifying on receivers against a trust anchor pinned at admission time.

## Design

* **Canonical signing bytes** live in `bot_framework::control::kick_signing_bytes(kicked_cn, kicked_at, banned)`. Domain-separated (`b"dverse.kick.v1\0"` prefix), length-prefixed (`u32_be` lengths around `kicked_cn` and `kicked_at`), with `banned` as a trailing `u8`. Both admin and receiver call this exact function; the layout is pinned by a unit test so a future "tidy this up" can't silently break compatibility.
* **`reason` is intentionally NOT signed.** It's display copy only, and the design choice lets admins fix typos without re-signing. Pinned by the `kick_with_mutated_reason_still_verifies` test.
* **Trust bootstrap.** Members learn the admin's Ed25519 from a new `admin_ed25519_key` field on `AdmissionDecision::Allow` (TOFU at parity with the existing `admin_identity_key`), pin it into `SessionCryptoState.session_admin_ed25519_b64`, and verify subsequent notices against that anchor.
* **Verification anchor is the STORED key, not the notice-carried key.** The notice carries `admin_ed25519_key_b64` for tracing/diagnostics; a mismatch between the stored anchor and the notice's key is itself a drop signal (pinned by `kick_with_carried_key_mismatching_anchor_fails_verify`).
* **Leakage hardening.** All drop paths use `tracing::warn!` / `tracing::debug!` without the `kicked_cn` of the dropped notice, per the issue body.

## Acceptance criteria

- [x] `KickNotice` carries an Ed25519 signature over a canonical, domain-separated byte form of its identifying fields (`bot_framework::control::kick_signing_bytes`).
- [x] Receiver verifies against the admin's known Ed25519 key (from the admission flow) before any teardown side effect.
- [x] Forged notice (wrong signer, mutated fields after signing, missing signature) is silently dropped on the receiver and the member stays in the session.
- [x] Unit test covers valid verify-and-teardown, mutated `kicked_cn`, mutated `reason` (verifies the design choice that it's NOT signed), signature by a different admitted member, and missing signature. Mutated `kicked_at` and `banned` are also covered as adjacent cases.

Test names (all in `zenoh_router::kick_handler::tests` unless noted):

| Test | Maps to |
| ---- | ------- |
| `kick_verifies_with_admin_key` | valid kick verifies, teardown fires |
| `kick_with_mutated_kicked_cn_fails_verify` | mutated `kicked_cn` rejected |
| `kick_with_mutated_kicked_at_fails_verify` | mutated `kicked_at` rejected |
| `kick_with_mutated_banned_flag_fails_verify` | mutated `banned` rejected |
| `kick_with_mutated_reason_still_verifies` | pins "reason is display-only" |
| `kick_signed_by_non_admin_member_fails_verify` | impostor signer rejected |
| `kick_with_missing_signature_fails_verify` | empty + zero-bytes sig rejected |
| `kick_with_carried_key_mismatching_anchor_fails_verify` | pins verify-against-anchor semantics |
| `handle_kick_routes_only_on_self_match` (updated) | existing PR #144 invariant preserved |
| `bot_framework::control::tests::kick_signing_bytes_layout_is_pinned` | pinned byte layout |
| `bot_framework::control::tests::kick_signing_bytes_disambiguates_field_boundaries` | length-prefix isolation |

## Test plan

- [x] `cargo test -p bot-framework --lib` (20 passed)
- [x] `cargo test -p zenoh-router --lib` (18 passed)
- [x] `cargo test -p zenoh-client-launcher` (build + 0 tests)
- [x] Reviewer reads #144 first so the stacked diff is coherent.
- [x] Spot-check that `kick_signing_bytes` byte layout matches the doc comment by eyeballing the pinned-bytes test.

## Commit slicing

Six commits, each independently `cargo check`-clean:

1. `bot_framework/control.rs` canonical bytes + new KickNotice fields + tests
2. `bot_framework/session_crypto.rs` Ed25519 pass-throughs on `SessionIdentity`
3. `bot_framework/admission.rs` new `admin_ed25519_key` on `AdmissionDecision::Allow`
4. `zenoh_router/state.rs` + `admission_handler.rs` pin the anchor on members
5. `zenoh_router/kick_handler.rs` sign on admin, verify on receiver, full test table
6. Em-dash style sweep on prose added by this branch