### PR TITLE
fix(a2a): support WS bridge mode in A2A council

### DIFF
--- a/experiments/chat-app/backend/services/a2a.py
+++ b/experiments/chat-app/backend/services/a2a.py
@@ -10,13 +10,22 @@ from ..telemetry import a2a_sessions, a2a_session_duration, a2a_turns, a2a_turn_
 
 
 async def _call_bot(bot: BotConfig, message: str, history: list[dict], room_id: str) -> str:
-    from .zenoh_bridge import zenoh_bridge
-    return await zenoh_bridge.request(
-        room_id=room_id,
-        bot_name=bot.name,
-        message=message,
-        history=history,
-        timeout=120.0,
+    import asyncio
+    from ..models.bot import BotProvider
+    if bot.provider == BotProvider.ZENOH:
+        from .zenoh_bridge import zenoh_bridge
+        return await zenoh_bridge.request(
+            room_id=room_id,
+            bot_name=bot.name,
+            message=message,
+            history=history,
+            timeout=120.0,
+        )
+    from .llm import build_bot_response
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: build_bot_response(bot, message, history),
     )
 
 

--- a/experiments/chat-app/backend/services/zenoh_bridge.py
+++ b/experiments/chat-app/backend/services/zenoh_bridge.py
@@ -62,6 +62,7 @@ class ZenohBridge:
         self.available = False
         self._broker = None         # injected after broker is initialised
         self._pending: dict[str, asyncio.Future] = {}
+        self._pending_ws: dict[str, asyncio.Future] = {}  # keyed "bot_name:room_id" for WS mode
 
     # ── Public API ─────────────────────────────────────────────────────────────
 
@@ -177,7 +178,14 @@ class ZenohBridge:
                     try:
                         data = json.loads(raw)
                         if data.get("type") == "a2a_response":
-                            self._handle_room_message(data)
+                            from_bot = data.get("from") or data.get("sender", "")
+                            ws_key = f"{from_bot}:{data.get('room_id', '')}"
+                            if ws_key in self._pending_ws:
+                                fut = self._pending_ws.pop(ws_key)
+                                if not fut.done():
+                                    self._loop.call_soon_threadsafe(fut.set_result, data.get("content", ""))
+                            else:
+                                self._handle_room_message(data)
                         elif data.get("is_agent") is True:
                             self._handle_room_message(data)
                         elif "cn" in data:
@@ -362,38 +370,65 @@ class ZenohBridge:
 
         from ..telemetry import tracer, zenoh_duration
 
-        request_id = str(uuid.uuid4())
         loop = asyncio.get_event_loop()
-        future: asyncio.Future = loop.create_future()
-        self._pending[request_id] = future
-
-        payload = json.dumps({
-            "request_id": request_id,
-            "room_id": room_id,
-            "bot_name": bot_name,
-            "message": message,
-            "history": history,
-        }).encode()
 
         with tracer.start_as_current_span("zenoh.bot_request") as span:
             span.set_attribute("zenoh.room_id", room_id)
             span.set_attribute("zenoh.bot_name", bot_name)
-            span.set_attribute("zenoh.request_id", request_id)
             span.set_attribute("zenoh.timeout", timeout)
             t0 = time.monotonic()
             try:
-                await loop.run_in_executor(
-                    None,
-                    lambda: self._session.put(f"chat/{room_id}/request/{bot_name}", payload),
-                )
-                return await asyncio.wait_for(future, timeout=timeout)
-            except asyncio.TimeoutError:
-                self._pending.pop(request_id, None)
-                span.set_status(Status(StatusCode.ERROR, "timeout"))
-                raise TimeoutError(
-                    f"@{bot_name} did not respond within {timeout}s. "
-                    "Is the bot agent running and connected to the Zenoh router?"
-                )
+                if self._ws and self._loop:
+                    # WebSocket bridge mode — route through Tauri's A2A to Tauri-managed bots
+                    ws_key = f"{bot_name}:{room_id}"
+                    future: asyncio.Future = loop.create_future()
+                    self._pending_ws[ws_key] = future
+                    await self._ws_send(json.dumps({
+                        "type": "a2a",
+                        "to": bot_name,
+                        "room_id": room_id,
+                        "content": message,
+                    }))
+                    try:
+                        return await asyncio.wait_for(future, timeout=timeout)
+                    except asyncio.TimeoutError:
+                        self._pending_ws.pop(ws_key, None)
+                        span.set_status(Status(StatusCode.ERROR, "timeout"))
+                        raise TimeoutError(
+                            f"@{bot_name} did not respond within {timeout}s. "
+                            "Is the bot running in the Tauri client?"
+                        )
+                elif self._session:
+                    # Direct zenoh mode — use plain chat/request topics (bot_agent.py bots)
+                    request_id = str(uuid.uuid4())
+                    future = loop.create_future()
+                    self._pending[request_id] = future
+                    payload = json.dumps({
+                        "request_id": request_id,
+                        "room_id": room_id,
+                        "bot_name": bot_name,
+                        "message": message,
+                        "history": history,
+                    }).encode()
+                    await loop.run_in_executor(
+                        None,
+                        lambda: self._session.put(f"chat/{room_id}/request/{bot_name}", payload),
+                    )
+                    try:
+                        return await asyncio.wait_for(future, timeout=timeout)
+                    except asyncio.TimeoutError:
+                        self._pending.pop(request_id, None)
+                        span.set_status(Status(StatusCode.ERROR, "timeout"))
+                        raise TimeoutError(
+                            f"@{bot_name} did not respond within {timeout}s. "
+                            "Is the bot agent running and connected to the Zenoh router?"
+                        )
+                else:
+                    raise RuntimeError(
+                        "Zenoh not connected. Start the Tauri bridge or connect a Zenoh router."
+                    )
+            except TimeoutError:
+                raise
             except Exception as exc:
                 span.record_exception(exc)
                 span.set_status(Status(StatusCode.ERROR, str(exc)))

--- a/experiments/chat-app/backend/tests/test_a2a.py
+++ b/experiments/chat-app/backend/tests/test_a2a.py
@@ -158,6 +158,24 @@ class TestCallBot(A2ATestCase):
             timeout=120.0,
         )
 
+    def test_calls_llm_for_local_provider(self):
+        from backend.services.a2a import _call_bot
+        bot = _make_bot("bot-1", "room-1", "local-bot", provider=BotProvider.LOCAL)
+
+        with patch("backend.services.llm.build_bot_response", return_value="llm reply"):
+            result = self._run(_call_bot(bot, "hello", [], "room-1"))
+
+        self.assertEqual(result, "llm reply")
+
+    def test_calls_llm_for_claude_provider(self):
+        from backend.services.a2a import _call_bot
+        bot = _make_bot("bot-1", "room-1", "claude-bot", provider=BotProvider.CLAUDE)
+
+        with patch("backend.services.llm.build_bot_response", return_value="claude reply"):
+            result = self._run(_call_bot(bot, "hello", [], "room-1"))
+
+        self.assertEqual(result, "claude reply")
+
 
 # ---------------------------------------------------------------------------
 # run_a2a_session — happy path


### PR DESCRIPTION
## Summary

- **Root cause**: `zenoh_bridge.request()` had no WebSocket mode branch. In Tauri WS mode `self._session` is `None`, so every `/zenoh @bot1 @bot2` command crashed with `AttributeError: 'NoneType' object has no attribute 'put'` → posted as `[A2A Error at turn 1]`.
- **`zenoh_bridge.py`**: Added `_pending_ws` futures dict; WS branch in `request()` sends `{"type":"a2a"}` to Tauri bridge, awaits `a2a_response` keyed by `"bot_name:room_id"`; fixed `_ws_run()` to route `a2a_response` to pending future OR `_handle_room_message()` for passive agent replies.
- **`a2a.py`**: `_call_bot()` now checks provider — non-Zenoh bots route to `build_bot_response()` instead of always trying Zenoh.
- **`test_a2a.py`**: Added tests for LOCAL and CLAUDE provider paths in `_call_bot()`.

## Test plan

- [ ] Run `python3 -m pytest tests/test_a2a.py -v` — all 11 tests pass
- [ ] Start Tauri app with WS bridge active, add a Zenoh bot to a chat room, run `/zenoh @bot1 @bot2 2 test topic` — should see multi-turn dialogue appear in chat
- [ ] Verify bot name in chat room matches bot name in Tauri client exactly (key for `_pending_ws` match)